### PR TITLE
CLAUDE.md: document OrbStack VM environment quirks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,16 @@ git push fork <branch-name>
 gh pr create --head idvorkin-ai-tools:<branch-name>
 ```
 
-## OrbStack VM Environment
+## devvm Environment (OrbStack Linux VM)
 
-This dev VM runs under OrbStack on a Mac. Non-obvious constraints that break standard Linux recipes:
+Claude sometimes runs on the Mac host, sometimes inside the "devvm" — an OrbStack Linux VM reachable over Tailscale as `c-NNNN`. **Check which environment you're in before applying the rules below**, because they only hold inside the devvm:
+
+```bash
+# Check: are we in the devvm?
+[ "$(whoami)" = "developer" ] && uname -r | grep -q orbstack && echo "devvm" || echo "not devvm (Mac host or other)"
+```
+
+If the check prints `devvm`, the following non-obvious constraints apply. If it prints `not devvm`, ignore this whole section — standard macOS rules apply instead.
 
 - **PID 1 is `sh -c 'while true; do tmux...'`, NOT systemd.** `systemd-run`, `systemctl`, and sysv `/etc/rc*.d` all fail — nothing executes them on boot.
 - **`/sys/fs/cgroup` is mounted `ro,nsdelegate`.** `remount,rw` is denied even for root. No in-VM cgroup writes; VM-level caps must be set Mac-side via `orb config set cpu N`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,16 @@ git push fork <branch-name>
 gh pr create --head idvorkin-ai-tools:<branch-name>
 ```
 
+## OrbStack VM Environment
+
+This dev VM runs under OrbStack on a Mac. Non-obvious constraints that break standard Linux recipes:
+
+- **PID 1 is `sh -c 'while true; do tmux...'`, NOT systemd.** `systemd-run`, `systemctl`, and sysv `/etc/rc*.d` all fail — nothing executes them on boot.
+- **`/sys/fs/cgroup` is mounted `ro,nsdelegate`.** `remount,rw` is denied even for root. No in-VM cgroup writes; VM-level caps must be set Mac-side via `orb config set cpu N`.
+- **User services bootstrap from `~/.zshrc`** via the idempotent `pgrep + setsid` pattern — see the tailscaled, etserver, and cpu-watchdog blocks. New background services go there too.
+- **`ps` is aliased to `procs` and `top` to `btm`.** Use `/usr/bin/ps` and `/usr/bin/top` for standard flags like `--sort=-%cpu` or `-bn2 -d1`.
+- **`pgrep -f` patterns must anchor** to avoid matching your own shell cmdline: `pgrep -f 'bin/myscript.sh$'`, not `pgrep -f myscript`.
+
 ## Terminal Command Conventions
 
 ### Important Usage Notes


### PR DESCRIPTION
## Summary

Codify non-obvious constraints from Igor's OrbStack VM that cost time in a recent session. 10 lines added to CLAUDE.md, one per constraint.

- PID 1 is a bash respawn loop (not systemd) — `systemctl` / `systemd-run` / sysv rc.d all fail silently
- `/sys/fs/cgroup` is `ro,nsdelegate` and `remount,rw` is denied even for root
- User services bootstrap from `~/.zshrc` via idempotent `pgrep + setsid` (same pattern as tailscaled, etserver, cpu-watchdog)
- `ps` is aliased to `procs` and `top` to `btm` — use `/usr/bin/ps` / `/usr/bin/top` for standard flags
- `pgrep -f` patterns must anchor with `$` to avoid matching the current shell's cmdline

## Test plan

- [x] No syntax issues (pre-commit passed)
- [x] Placement: new section above "Terminal Command Conventions" — consistent with the existing H2 structure
- [ ] Visual check after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for OrbStack Linux VM environment operations and deployment specifications, including detailed guidance for system initialization, process bootstrap mechanisms and operational constraints, cgroup mounting behaviors, command alias requirements, service operation patterns, and complete operational guidelines needed to ensure consistent, reliable, and optimal functionality within this specialized virtualized environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->