### PR TITLE
fix(py): running-servers check — --port/--process filters + exit codes (#60)

### DIFF
--- a/py/running_servers.py
+++ b/py/running_servers.py
@@ -423,25 +423,79 @@ def status(
 @app.command()
 def check(
     directory: Path = typer.Argument(None, help="Directory to check (default: cwd)"),
+    expected_port: int | None = typer.Option(
+        None,
+        "--port",
+        "-p",
+        help="Only succeed if a server is listening on this port in the directory",
+    ),
+    expected_process: str | None = typer.Option(
+        None,
+        "--process",
+        help="Only succeed if a server's process name or cmdline matches (substring, case-insensitive)",
+    ),
 ):
-    """Check what servers are running for a directory."""
+    """Check what servers are running for a directory.
+
+    Exits 0 when matching servers are found, 1 otherwise. Use --port or
+    --process to require a specific server (e.g. `check . --port 4000` to
+    confirm Jekyll is up before taking screenshots). Without filters,
+    succeeds when any server has its cwd in the directory.
+    """
     directory = directory or Path.cwd()
     hostname = get_tailscale_hostname()
     finder = get_finder()
     servers = finder.find_for_directory(directory)
+
+    # Apply filters so callers can ask for a specific server rather than
+    # "any dev server in this cwd" (see issue #60).
+    if expected_port is not None:
+        servers = [s for s in servers if s["port"] == expected_port]
+    if expected_process is not None:
+        needle = expected_process.lower()
+        servers = [
+            s
+            for s in servers
+            if needle in s["process"].lower() or needle in s["cmdline"].lower()
+        ]
 
     if servers:
         console.print(f"[green]✓[/green] Servers running for [cyan]{directory}[/cyan]")
         for s in servers:
             url = get_url(s["port"], hostname)
             console.print(
-                f"  :{s['port']} [yellow]{s['process']}[/yellow] → [blue]{url}[/blue]"
+                f"  :{s['port']} [yellow]{s['process']}[/yellow] "
+                f"[dim]({s['cmdline']})[/dim] → [blue]{url}[/blue]"
             )
+        return
+
+    # No match — explain why and exit non-zero so shell callers can branch.
+    if expected_port is not None or expected_process is not None:
+        criteria_parts = []
+        if expected_port is not None:
+            criteria_parts.append(f"port {expected_port}")
+        if expected_process is not None:
+            criteria_parts.append(f"process matching '{expected_process}'")
+        criteria = " and ".join(criteria_parts)
+        console.print(
+            f"[yellow]✗[/yellow] No server with {criteria} in [cyan]{directory}[/cyan]"
+        )
+        # Still show what is running in the dir so the caller can see the
+        # stray processes that confused them.
+        other = finder.find_for_directory(directory)
+        if other:
+            console.print("[dim]  Other servers in this directory:[/dim]")
+            for s in other:
+                console.print(
+                    f"[dim]    :{s['port']} {s['process']} ({s['cmdline']})[/dim]"
+                )
     else:
         console.print(f"[yellow]✗[/yellow] No servers for [cyan]{directory}[/cyan]")
         available = finder.find_available_port()
         if available:
             console.print(f"  Available port: [cyan]{available}[/cyan]")
+
+    raise typer.Exit(code=1)
 
 
 @app.command()

--- a/py/test_running_servers.py
+++ b/py/test_running_servers.py
@@ -1,0 +1,201 @@
+"""Tests for running_servers.
+
+Uses a MockAdapter so tests work on any platform without touching real /proc or lsof.
+"""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import running_servers
+from running_servers import PlatformAdapter, ServerFinder, app
+
+
+class MockAdapter(PlatformAdapter):
+    """Configurable adapter for tests.
+
+    servers: list of dicts with keys: port, pid, cwd, name, cmdline, ppid
+    """
+
+    def __init__(self, servers: list[dict]):
+        self._by_pid = {s["pid"]: s for s in servers}
+        self._ports = {s["port"]: s["pid"] for s in servers}
+
+    def get_listening_ports(self) -> dict[int, int]:
+        return dict(self._ports)
+
+    def get_process_cwd(self, pid: int) -> Path | None:
+        s = self._by_pid.get(pid)
+        return Path(s["cwd"]) if s and s.get("cwd") else None
+
+    def get_process_name(self, pid: int) -> str | None:
+        s = self._by_pid.get(pid)
+        return s["name"] if s else None
+
+    def get_process_cmdline(self, pid: int) -> str | None:
+        s = self._by_pid.get(pid)
+        return s["cmdline"] if s else None
+
+    def get_parent_pid(self, pid: int) -> int | None:
+        s = self._by_pid.get(pid)
+        return s.get("ppid") if s else None
+
+
+# --- ServerFinder unit tests (using MockAdapter directly) ---
+
+
+def test_find_for_directory_matches(tmp_path):
+    adapter = MockAdapter(
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(tmp_path),
+                "name": "ruby",
+                "cmdline": "jekyll serve",
+            },
+        ]
+    )
+    finder = ServerFinder(adapter)
+    servers = finder.find_for_directory(tmp_path)
+    assert len(servers) == 1
+    assert servers[0]["port"] == 4000
+    assert servers[0]["cmdline"] == "jekyll serve"
+
+
+def test_find_for_directory_excludes_other_dirs(tmp_path):
+    other = tmp_path / "other"
+    other.mkdir()
+    target = tmp_path / "target"
+    target.mkdir()
+    adapter = MockAdapter(
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(other),
+                "name": "ruby",
+                "cmdline": "jekyll serve",
+            },
+        ]
+    )
+    finder = ServerFinder(adapter)
+    assert finder.find_for_directory(target) == []
+
+
+# --- CLI tests: reproduce issue #60 and lock in the fix ---
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _patch_adapter(monkeypatch, servers: list[dict]):
+    """Replace get_adapter so CLI commands use our MockAdapter."""
+    monkeypatch.setattr(running_servers, "get_adapter", lambda: MockAdapter(servers))
+
+
+def test_check_no_servers_exits_nonzero(runner, monkeypatch, tmp_path):
+    """check on an empty dir must exit non-zero so shell callers can react."""
+    _patch_adapter(monkeypatch, [])
+    result = runner.invoke(app, ["check", str(tmp_path)])
+    assert result.exit_code != 0, result.output
+    assert "No servers" in result.output
+
+
+def test_check_with_server_exits_zero(runner, monkeypatch, tmp_path):
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(tmp_path),
+                "name": "ruby",
+                "cmdline": "jekyll serve",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["check", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "4000" in result.output
+
+
+def test_check_port_filter_mismatch_exits_nonzero(runner, monkeypatch, tmp_path):
+    """Issue #60 core case: stray node on :40816 should not satisfy
+    `check --port 4000`."""
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 40816,
+                "pid": 200,
+                "cwd": str(tmp_path),
+                "name": "node",
+                "cmdline": "node some-dev-tool.js",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["check", str(tmp_path), "--port", "4000"])
+    assert result.exit_code != 0, result.output
+    assert "4000" in result.output  # mentions the expected port
+
+
+def test_check_port_filter_match_exits_zero(runner, monkeypatch, tmp_path):
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(tmp_path),
+                "name": "ruby",
+                "cmdline": "jekyll serve",
+            },
+            {
+                "port": 40816,
+                "pid": 200,
+                "cwd": str(tmp_path),
+                "name": "node",
+                "cmdline": "node some-dev-tool.js",
+            },
+        ],
+    )
+    result = runner.invoke(app, ["check", str(tmp_path), "--port", "4000"])
+    assert result.exit_code == 0, result.output
+
+
+def test_check_process_filter_mismatch_exits_nonzero(runner, monkeypatch, tmp_path):
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 40816,
+                "pid": 200,
+                "cwd": str(tmp_path),
+                "name": "node",
+                "cmdline": "node some-dev-tool.js",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["check", str(tmp_path), "--process", "jekyll"])
+    assert result.exit_code != 0, result.output
+
+
+def test_check_process_filter_match_exits_zero(runner, monkeypatch, tmp_path):
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(tmp_path),
+                "name": "ruby",
+                "cmdline": "jekyll serve",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["check", str(tmp_path), "--process", "jekyll"])
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
Fixes #60. Supersedes #61 — captures the `--port`+exit-code work from that draft and layers on tests, `--process`, and better output.

