### PR TITLE
docs(rmux): clarify PICKER_SPEC scope + pin side-edit wire format

### DIFF
--- a/rust/tmux_helper/CLAUDE.md
+++ b/rust/tmux_helper/CLAUDE.md
@@ -4,9 +4,9 @@ Fast Rust-based tmux helper for session/window/pane management.
 
 ## Important
 
-**When modifying rmux_helper, update `PICKER_SPEC.md` to reflect any rule changes.**
+**When modifying the picker (`pick-tui` / `pick-list`), update `PICKER_SPEC.md` to reflect any rule changes.**
 
-The spec documents the *what* (behavior rules), not the *how* (implementation).
+The spec documents the *what* (behavior rules), not the *how* (implementation). It only covers the picker — `side-edit`, `side-run`, `rename-all`, `rotate`, `third`, etc. do not have specs and don't need PICKER_SPEC updates.
 
 ## Commands
 
@@ -27,3 +27,23 @@ cargo install --path . --force
 ```bash
 cargo test
 ```
+
+## Smoke testing against tmux
+
+`cargo build` updates `target/`, but tmux keybindings and `$PATH` resolve to `~/.cargo/bin/rmux_helper`. After any change you want to exercise live, run `cargo install --path . --force` before invoking `rmux_helper` from a tmux session.
+
+## side-edit / side-run stdout contract
+
+`side-edit` and `side-run` (with no args, status-only) print three lines that shell scripts consume:
+
+```
+pane_id: <%N | none | ambiguous>
+nvim: <true | false | unknown>
+file: <path or empty>
+```
+
+- `pane_id: none` = no candidate side pane in the window (we *did* look)
+- `pane_id: ambiguous` = multiple plausible candidates, refuse to route
+- `nvim: unknown` = inspection failed (pid query, sysinfo race) — must NOT be collapsed to `false`
+
+Tested by `format_pane_status` unit tests in `main.rs`. Don't rename sentinels or change the format without updating consumers.


### PR DESCRIPTION
## Summary

Three small clarifications to `rust/tmux_helper/CLAUDE.md` learned from PR #56:

1. **PICKER_SPEC scope** — the existing "When modifying rmux_helper, update PICKER_SPEC.md" was misleading. PICKER_SPEC only covers the picker (`pick-tui` / `pick-list`), not all of rmux_helper. Tightened the wording so future Claude sessions don't accidentally try to update the spec when touching `side-edit`, `side-run`, `rename-all`, etc.

2. **Smoke-test gotcha** — `cargo build` updates `target/`, but tmux keybindings and `$PATH` resolve to `~/.cargo/bin/rmux_helper`. After any change you want to exercise live (not just unit-test), run `cargo install --path . --force` first.

3. **side-edit / side-run stdout contract** — pin the three-line wire format (`pane_id` with `none`/`ambiguous` sentinels, `nvim` with `true|false|unknown` state). Shell consumers depend on this — silently collapsing `unknown` to `false` or renaming sentinels would re-introduce the exact bug PR #56 fixed.

## Test plan

- [x] Markdown renders correctly (passed Prettier in pre-commit)
- [x] No code changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)