### PR TITLE
Add cpu-watchdog.sh for OrbStack VM CPU runaway catcher

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,10 +62,6 @@ ln -s -f ~/settings/shared/.ideavim ~/.ideavimrc
 ln -s -f ~/settings/shared/aider.conf.yml ~/.aider.conf.yml
 ln -s -f ~/settings/shared/ssh_config ~/.ssh/config
 
-# Reactive CPU runaway watchdog — launched from ~/.zshrc on interactive shells
-mkdir -p ~/bin
-ln -s -f ~/settings/shared/cpu-watchdog.sh ~/bin/cpu-watchdog.sh
-
 # Todo consider enumerating the directory and linking all of them
 ln -s -f ~/settings/nvim ~/.config/nvim
 ln -s -f ~/settings/config/carapace/ ~/.config/carapace

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,6 +62,10 @@ ln -s -f ~/settings/shared/.ideavim ~/.ideavimrc
 ln -s -f ~/settings/shared/aider.conf.yml ~/.aider.conf.yml
 ln -s -f ~/settings/shared/ssh_config ~/.ssh/config
 
+# Reactive CPU runaway watchdog — launched from ~/.zshrc on interactive shells
+mkdir -p ~/bin
+ln -s -f ~/settings/shared/cpu-watchdog.sh ~/bin/cpu-watchdog.sh
+
 # Todo consider enumerating the directory and linking all of them
 ln -s -f ~/settings/nvim ~/.config/nvim
 ln -s -f ~/settings/config/carapace/ ~/.config/carapace

--- a/shared/cpu-watchdog.sh
+++ b/shared/cpu-watchdog.sh
@@ -28,8 +28,8 @@ log() {
 # Do not throttle anything in this list — stopping them would wedge the VM
 is_excluded() {
     case "$1" in
-        cpulimit|tailscaled|etserver|sh|init|systemd|dolt|\
-        "tmux:"*|kthreadd|kworker*|ksoftirqd*|migration*|rcu_*) return 0 ;;
+        cpulimit|tailscaled|etserver|etterminal|etclient|sh|init|systemd|dolt|\
+        tmux|"tmux:"*|kthreadd|kworker*|ksoftirqd*|migration*|rcu_*) return 0 ;;
     esac
     return 1
 }

--- a/shared/cpu-watchdog.sh
+++ b/shared/cpu-watchdog.sh
@@ -25,6 +25,19 @@ log() {
     printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG"
 }
 
