### PR TITLE
refactor(nvim): migrate to mini.nvim + built-in treesitter

### DIFF
--- a/nvim/lsp/tsserver.lua
+++ b/nvim/lsp/tsserver.lua
@@ -1,24 +1,33 @@
 return {
-  cmd = { "typescript-language-server", "--stdio" },
-  filetypes = { "typescript", "typescriptreact", "typescript.tsx", "javascript", "javascriptreact", "javascript.jsx" },
-  root_markers = { "package.json", "tsconfig.json", "jsconfig.json", ".git" },
-  settings = {
-    typescript = {
-      inlayHints = {
-        includeInlayParameterNameHints = "all",
-        includeInlayVariableTypeHints = true,
-        includeInlayFunctionLikeReturnTypeHints = true,
-        includeInlayPropertyDeclarationTypeHints = true,
-      },
-    },
-    javascript = {
-      inlayHints = {
-        includeInlayParameterNameHints = "all",
-        includeInlayVariableTypeHints = true,
-        includeInlayFunctionLikeReturnTypeHints = true,
-        includeInlayPropertyDeclarationTypeHints = true,
-      },
-    },
-  },
+	cmd = { "typescript-language-server", "--stdio" },
+	filetypes = { "typescript", "typescriptreact", "typescript.tsx", "javascript", "javascriptreact", "javascript.jsx" },
+	root_markers = { "package.json", "tsconfig.json", "jsconfig.json", ".git" },
+	init_options = {
+		-- Suppress tsserver "suggestion" diagnostics (TS6133 "declared but never read",
+		-- TS6192 "all imports unused"). These are emitted regardless of noUnusedLocals
+		-- via the reportsUnnecessary channel, and produce stale false positives during
+		-- rapid file edits in partialSemantic mode. ESLint's @typescript-eslint/no-unused-vars
+		-- remains the authoritative check on `npm run lint`. Real type errors still flow through.
+		preferences = {
+			disableSuggestions = true,
+		},
+	},
+	settings = {
+		typescript = {
+			inlayHints = {
+				includeInlayParameterNameHints = "all",
+				includeInlayVariableTypeHints = true,
+				includeInlayFunctionLikeReturnTypeHints = true,
+				includeInlayPropertyDeclarationTypeHints = true,
+			},
+		},
+		javascript = {
+			inlayHints = {
+				includeInlayParameterNameHints = "all",
+				includeInlayVariableTypeHints = true,
+				includeInlayFunctionLikeReturnTypeHints = true,
+				includeInlayPropertyDeclarationTypeHints = true,
+			},
+		},
+	},
 }
-