## Why

`running-servers check .` reported a green light as soon as *any* process in the target directory had an open port. A stray \`node\` on :40816 looked identical to Jekyll on :4000, so screenshot workflows gated on this check were silently taking blank screenshots. From #60: *\"my PR-screenshot workflow assumed 'positive result → Jekyll is up → take screenshot,' and only caught the mistake because the subsequent \`curl localhost:4000\` returned nothing.\"*

## What changed

**`check` now takes filters and respects exit codes:**

- `--port / -p` — only succeed when a server is listening on that specific port in the directory
- `--process` — only succeed when a server's process name or cmdline matches (substring, case-insensitive)
- Exits **1** when no matching server is found, including the bare \`check\` with zero servers. Previously always exited 0, even in the \"✗ No servers\" branch.
- Output now shows the full cmdline next to the process name, so a stray \`node\` masquerading as Jekyll is obvious at a glance. This is Option 1 from #60.
- On a filtered mismatch, the failure message lists the *other* servers in the directory so you can see what confused the match.

## Example

\`\`\`console
# Before (buggy): false positive in the blog dir
\$ running-servers check ~/gits/blog5
✓ Servers running for /home/developer/gits/blog5
  :40816 node-MainThread → http://…:40816
\$ echo \$?
0

# After: ask for what you actually want
\$ running-servers check ~/gits/blog5 --port 4000
✗ No server with port 4000 in /home/developer/gits/blog5
  Other servers in this directory:
    :40816 node (node some-dev-tool.js)
\$ echo \$?
1
\`\`\`

This lets the blog \`CLAUDE.md\` drop the extra \`curl localhost:4000\` workaround and use \`running-servers check . --port 4000\` as a real gate.

## Tests

New \`py/test_running_servers.py\` with a MockAdapter-based suite (8 tests, pytest). Locks in:

- \`find_for_directory\` matches/excludes correctly
- bare \`check\` on empty dir → exit 1
- bare \`check\` with server → exit 0
- \`check --port X\` mismatch → exit 1
- \`check --port X\` match → exit 0
- \`check --process X\` mismatch → exit 1
- \`check --process X\` match → exit 0

Tests use dependency injection via the existing \`PlatformAdapter\` ABC, so they run on any platform without touching real \`/proc\` or \`lsof\`. Note: pytest wasn't in the py/ venv before — I \`uv pip install\`'d it locally but didn't modify \`pyproject.toml\`. Happy to add it to the dev dependency group if you'd like.

## Test plan

- [x] \`pytest py/test_running_servers.py\` — 8/8 passing
- [x] Manual repro on devvm: spun up \`python3 -m http.server 49999\` in the settings dir and verified all five cases (bare check, \`--port\` match, \`--port\` mismatch, \`--process\` match, \`--process\` mismatch) produce the right output and exit code
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Pre-commit hooks passed
- [ ] On merge: update blog \`CLAUDE.md\` to drop the curl workaround

## Re #61

Nothing in #61 is lost — I cross-checked Copilot's diff before pushing this. #61 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--port/-p` and `--process` CLI options to filter discovered servers.
  * Enhanced output now includes command-line details for matched servers.

* **Bug Fixes**
  * Improved error messages with specific filtering criteria and list of alternative servers.
  * Corrected exit codes to properly indicate success or failure.

* **Tests**
  * Added comprehensive test suite covering server discovery and CLI filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->