### PR TITLE
CLAUDE.md: CocoaPods Ruby gem PATH for Expo iOS builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,12 @@ Essential packages are installed via Homebrew from `shared/brew_packages.sh`:
 - CLI utilities: `bat`, `eza`, `fzf`, `ripgrep`, `fd`
 - Git enhancements: `gh`, `lazygit`, `git-delta`
 
+### CocoaPods / Ruby gems PATH
+`pod` installed via `gem` lives at `/opt/homebrew/lib/ruby/gems/<ver>/bin/pod`, not in default PATH. Without it, `npx expo prebuild` and `pod install` fail with `spawn pod ENOENT`. Export before running iOS native commands:
+```bash
+export PATH="/opt/homebrew/lib/ruby/gems/4.0.0/bin:$PATH"
+```
+
 ### Python Environment Setup
 Python tools are managed via UV for speed and consistency:
 ```bash


### PR DESCRIPTION
## Summary
`pod` installed via `gem` sits at `/opt/homebrew/lib/ruby/gems/<ver>/bin/pod`, outside default PATH. Without the export, `npx expo prebuild` and `pod install` fail with `spawn pod ENOENT`.

Ate meaningful time in a recent Expo iOS session until PATH was fixed. Adding the one-liner to CLAUDE.md so it's discoverable next time.

## Test plan
- [x] CLAUDE.md renders correctly
- [x] Command verified: `export PATH="/opt/homebrew/lib/ruby/gems/4.0.0/bin:$PATH"` then `pod --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS setup documentation for CocoaPods and Ruby package manager path configuration to prevent build tool failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->