### PR TITLE
watchdog: prefer /usr/bin/cpulimit over linuxbrew shadow

### DIFF
--- a/shared/cpu-watchdog.sh
+++ b/shared/cpu-watchdog.sh
@@ -36,7 +36,18 @@ require_cmd() {
 require_cmd /usr/bin/top
 require_cmd awk
 require_cmd pgrep
-require_cmd cpulimit
+
+# Prefer /usr/bin/cpulimit (apt 3.1+). The brew package on Linux is an
+# unrelated fork stuck at v0.2 that lacks `-q` and silently fails, so if
+# linuxbrew is first on PATH it will shadow the working version.
+if [ -x /usr/bin/cpulimit ]; then
+    CPULIMIT=/usr/bin/cpulimit
+else
+    CPULIMIT=$(command -v cpulimit 2>/dev/null) || {
+        log "missing dependency: cpulimit not found in PATH; exiting"
+        exit 1
+    }
+fi
 
 # Do not throttle anything in this list — stopping them would wedge the VM
 is_excluded() {
@@ -71,7 +82,7 @@ while true; do
             # Already being throttled? (our cpulimit has `-p <pid>` in its args)
             if pgrep -f "cpulimit.*-p $pid " >/dev/null 2>&1; then continue; fi
             log "throttle pid=$pid comm=\"$comm\" cpu=${pcpu}% → cap ${LIMIT_PCT}%"
-            cpulimit -l "$LIMIT_PCT" -p "$pid" -z -q >/dev/null 2>&1 &
+            "$CPULIMIT" -l "$LIMIT_PCT" -p "$pid" -z -q >/dev/null 2>&1 &
         done
     sleep "$INTERVAL"
 done


### PR DESCRIPTION
## Summary

- Linuxbrew's cpulimit on Linux is an unrelated fork stuck at v0.2 that lacks \`-q\` and other modern flags. But linuxbrew prepends its own bin to PATH, so a bare \`cpulimit\` call silently picks the broken version even after \`apt install cpulimit\` lands the working 3.1 at \`/usr/bin/cpulimit\`.
- Hit this today setting up a fresh OrbStack VM. Symptom: the watchdog log shows a \`throttle pid=...\` line every scan (because the v0.2 cpulimit exits immediately and the pgrep "already throttled" check never matches), but %CPU on the burner process never drops.
- Fix: resolve \`CPULIMIT=/usr/bin/cpulimit\` up front and call it by full path. Falls back to \`command -v cpulimit\` if \`/usr/bin/cpulimit\` is missing.

## Test plan

- [x] Symlink \`~/bin/cpu-watchdog.sh\` → \`~/settings/shared/cpu-watchdog.sh\`
- [x] Install \`cpulimit\` via apt (3.1-1 on Ubuntu 25.10)
- [x] Run smoke test with \`CPU_WATCHDOG_LIMIT=30 CPU_WATCHDOG_THRESHOLD=50 CPU_WATCHDOG_INTERVAL=5\` against \`yes > /dev/null\`
- [x] Verified: single throttle line in log, \`%CPU\` drops from 100% → ~38% (within SIGSTOP duty-cycle variance), \`/usr/bin/cpulimit -l 30 -p <pid> -z -q\` child survives and is visible to \`pgrep\`
- [x] Start watchdog in production mode via \`~/.zshrc\` boot hook, confirm it's alive after shell restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)