### PR TITLE
rbv: show install hint when bv is missing

### DIFF
--- a/py/rbv.py
+++ b/py/rbv.py
@@ -62,6 +62,12 @@ def main(ctx: typer.Context) -> None:
         os.execvp("bv", bv_args)
     except FileNotFoundError:
         console.print("[red]'bv' command not found on PATH[/red]")
+        console.print(
+            "Install with: [cyan]brew install dicklesworthstone/tap/bv[/cyan]"
+        )
+        console.print(
+            "See: [blue]https://github.com/Dicklesworthstone/beads_viewer[/blue]"
+        )
         raise typer.Exit(127)
 
 


### PR DESCRIPTION
## Summary

- When `bv` isn't on PATH, `rbv` now prints the Homebrew install command (`brew install dicklesworthstone/tap/bv`) and a link to the upstream repo instead of just "command not found".

## Why

`rbv` is our Dolt-aware launcher for `bv` (the beads TUI). First-time users hitting the FileNotFoundError had to go searching for how to install it — now the error message tells them directly.

## Test plan

- [x] Run `rbv` in a dir with `.beads/` but `bv` absent from PATH — shows install hint, exits 127
- [x] Pre-commit hooks (ruff lint + format, tests, typos) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)