### PR TITLE
py: canonical PEP 723 shebangs across all py/ scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,14 +52,15 @@ uv tool install --force mypy
 ## Python Development Conventions
 
 ### UV Shebang Usage
-All Python scripts should use UV shebangs for easy deployment:
+All Python scripts in `py/` use PEP 723 inline script dependencies — no venv setup required, run directly:
 ```python
-#!/usr/bin/env uv run --script
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.11"
 # dependencies = ["typer", "rich", "pydantic"]
 # ///
 ```
+The `-S` in `env -S` is required so `env` splits `uv run --script` into multiple args — without it, the kernel passes the whole string as a single argument to `env` and the shebang fails on both macOS and Linux.
 
 ### CLI Framework
 Use Typer for all command-line interfaces:
@@ -101,29 +102,31 @@ console.print("[green]Success![/green] Operation completed")
 
 ### Testing Organization
 - Test files mirror source structure: `py/foo.py` → `py/test_foo.py`
-- Use pytest fixtures for shared test data
-- Mock external dependencies
-- Test both success and error cases
+- Test files are standalone PEP 723 scripts — pytest is declared in the inline `# /// script` block so you can run them directly: `./py/test_foo.py`. No `py/.venv/` setup needed.
+- `if __name__ == "__main__": sys.exit(pytest.main([__file__, "-v"]))` at the bottom lets direct execution invoke pytest on the file.
+- For CLI commands, inject dependencies via ABC (see `PlatformAdapter` in `py/running_servers.py`) and test with a MockAdapter subclass + `typer.testing.CliRunner`.
+- Mock external dependencies; test both success and error cases.
+- `just test` runs nvim lua tests, **not** Python tests — run Python test files directly.
 
-## Before Implementing
+## Shared Conventions
 