--- a/nvim/nvim_cmp_copilot.lua
+++ b/nvim/nvim_cmp_copilot.lua
@@ -163,15 +163,15 @@ cmp.setup({
 		completion = cmp.config.window.bordered(),
 		documentation = cmp.config.window.bordered(),
 	},
+	snippet = {
+		expand = function(args)
+			-- LSP-server-provided snippets expanded via mini.snippets
+			require("mini.snippets").default_insert({ body = args.body })
+		end,
+	},
 	sources = cmp.config.sources({
 		{ name = "copilot" },
 		{ name = "nvim_lsp" },
-		{ name = "luasnip" },
-		snippet = {
-			expand = function(args)
-				require("luasnip").lsp_expand(args.body)
-			end,
-		},
 		{ name = "conjure" },
 		--       {name = 'buffer'},  Exclude buffer as it's pretty noisy
 	}),

--- a/nvim/nvim_init.lua
+++ b/nvim/nvim_init.lua
@@ -25,7 +25,9 @@ if vim.g.vscode then
 end
 
 dofile(settings_dir .. "nvim_plugins.lua")
-print("nvim_plugins done")
+vim.schedule(function()
+	print("nvim_plugins done")
+end)
 
 require("aerial").setup({
 	placement = "edge",
@@ -77,37 +79,47 @@ vim.cmd([[
 -- For TS Highlights
 --  :TSHighlightCapturesUnderCursor
 
-require("nvim-treesitter.configs").setup({
-	-- A list of parser names, or "all" (the five listed parsers should always be installed)
-	ensure_installed = { "c", "lua", "vim", "vimdoc", "query", "markdown_inline", "python", "javascript", "regex" },
+-- Tree-sitter highlighting via Neovim 0.12+ built-in (no nvim-treesitter plugin).
+-- Parsers installed previously by nvim-treesitter remain on disk and are picked up.
+-- Inspect with :InspectTree, :Inspect, :EditQuery
+vim.api.nvim_create_autocmd("FileType", {
+	callback = function(args)
+		pcall(vim.treesitter.start, args.buf)
+	end,
+})
 
-	-- Install parsers synchronously (only applied to `ensure_installed`)
-	sync_install = false,
-
-	-- Automatically install missing parsers when entering buffer
-	-- Recommendation: set to false if you don't have `tree-sitter` CLI installed locally
-	auto_install = true,
-
-	highlight = {
-		enable = true,
-		-- Setting this to true will run `:h syntax` and tree-sitter at the same time.
-		-- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
-		-- Using this option may slow down your editor, and you may see some duplicate highlights.
-		-- Instead of true it can also be a list of languages
-		-- additional_vim_regex_highlighting = {'markdown','markdown_inline'},
-		additional_vim_regex_highlighting = false,
+-- mini.nvim modules
+require("mini.surround").setup({
+	mappings = {
+		add = "ys",
+		delete = "ds",
+		find = "",
+		find_left = "",
+		highlight = "",
+		replace = "cs",
+		update_n_lines = "",
 	},
-	textobjects = {
-		select = {
-			enable = true,
-			lookahead = true,
-			keymaps = {
-				["af"] = "@function.outer",
-				["if"] = "@function.inner",
-			},
-		},
+	search_method = "cover_or_next",
+})
+-- Re-enable default Vim `s` (mini.surround shadows it otherwise)
+vim.keymap.set({ "n", "x" }, "s", "s", { noremap = true })
+
+require("mini.bracketed").setup() -- unified ]/[ navigation
+require("mini.hipatterns").setup({
+	highlight = {
+		fixme = { pattern = "%f[%w]()FIXME()%f[%W]", group = "MiniHipatternsFixme" },
+		hack = { pattern = "%f[%w]()HACK()%f[%W]", group = "MiniHipatternsHack" },
+		todo = { pattern = "%f[%w]()TODO()%f[%W]", group = "MiniHipatternsTodo" },
+		note = { pattern = "%f[%w]()NOTE()%f[%W]", group = "MiniHipatternsNote" },
 	},
 })
+require("mini.splitjoin").setup() -- gS to split/join arg lists
+
+-- nerdcommenter compat: \cc and \cu now use built-in gc/gcc
+vim.keymap.set("n", "<leader>cc", "gcc", { remap = true, desc = "Toggle comment (line)" })
+vim.keymap.set("n", "<leader>cu", "gcc", { remap = true, desc = "Toggle comment (line)" })
+vim.keymap.set("x", "<leader>cc", "gc", { remap = true, desc = "Toggle comment (selection)" })
+vim.keymap.set("x", "<leader>cu", "gc", { remap = true, desc = "Toggle comment (selection)" })
 
 dofile(settings_dir .. "nvim_cmp_copilot.lua")
 dofile(settings_dir .. "nvim_git.lua")
@@ -133,15 +145,6 @@ function ZenModeToggleFunction(width)
 	})
 end
 
-require("neotest").setup({
-	adapters = {
-		require("neotest-python")({
-			dap = { justMyCode = false },
-		}),
-		require("neotest-plenary"),
-	},
-})
-
 local hostname = vim.fn.hostname()
 
 function CheckCopilotHost()
@@ -156,9 +159,13 @@ function CheckCopilotHost()
 	end
 
 	if is_allowed then
-		print("Enabling Copilot on host: " .. hostname)
+		vim.schedule(function()
+			print("Enabling Copilot on host: " .. hostname)
+		end)
 	else
-		print("Disabling  Copilot on host: " .. hostname)
+		vim.schedule(function()
+			print("Disabling  Copilot on host: " .. hostname)
+		end)
 		vim.cmd("Copilot disable")
 	end
 end
@@ -267,4 +274,6 @@ end, { nargs = "?" })
 vim.cmd("command! WorkNotes :Explore scp://idvorkin@devbox//home/idvorkin/work_notes/")
 
 -- vim.opt.laststatus = 3
-print("nvim_init.lua loaded")
+vim.schedule(function()
+	print("nvim_init.lua loaded")
+end)

--- a/nvim/nvim_plugins.lua
+++ b/nvim/nvim_plugins.lua
@@ -47,9 +47,7 @@ local vscode_compatible_plugins = {
 	"dhruvasagar/vim-table-mode",
 	-- :Rename a file
 	"danro/rename.vim",
-	-- Comment \cc
-	-- Uncomment \cu
-	"scrooloose/nerdcommenter",
+	-- Comments: built-in gc/gcc (Neovim 0.10+); \cc/\cu aliases set in nvim_init.lua
 	"preservim/vim-markdown",
 
 	"panozzaj/vim-autocorrect",
@@ -194,16 +192,6 @@ local plugins = {
 					{ wordcount, cond = is_markdown },
 				},
 			},
-		},
-	},
-	{
-		"nvim-neotest/neotest",
-		dependencies = {
-			"nvim-neotest/nvim-nio",
-			"nvim-neotest/neotest-plenary",
-			"nvim-neotest/neotest-python",
-			"nvim-lua/plenary.nvim",
-			"nvim-treesitter/nvim-treesitter",
 		},
 	},
 	{
@@ -352,10 +340,7 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- Tree-sitter inspection: use :InspectTree, :Inspect, :EditQuery (built-in since 0.10)
-plugins = appendTables(plugins, {
-	"nvim-treesitter/nvim-treesitter",
-	"nvim-treesitter/nvim-treesitter-textobjects",
-})
+-- Highlighting is started via a FileType autocmd in nvim_init.lua; no plugin needed.
 
 function TelescopePlugins()
 	return {
@@ -642,27 +627,11 @@ end
 -- C-L Insert markdown link to issue
 -- <cr> Insert reference to issue number (probably want C-L instead)
 
-plugins = appendTables(plugins, { "tpope/vim-surround" })
---[[
-     Cool does wrapping
-    help surround
-
-    Wrap current line
-    ys -> you surround, motion, element
-    yss* <- Wrap 'Surround' line '*'
-    ds" -> delete surround
-    cs" -> change surround
-
-    Setup surround for b (old)  and i(talics) for markdown.
-    echo char2nr('b') -> 105
-    "
-    Cheat Sheet
-    " - yssX - soround the current line with italics(i) or bold(b) or something
-    " else.
-    "
-    - Once in visual mode, S will do the surround followed by the b so like
-    select text in visual mode, then Sb will make it bold.
-]]
+-- Surround: provided by mini.surround (setup in nvim_init.lua)
+--   ys{motion}{char}  add surround
+--   ds{char}          delete surround
+--   cs{old}{new}      change surround
+--   visual: S{char}   surround selection
 
 local git_plugins = {
 	"tpope/vim-fugitive",
@@ -799,16 +768,9 @@ local git_plugins = {
 }
 plugins = appendTables(plugins, git_plugins)
 -- cmp and friends
+-- Snippets: provided by mini.snippets (setup in snippets.lua)
 local cmp_and_friends = {
-	{
-		"L3MON4D3/LuaSnip",
-		-- follow latest release.
-		version = "v2.*", -- Replace <CurrentMajor> by the latest released major (first number of latest release)
-		-- install jsregexp (optional!).
-		build = "make install_jsregexp",
-	},
 	"hrsh7th/nvim-cmp",
-	"saadparwaiz1/cmp_luasnip",
 	"hrsh7th/cmp-nvim-lsp",
 	{ "stevanmilic/nvim-lspimport" },
 	"hrsh7th/cmp-buffer",
@@ -935,7 +897,6 @@ plugins = appendTables(plugins, {
 plugins = appendTables(plugins, {
 	{ "williamboman/mason.nvim" },
 	{ "neovim/nvim-lspconfig" },
-	{ "L3MON4D3/LuaSnip" },
 	{
 		"smjonas/inc-rename.nvim",
 		config = function()

--- a/nvim/snippets.lua
+++ b/nvim/snippets.lua
@@ -1,105 +1,50 @@
--- Snippets
--- OK, no clue how to make this work... project for another day.
--- Force reload with \\s - see nvim_plugins.lua
-local ls = require("luasnip")
-local s = ls.snippet
-local sn = ls.snippet_node
-local isn = ls.indent_snippet_node
-local t = ls.text_node
-local i = ls.insert_node
-local f = ls.function_node
-local c = ls.choice_node
-local d = ls.dynamic_node
-local r = ls.restore_node
-local events = require("luasnip.util.events")
-local ai = require("luasnip.nodes.absolute_indexer")
-local extras = require("luasnip.extras")
-local l = extras.lambda
-local rep = extras.rep
-local p = extras.partial
-local m = extras.match
-local n = extras.nonempty
-local dl = extras.dynamic_lambda
-local fmt = require("luasnip.extras.fmt").fmt
-local fmta = require("luasnip.extras.fmt").fmta
-local conds = require("luasnip.extras.expand_conditions")
-local postfix = require("luasnip.extras.postfix").postfix
-local types = require("luasnip.util.types")
-local parse = require("luasnip.util.parser").parse_snippet
-local ms = ls.multi_snippet
-local k = require("luasnip.nodes.key_indexer").new_key
+-- Snippets via mini.snippets (LSP snippet format)
+-- Reload with \\s — see nvim_plugins.lua
+--
+-- Keymaps (set in nvim_init.lua mini.snippets setup):
+--   i <C-k>  expand snippet under cursor
+--   i,s <C-j>  jump to next placeholder
+--   i,s <C-l>  jump to previous placeholder
 
-ls.config.set_config({
-	history = true,
-	updateevents = "TextChanged,TextChangedI",
-	enable_autosnippets = true,
-	ext_opts = {
-		[".lua"] = {
-			-- Whether to use treesitter to determine the end of a snippet
-			-- (used for moving out of a snippet)
-			treesitter = true,
-		},
+local MiniSnippets = require("mini.snippets")
+
+MiniSnippets.setup({
+	snippets = {
+		-- All filetypes
+		{ prefix = "today", body = "$CURRENT_YEAR-$CURRENT_MONTH-$CURRENT_DATE", desc = "Today's date" },
+
+		-- Lua
+		function()
+			if vim.bo.filetype ~= "lua" then
+				return
+			end
+			return {
+				{
+					prefix = "lf",
+					body = "local function $1($2)\n\t$3\nend",
+					desc = "local function",
+				},
+			}
+		end,
+
+		-- Markdown
+		function()
+			if vim.bo.filetype ~= "markdown" then
+				return
+			end
+			return {
+				{
+					prefix = "esummarize",
+					body = '{%include summarize-page.html src="/$1"%}',
+					desc = "Jekyll summarize include",
+				},
+			}
+		end,
+	},
+	mappings = {
+		expand = "<C-k>",
+		jump_next = "<C-j>",
+		jump_prev = "<C-l>",
+		stop = "<C-c>",
 	},
 })
-
-local ls = require("luasnip")
-
--- I don't need expand, I get it for free from comp
-vim.keymap.set({ "i" }, "<C-k>", function()
-	ls.expand()
-end, { silent = true })
-vim.keymap.set({ "i", "s" }, "<C-j>", function()
-	ls.jump(1)
-end, { silent = true })
-vim.keymap.set({ "i", "s" }, "<C-l>", function()
-	ls.jump(-1)
-end, { silent = true })
-
-vim.keymap.set({ "i", "s" }, "<C-E>", function()
-	if ls.choice_active() then
-		ls.change_choice(1)
-	end
-end, { silent = true })
-
-local function lua_snippets()
-	-- Lua-specific snippets can be added here
-	-- lf = local function
-	return {
-		s("lf", {
-			t("local function "),
-			i(1),
-			t("("),
-			i(2),
-			t(")"),
-			t({ "", "\t" }),
-			i(3),
-			t({ "", "end" }),
-		}),
-	}
-end
-
-local function all_snippets()
-	return {
-		s("today", {
-			f(function()
-				return os.date("%Y-%m-%d")
-			end, {}),
-		}),
-	}
-end
-
-local function md_snippets()
-    return {
-		s("esummarize", {
-			t('{%include summarize-page.html src="/'),
-			i(1),
-			t('"%}'),
-		}),
-    }
-end
-
-ls.add_snippets("lua", lua_snippets(), { overwrite = true })
-ls.add_snippets("all", all_snippets(), { overwrite = true })
-ls.add_snippets("markdown", md_snippets(), { overwrite = true })
-
--- When I source this should auto reload the snippets


### PR DESCRIPTION
## Summary
- Drops heavy nvim plugins in favor of `mini.nvim` modules and Neovim 0.12 built-ins
- Fixes a latent bug in `nvim_cmp_copilot.lua` where `snippet.expand` was nested inside `sources = cmp.config.sources({...})` as a misplaced named key, so nvim-cmp never saw it
- Stops the "Press ENTER" hit-enter prompt on nvim startup by deferring startup `print()` calls with `vim.schedule()`
- Bundles a small tsserver config change to suppress TS6133/TS6192 suggestion diagnostics (ESLint remains authoritative)

## Plugin changes
| Out | In |
|---|---|
| `nvim-treesitter` (archived 2026-04-03) | `vim.treesitter.start()` via `FileType` autocmd |
| `LuaSnip` + `cmp_luasnip` | `mini.snippets` (LSP format) |
| `vim-surround` | `mini.surround` |
| `nerdcommenter` | built-in `gc`/`gcc` with `\cc`/`\cu` compat remaps |
| `neotest` + python/plenary adapters | — (removed) |
| — | `mini.bracketed`, `mini.hipatterns`, `mini.splitjoin` |

## Why the cmp fix matters
Pre-migration, LSP snippet expansion was routed through the `{ name = "luasnip" }` source. Removing LuaSnip without first hoisting `snippet.expand` to top-level `cmp.setup({})` would have left LSP completion placeholders (e.g. `foo($1, $2)`) silently broken. Fix is in the same commit as the migration so there is no broken intermediate state.

## Test plan
- [ ] Open `nvim` from a shell and confirm no "Press ENTER" prompt on startup
- [ ] Open a `.lua` / `.py` / `.md` file and confirm tree-sitter highlighting is active (`:Inspect` under a token)
- [ ] Trigger LSP completion on a function, accept it, and confirm snippet placeholders expand and `<C-j>`/`<C-l>` jump between them
- [ ] `ys`/`ds`/`cs` surround ops on a quoted string
- [ ] `gcc` / `\cc` comment toggle on a line
- [ ] Open a `.ts` file and confirm no TS6133 "declared but never read" suggestions on temporarily-unused variables; confirm real type errors still report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comment toggle keymaps and expanded mini.nvim module support (surround, bracketed, splitjoin).

* **Improvements**
  * Reduced TypeScript suggestion diagnostics for cleaner error reporting; optimized startup performance with deferred plugin initialization.

* **Refactoring**
  * Migrated snippet handling to mini.snippets; consolidated plugin-based utilities with Neovim built-in alternatives for streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->