+# Fail fast if any required external command is missing — otherwise the loop
+# runs silently without throttling and we'd only notice when the VM melts.
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        log "missing dependency: $1 not found in PATH; exiting"
+        exit 1
+    }
+}
+require_cmd /usr/bin/top
+require_cmd awk
+require_cmd pgrep
+require_cmd cpulimit
+
 # Do not throttle anything in this list — stopping them would wedge the VM
 is_excluded() {
     case "$1" in
@@ -41,10 +54,10 @@ log "cpu-watchdog starting (limit=${LIMIT_PCT}% threshold=${THRESHOLD}% interval
 while true; do
     # top -bn2 -d1 → second iteration has instantaneous CPU over 1s
     # -w512 prevents COMMAND truncation. awk concatenates cols 12..NF as COMMAND.
-    /usr/bin/top -bn2 -d1 -w512 2>/dev/null \
+    LC_ALL=C LANG=C /usr/bin/top -bn2 -d1 -w512 2>/dev/null \
         | awk '
             /^top - /{iter++}
-            iter==2 && $1 ~ /^[0-9]+$/ {
+            iter==2 && $1 ~ /^[0-9]+$/ && $9 ~ /^[0-9]+([.][0-9]+)?$/ {
                 comm=""
                 for (i=12; i<=NF; i++) comm = comm (i>12 ? " " : "") $i
                 print $1, $9, comm

--- a/shared/cpu-watchdog.sh
+++ b/shared/cpu-watchdog.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# cpu-watchdog.sh — reactive in-VM CPU runaway catcher.
+#
+# Scans every INTERVAL seconds. When a user process exceeds THRESHOLD%
+# instantaneous CPU (from `top -bn2 -d1`), attaches a cpulimit instance
+# capped at LIMIT_PCT%. cpulimit uses -z so it auto-exits when the target
+# dies. Pairs with the OrbStack Mac-side VM CPU cap for two-layer protection:
+# the hypervisor sets the ceiling, this script catches individual runaways
+# early so the whole VM never approaches the ceiling.
+#
+# Tunables via env:
+#   CPU_WATCHDOG_LIMIT      per-process cap once fired (default 200 = 2 cores)
+#   CPU_WATCHDOG_THRESHOLD  fire threshold (default 400 = 4 cores sustained)
+#   CPU_WATCHDOG_INTERVAL   scan interval in seconds (default 30)
+#   CPU_WATCHDOG_LOG        log file (default /tmp/cpu-watchdog.log)
+
+set -u
+
+LIMIT_PCT=${CPU_WATCHDOG_LIMIT:-200}
+THRESHOLD=${CPU_WATCHDOG_THRESHOLD:-400}
+INTERVAL=${CPU_WATCHDOG_INTERVAL:-30}
+LOG=${CPU_WATCHDOG_LOG:-/tmp/cpu-watchdog.log}
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG"
+}
+
+# Do not throttle anything in this list — stopping them would wedge the VM
+is_excluded() {
+    case "$1" in
+        cpulimit|tailscaled|etserver|sh|init|systemd|dolt|\
+        "tmux:"*|kthreadd|kworker*|ksoftirqd*|migration*|rcu_*) return 0 ;;
+    esac
+    return 1
+}
+
+trap 'log "cpu-watchdog stopping (pid=$$)"; exit 0' TERM INT
+
+log "cpu-watchdog starting (limit=${LIMIT_PCT}% threshold=${THRESHOLD}% interval=${INTERVAL}s pid=$$)"
+
+while true; do
+    # top -bn2 -d1 → second iteration has instantaneous CPU over 1s
+    # -w512 prevents COMMAND truncation. awk concatenates cols 12..NF as COMMAND.
+    /usr/bin/top -bn2 -d1 -w512 2>/dev/null \
+        | awk '
+            /^top - /{iter++}
+            iter==2 && $1 ~ /^[0-9]+$/ {
+                comm=""
+                for (i=12; i<=NF; i++) comm = comm (i>12 ? " " : "") $i
+                print $1, $9, comm
+            }
+          ' \
+        | while read -r pid pcpu comm; do
+            # bash can't compare floats; let awk do it
+            over=$(awk -v a="$pcpu" -v t="$THRESHOLD" 'BEGIN{print (a+0 > t+0)}')
+            [ "$over" = "1" ] || continue
+            is_excluded "$comm" && continue
+            # Already being throttled? (our cpulimit has `-p <pid>` in its args)
+            if pgrep -f "cpulimit.*-p $pid " >/dev/null 2>&1; then continue; fi
+            log "throttle pid=$pid comm=\"$comm\" cpu=${pcpu}% → cap ${LIMIT_PCT}%"
+            cpulimit -l "$LIMIT_PCT" -p "$pid" -z -q >/dev/null 2>&1 &
+        done
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

- Adds `shared/cpu-watchdog.sh`, a reactive in-VM CPU runaway catcher that scans every 30s (via `top -bn2 -d1`) and attaches `cpulimit` at 200% to any user process exceeding 400% instantaneous CPU. It pairs with the OrbStack Mac-side VM CPU cap to form a two-layer guard: the hypervisor sets the VM ceiling, this script catches individual runaways early so the whole VM never approaches the ceiling.
- Wires `bootstrap.sh` to `mkdir -p ~/bin` and symlink `~/bin/cpu-watchdog.sh -> ~/settings/shared/cpu-watchdog.sh`, matching the existing idiom used elsewhere in the file (`ln -s -f ~/settings/shared/<foo> ~/.<foo>`).
- Lives in `shared/` rather than `py/` or a platform dir because it's a POSIX bash script with no Python deps and is cross-platform in principle — the path that launches it (`~/.zshrc` with `setsid ~/bin/cpu-watchdog.sh &>/dev/null &` inside an idempotent `pgrep` guard) is OrbStack-specific today, but the script itself is platform-neutral Linux.
- Exclusion list covers `cpulimit` itself (prevent recursion), `tailscaled`/`etserver` (stopping them would wedge the VM), and kernel helper threads.
- Tunables via env: `CPU_WATCHDOG_LIMIT` (default 200), `CPU_WATCHDOG_THRESHOLD` (default 400), `CPU_WATCHDOG_INTERVAL` (default 30), `CPU_WATCHDOG_LOG` (default `/tmp/cpu-watchdog.log`).

## Test plan

- [x] Script was already running (PID 42858) as `/home/developer/bin/cpu-watchdog.sh` before the move
- [x] Atomic swap (`rm` then `ln -s`) of the live path to a symlink into the settings repo — running watchdog PID 42858 still alive after the swap (bash reads the script into memory at parse time, doesn't re-read)
- [x] `readlink /home/developer/bin/cpu-watchdog.sh` resolves to `/home/developer/settings/shared/cpu-watchdog.sh`
- [x] `[ -x /home/developer/bin/cpu-watchdog.sh ] && echo ok` passes (executable bit visible through symlink)
- [x] `git ls-files -s shared/cpu-watchdog.sh` reports mode `100755` — git tracks the executable bit
- [x] `bootstrap.sh` new line matches the surrounding idiom (`ln -s -f ~/settings/shared/...`) and is placed next to the other shared-script symlinks
- [ ] Next fresh VM will exercise `bootstrap.sh` end-to-end — nothing to run here, but the mkdir/ln line is idempotent on re-runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CPU watchdog tool that monitors running processes for excessive CPU usage and automatically throttles them based on configurable thresholds.

* **Chores**
  * Updated bootstrap setup to create the necessary directory structure and symlink for the CPU watchdog, making it available for launch from shell initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->