-Follow [chop-conventions/dev-inner-loop/before-implementing.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/before-implementing.md):
-1. **Spec first** - understand what success looks like
-2. **Confirm understanding** - ask if unclear
-3. **Read existing code** - understand context
-4. **Check patterns** - match existing conventions
-5. **Plan for context loss** - create tracking issue for non-trivial work
+This repo follows the conventions in [chop-conventions/dev-inner-loop](https://github.com/idvorkin/chop-conventions/tree/main/dev-inner-loop). Key references:
 
-## Bug Investigation
+- [clean-code.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/clean-code.md) — code quality standards
+- [clean-commits.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/clean-commits.md) — commit message standards
+- [pr-workflow.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/pr-workflow.md) — pull request process
+- [guardrails.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/guardrails.md) — safety rules requiring user approval
+- [repo-modes.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/repo-modes.md) — AI-tools vs human-supervised modes (this repo is human-supervised: no direct pushes to main)
+- [retros.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/retros.md) — periodic retrospective process
+- [running-commands.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/running-commands.md) — command-line conventions
 
-Follow [chop-conventions/dev-inner-loop/bug-investigation.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/bug-investigation.md):
-1. **Spec**: Is this actually a bug? Ask if unclear
-2. **Test**: Add missing test BEFORE fixing
-3. **Arch**: Deeper problem? Create issue, don't patch around bad architecture
+Superseded by skills — use the skill, not a convention doc:
+- **Before implementing** → `superpowers:brainstorming` skill
+- **Bug investigation** → `superpowers:systematic-debugging` skill
 
 ## Guardrails
 
-See [chop-conventions/dev-inner-loop/guardrails.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/guardrails.md)
+See [chop-conventions/dev-inner-loop/guardrails.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/guardrails.md).
 - Never remove failing tests without explicit "YES" approval
 - Never push to main directly - use feature branches and PRs
 - Never force push - can destroy history

--- a/py/a.py
+++ b/py/a.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
@@ -183,7 +183,7 @@ def rotate():
 
 
 @app.command()
-def accordian():
+def accordion():
     call_aerospace("layout accordion")
 
 

--- a/py/ai_clip.py
+++ b/py/ai_clip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/amazon2monarch.py
+++ b/py/amazon2monarch.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/chop.py
+++ b/py/chop.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/gmail_reader.py
+++ b/py/gmail_reader.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/shorten.py
+++ b/py/shorten.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/test_running_servers.py
+++ b/py/test_running_servers.py
@@ -1,15 +1,27 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest", "typer", "rich"]
+# ///
 """Tests for running_servers.
 
 Uses a MockAdapter so tests work on any platform without touching real /proc or lsof.
+
+Run directly with uv (no venv setup needed):
+    ./test_running_servers.py
 """
 
+import sys
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
-import running_servers
-from running_servers import PlatformAdapter, ServerFinder, app
+# Make sibling running_servers.py importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).parent))
+
+import running_servers  # noqa: E402
+from running_servers import PlatformAdapter, ServerFinder, app  # noqa: E402
 
 
 class MockAdapter(PlatformAdapter):
@@ -199,3 +211,7 @@ def test_check_process_filter_match_exits_zero(runner, monkeypatch, tmp_path):
     )
     result = runner.invoke(app, ["check", str(tmp_path), "--process", "jekyll"])
     assert result.exit_code == 0, result.output
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/py/tmux_helper.py
+++ b/py/tmux_helper.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/ux.py
+++ b/py/ux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/vim_python.py
+++ b/py/vim_python.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/web_to_markdown.py
+++ b/py/web_to_markdown.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [

--- a/py/y.py
+++ b/py/y.py
@@ -1,4 +1,4 @@
-#!/opt/homebrew/bin/uv run
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [


### PR DESCRIPTION
## Summary

All 16 \`py/*.py\` scripts already had PEP 723 \`# /// script\` inline dependency blocks, but the shebang lines were inconsistent:

| Before | Count |
|---|---|
| \`#!uv run\` (not portable — kernel won't PATH-search) | 8 |
| \`#!/usr/bin/env uv run\` (missing \`--script\`) | 1 |
| \`#!/usr/bin/env -S uv run\` (missing \`--script\`) | 1 |
| \`#!/opt/homebrew/bin/uv run\` (hardcoded mac path) | 1 |
| \`#!/usr/bin/env -S uv run --script\` ✓ | 4 |

Swapped all 11 non-canonical forms to \`#!/usr/bin/env -S uv run --script\`. None of the non-shebang content changed (other than a pre-commit typos hook fixing a latent \`accordian\` → \`accordion\` typo in \`a.py\`, no live callers).

## \`py/test_running_servers.py\`

Converted from a plain pytest file (which required \`pip install pytest\` in \`py/.venv/\`) to a self-executing PEP 723 script:

- Declares \`pytest\`, \`typer\`, \`rich\` as inline deps
- Inserts its own directory on \`sys.path\` so it can still import sibling \`running_servers.py\` when run directly
- Bootstraps pytest on itself via \`if __name__ == \"__main__\": sys.exit(pytest.main([__file__, \"-v\"]))\`
- Run it with \`./py/test_running_servers.py\` — all 8 tests pass, no venv setup needed

## CLAUDE.md

1. **Fix the UV shebang example** — was \`#!/usr/bin/env uv run --script\` (missing \`-S\`). Without \`-S\`, the kernel passes the whole \`uv run --script\` string as a single argument to \`env\`, which fails on both macOS and Linux. Only \`env -S\` splits it into separate args.

2. **Rewrite Testing Organization** to describe the standalone PEP 723 script pattern, the \`pytest.main([__file__])\` bootstrap, and the MockAdapter+CliRunner testability idiom from \`running_servers.py\`. Also explicitly notes \`just test\` runs nvim lua tests, **not** Python tests.

3. **Replace broken convention links.** The old \`## Before Implementing\` and \`## Bug Investigation\` sections linked to \`before-implementing.md\` and \`bug-investigation.md\` in \`idvorkin/chop-conventions\` — both return 404. According to \`chop-conventions/dev-inner-loop/a_readme_first.md\`, those two workflows have been superseded by skills:
   - Before implementing → \`superpowers:brainstorming\`
   - Bug investigation → \`superpowers:systematic-debugging\`

   Replaced with a new \`## Shared Conventions\` section that lists the actual core convention docs in that repo (clean-code, clean-commits, pr-workflow, guardrails, repo-modes, retros, running-commands) and the skill supersession notes.

## Test plan

- [x] \`head -1 py/*.py | sort -u\` returns exactly one line: \`#!/usr/bin/env -S uv run --script\`
- [x] Smoke-tested 7 representative converted files: \`tmux_helper\`, \`amazon2monarch\`, \`vim_python\`, \`chop\`, \`web_to_markdown\`, \`a.py\`, \`test_running_servers\` — all run, uv auto-installs deps in isolated cache. (\`shorten.py\` loads deps but crashes on a pre-existing missing \`~/gits/igor2/secretBox.json\`, unrelated.)
- [x] \`./py/test_running_servers.py\` → 8/8 tests pass
- [x] Pre-commit hooks pass (ruff lint/format, prettier, fast tests, typos)
- [ ] @idvorkin: sanity-check that nothing in your mac workflow relied on one of the non-canonical shebang forms (e.g. the hardcoded \`/opt/homebrew/bin/uv\` in \`y.py\`). \`/usr/bin/env -S uv run --script\` works on macOS 10.15+ and any Linux with coreutils 8.30+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Python development conventions and testing guidelines in developer documentation.

* **Bug Fixes**
  * Fixed command name spelling: `accordian` → `accordion`.

* **Tests**
  * Enhanced test scripts to be directly executable as standalone Python files.

* **Chores**
  * Standardized Python script execution shebangs across the codebase for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->