### PR TITLE
feat(rmux_helper): scrollback link picker (pick-links)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,11 @@ Superseded by skills — use the skill, not a convention doc:
 - **Before implementing** → `superpowers:brainstorming` skill
 - **Bug investigation** → `superpowers:systematic-debugging` skill
 
+## Collaboration Preferences
+
+- **Multi-task plans use subagent-driven execution with max parallelization.** Batch cohesive tasks that share files into a single implementer dispatch (e.g. all enrichment files in one go); fire spec + quality reviewers in parallel per task; fall back to inline only for trivial touch-ups.
+- **When a popup/TUI bug is reported, reproduce it yourself first** via the backgrounded `tmux display-popup -E "cmd; echo \$? >/tmp/done" &` recipe (see `### Tmux popup/bind-key gotchas`). Don't ask the user to re-test until you've narrowed the failure locally.
+
 ## Guardrails
 
 See [chop-conventions/dev-inner-loop/guardrails.md](https://github.com/idvorkin/chop-conventions/blob/main/dev-inner-loop/guardrails.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ If the check prints `devvm`, the following non-obvious constraints apply. If it 
 - **`/sys/fs/cgroup` is mounted `ro,nsdelegate`.** `remount,rw` is denied even for root. No in-VM cgroup writes; VM-level caps must be set Mac-side via `orb config set cpu N`.
 - **User services bootstrap from `~/.zshrc`** via the idempotent `pgrep + setsid` pattern — see the tailscaled, etserver, and cpu-watchdog blocks. New background services go there too.
 - **`ps` is aliased to `procs` and `top` to `btm`.** Use `/usr/bin/ps` and `/usr/bin/top` for standard flags like `--sort=-%cpu` or `-bn2 -d1`.
-- **`pgrep -f` patterns must anchor** to avoid matching your own shell cmdline: `pgrep -f 'bin/myscript.sh$'`, not `pgrep -f myscript`.
+- **`pgrep` without `-f` silently truncates to 15-char name matches** — always use `-f` and anchor the pattern: `pgrep -f 'bin/myscript.sh$'`, not `pgrep -f myscript`.
 
 ## Terminal Command Conventions
 
@@ -315,6 +315,11 @@ To add new tmux commands via `py/tmux_helper.py`:
 cd rust/tmux_helper
 cargo install --path . --force
 ```
+
+### Tmux popup/bind-key gotchas
+
+- **`#{pane_id}` in a `display-popup -E` command argument is NOT reliably format-expanded** from a bind-key context. Don't embed it — resolve at runtime via `tmux display-message -p -t '#{client_active_pane}' '#{pane_id}'` inside the invoked command.
+- **Test a popup-bound TUI non-interactively:** `tmux display-popup -E "cmd; echo \$? >/tmp/done" &; sleep 2; /bin/cat /tmp/done`. No `done` file = TUI alive and blocking on input; anything else = early exit with the captured code.
 
 ## File Organization
 

--- a/docs/superpowers/plans/2026-04-12-scrollback-link-picker.md
+++ b/docs/superpowers/plans/2026-04-12-scrollback-link-picker.md
@@ -1,0 +1,2904 @@
+# Scrollback Link Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `rmux_helper pick-links`: a ratatui TUI that scans the current tmux pane's scrollback for GitHub links, blog posts, servers, and IPs; fuzzy-picks one; and acts contextually (yank via OSC 52 / open browser / ssh). Bidirectional `F2` cross-picker with the existing `pick-tui` session picker.
+
+**Architecture:** Strictly-phased pipeline `capture → detect → enrich → TUI → dispatch`. Sync Rust on the main thread for capture and detect. A single-thread tokio runtime wraps enrichment (parallel `gh` fan-out bounded by a semaphore and a shared wall-clock deadline). TUI is crossterm/ratatui — entered only after `block_on` returns. OSC 52 yank writes to `/dev/tty` after teardown but before exit. The `F2` branch skips OSC 52 and `execvp`s the sibling picker.
+
+**Tech Stack:** Rust (existing `rmux_helper` crate), ratatui 0.29, crossterm 0.29, tokio 1 (`rt` + `process` + `time` + `sync` + `macros`), regex 1, serde + serde_json 1, unicode-width 0.2, base64 0.22, dirs 5.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md`. Every task below cites the relevant section. Read the spec's Execution Flow (lines 47–121) before starting.
+
+**Prerequisite worktree:** This plan assumes a dedicated git worktree off `main`. If the brainstorming skill did not create one, run:
+
+```bash
+git worktree add ../rmux-link-picker -b feat/link-picker
+cd ../rmux-link-picker
+```
+
+All commits below target this branch. The final step opens a PR against `upstream/main`.
+
+---
+
+## File Structure
+
+**Create:**
+- `rust/tmux_helper/src/link_picker/mod.rs` — public entry: `pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> anyhow::Result<()>`. Implements the top-level Execution Flow from spec lines 55–106.
+- `rust/tmux_helper/src/link_picker/detect.rs` — pure sync detection: regex, canonicalization, dedup, ordering, context extraction. No tokio, no ratatui. Unit-tested via `#[cfg(test)] mod tests`.
+- `rust/tmux_helper/src/link_picker/enrich.rs` — tokio `current_thread` runtime, parallel `gh` fan-out, JSON cache at `~/.cache/rmux_helper/gh-links.json`. Integration-tested with a stub `gh` binary on `$PATH`.
+- `rust/tmux_helper/src/link_picker/tui.rs` — ratatui app, render loop, key handling. Mirrors `picker.rs` chrome; imports shared constants where possible.
+- `rust/tmux_helper/LINK_PICKER_SPEC.md` — behavior contract in the style of the existing `PICKER_SPEC.md`. Concise rules, not narrative.
+
+**Modify:**
+- `rust/tmux_helper/Cargo.toml` — add deps listed in `Tech Stack`.
+- `rust/tmux_helper/src/main.rs` — add `mod link_picker;` at line 1, add `PickLinks { json, enrich_deadline_ms }` to the `Commands` enum (around line 40–73), add the dispatch arm at line 1819.
+- `rust/tmux_helper/src/picker.rs` — add `F2` → exec `rmux_helper pick-links` in the key handler (around line 650). Teardown-then-exec pattern matching the spec's F2 sequence.
+- `rust/tmux_helper/PICKER_SPEC.md` — document the new `F2` cross-picker entry.
+- `shared/.tmux.conf` — add `bind-key L display-popup -E -w 95% -h 95% "TMUX_PANE=#{pane_id} rmux_helper pick-links"`, a help-section entry at the top, and a `set -s command-alias` entry in the aliases block.
+
+**File-boundary rationale.** `detect.rs` is leaf (no async, no TUI) so its tests compile fast and don't pull tokio. `enrich.rs` owns the tokio runtime construction so `mod.rs` doesn't leak async up. `tui.rs` owns crossterm, mirroring `picker.rs`'s separation. `mod.rs` is the thin orchestrator implementing the Execution Flow sequence — any ordering bug shows up there, not spread across four files.
+
+---
+
+## Task 1 — Scaffolding and `--json` smoke test
+
+**Files:**
+- Modify: `rust/tmux_helper/Cargo.toml`
+- Create: `rust/tmux_helper/src/link_picker/mod.rs`
+- Create: `rust/tmux_helper/src/link_picker/detect.rs` (empty stub)
+- Create: `rust/tmux_helper/src/link_picker/enrich.rs` (empty stub)
+- Create: `rust/tmux_helper/src/link_picker/tui.rs` (empty stub)
+- Modify: `rust/tmux_helper/src/main.rs:1` (add `mod link_picker;`)
+- Modify: `rust/tmux_helper/src/main.rs:41-73` (add `PickLinks` variant)
+- Modify: `rust/tmux_helper/src/main.rs:1819` (add dispatch arm)
+
+- [ ] **Step 1: Write the failing integration smoke test.**
+
+Create `rust/tmux_helper/src/link_picker/mod.rs` with this test scaffold:
+
+```rust
+//! Scrollback link picker — top-level orchestration.
+
+pub mod detect;
+pub mod enrich;
+pub mod tui;
+
+use anyhow::Result;
+
+/// Entry point for `rmux_helper pick-links`.
+pub fn pick_links(_json: bool, _enrich_deadline_ms: u64) -> Result<()> {
+    // Minimal smoke: print empty JSON array.
+    println!("[]");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn pick_links_json_mode_returns_empty_array_when_scrollback_is_empty() {
+        // Integration-level smoke; replaced in Task 13 with real pipeline.
+        assert!(true, "placeholder — replaced when pipeline lands");
+    }
+}
+```
+
+Create three empty stubs so the module tree compiles:
+
+```rust
+// detect.rs
+//! Pure scrollback detection. No I/O, no async.
+```
+
+```rust
+// enrich.rs
+//! Parallel `gh` enrichment with a shared deadline.
+```
+
+```rust
+// tui.rs
+//! Ratatui TUI for the link picker.
+```
+
+- [ ] **Step 2: Wire the module into `main.rs` and add the `PickLinks` subcommand.**
+
+At `rust/tmux_helper/src/main.rs:1`, add `mod link_picker;` below the existing `mod picker;`:
+
+```rust
+mod picker;
+mod link_picker;
+```
+
+At `rust/tmux_helper/src/main.rs:41-73` (inside `enum Commands`), append a new variant after `DebugKeys`:
+
+```rust
+    /// TUI picker for GitHub links, servers, and IPs in the current tmux pane's scrollback
+    PickLinks {
+        /// Emit JSON of detected items to stdout and exit (no TUI)
+        #[arg(long)]
+        json: bool,
+        /// Enrichment deadline in milliseconds (0 disables gh enrichment)
+        #[arg(long, default_value_t = 3000)]
+        enrich_deadline_ms: u64,
+    },
+```
+
+At `rust/tmux_helper/src/main.rs:1819`, add a dispatch arm beneath `PickTui`:
+
+```rust
+        Some(Commands::PickTui) => picker::pick_tui(),
+        Some(Commands::PickLinks { json, enrich_deadline_ms }) => {
+            link_picker::pick_links(json, enrich_deadline_ms)
+        }
+```
+
+- [ ] **Step 3: Add Cargo dependencies.**
+
+Edit `rust/tmux_helper/Cargo.toml` — append to the `[dependencies]` block:
+
+```toml
+tokio = { version = "1", features = ["rt", "process", "time", "sync", "macros"] }
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+unicode-width = "0.2"
+base64 = "0.22"
+dirs = "5"
+```
+
+Note: `rt` (not `rt-multi-thread`) per spec line 733. A single-thread runtime is sufficient for `gh` fan-out.
+
+- [ ] **Step 4: Run the smoke test and verify the crate still compiles.**
+
+```bash
+cd rust/tmux_helper
+cargo build 2>&1 | /usr/bin/tail -20
+cargo test -p rmux_helper link_picker:: 2>&1 | /usr/bin/tail -10
+```
+
+Expected: build succeeds with the new deps; `cargo test` passes 1 test (the placeholder). If you see `unresolved module` errors, check that the `link_picker/` directory has `mod.rs`, `detect.rs`, `enrich.rs`, and `tui.rs` files.
+
+- [ ] **Step 5: Verify `--json` end-to-end from the terminal.**
+
+```bash
+cargo install --path . --force 2>&1 | /usr/bin/tail -5
+rmux_helper pick-links --json
+```
+
+Expected output: `[]` on one line. If `rmux_helper: command not found`, check `~/.cargo/bin` is on `$PATH`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add rust/tmux_helper/Cargo.toml \
+        rust/tmux_helper/src/main.rs \
+        rust/tmux_helper/src/link_picker/
+git commit -m "feat(link-picker): scaffold pick-links subcommand and module tree"
+```
+
+---
+
+## Task 2 — Detection data model
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+This task defines the types every downstream task consumes. No parsing yet — just shapes and invariants.
+
+- [ ] **Step 1: Write the failing unit tests for the data model.**
+
+Add to `detect.rs`:
+
+```rust
+use serde::Serialize;
+use std::fmt;
+
+/// Categories in fixed display order. Numeric value doubles as the
+/// display position (1-indexed in the spec) and the 1-9 drill-down key.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Category {
+    PullRequest = 1,
+    Issue = 2,
+    Commit = 3,
+    File = 4,
+    Repo = 5,
+    Blog = 6,
+    OtherLink = 7,
+    Server = 8,
+    Ip = 9,
+}
+
+impl Category {
+    /// Short-name filter tag (see spec "Filtering semantics").
+    pub fn tag(self) -> &'static str {
+        match self {
+            Category::PullRequest => "pr",
+            Category::Issue => "issue",
+            Category::Commit => "commit",
+            Category::File => "file",
+            Category::Repo => "repo",
+            Category::Blog => "blog",
+            Category::OtherLink => "link",
+            Category::Server => "server",
+            Category::Ip => "ip",
+        }
+    }
+
+    pub fn display(self) -> &'static str {
+        match self {
+            Category::PullRequest => "Pull Requests",
+            Category::Issue => "Issues",
+            Category::Commit => "Commits",
+            Category::File => "Files",
+            Category::Repo => "Repos",
+            Category::Blog => "Blog",
+            Category::OtherLink => "Other links",
+            Category::Server => "Servers",
+            Category::Ip => "IPs",
+        }
+    }
+
+    pub fn all() -> &'static [Category] {
+        &[
+            Category::PullRequest,
+            Category::Issue,
+            Category::Commit,
+            Category::File,
+            Category::Repo,
+            Category::Blog,
+            Category::OtherLink,
+            Category::Server,
+            Category::Ip,
+        ]
+    }
+}
+
+/// One detected item, pre-dedup. `canonical` is the dedup key within a category.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct Item {
+    pub category: Category,
+    pub canonical: String,     // canonical URL, hostname, or IP
+    pub key: String,           // key column: "#68", "a22bc17", "picker.rs:L42", "c-5001"
+    pub repo_or_host: String,  // repo-or-host column: "settings", "idvorkin.github.io", "—"
+    /// Line index in the captured scrollback where this occurrence was found.
+    pub line_index: usize,
+}
+
+/// A finished row the TUI renders. One per unique (category, canonical).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct Row {
+    pub category: Category,
+    pub canonical: String,
+    pub key: String,
+    pub repo_or_host: String,
+    pub context: String,      // from scrollback line at most_recent_line
+    pub enriched: Option<EnrichedTitle>, // None in v1 detection output; filled by enrich.rs
+    pub count: usize,
+    pub most_recent_line: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct EnrichedTitle {
+    pub title: String,
+    pub state: GhState,
+    pub author: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GhState {
+    Open,
+    MergedPr,
+    Closed,
+    Draft,
+    Commit, // not a PR state; used for the ⎇ glyph
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_all_is_in_display_order() {
+        let nums: Vec<u8> = Category::all().iter().map(|c| *c as u8).collect();
+        assert_eq!(nums, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn category_tags_are_unique_and_lowercase() {
+        let mut seen = std::collections::HashSet::new();
+        for c in Category::all() {
+            let tag = c.tag();
+            assert_eq!(tag, tag.to_lowercase());
+            assert!(seen.insert(tag), "duplicate tag: {}", tag);
+        }
+    }
+
+    #[test]
+    fn row_is_serializable_to_json() {
+        let row = Row {
+            category: Category::PullRequest,
+            canonical: "https://github.com/a/b/pull/1".into(),
+            key: "#1".into(),
+            repo_or_host: "b".into(),
+            context: "Merge pull request #1".into(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 42,
+        };
+        let json = serde_json::to_string(&row).unwrap();
+        assert!(json.contains("\"category\":\"pull_request\""));
+        assert!(json.contains("\"canonical\":\"https://github.com/a/b/pull/1\""));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail.**
+
+```bash
+cd rust/tmux_helper
+cargo test -p rmux_helper link_picker::detect 2>&1 | /usr/bin/tail -30
+```
+
+Expected: 3 tests defined, all compile (the types were defined in Step 1 so they all pass). If a test fails to compile, the type shape is wrong.
+
+- [ ] **Step 3: If Step 2 shows all tests passing, skip to Step 4. (The types and tests were written in one shot, so this is structurally a "green-first" task.)**
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): add Category/Item/Row data model"
+```
+
+---
+
+## Task 3 — URL regex + trailing punctuation stripping
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+Spec reference: URL regex at spec line ~278 (`https?://[^\s<>"'`()\[\]{}]+`), trailing punctuation rules below it.
+
+- [ ] **Step 1: Write failing unit tests.**
+
+Append to `detect.rs`:
+
+```rust
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Base URL regex — matches scheme + greedy body up to whitespace or URL-unsafe chars.
+/// Trailing punctuation is stripped separately (see `strip_trailing_punct`).
+pub(crate) fn url_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"https?://[^\s<>"'`()\[\]{}]+"#).unwrap()
+    })
+}
+
+/// Strip trailing `.,;:!?)]}>'"` from a matched URL. Preserves trailing `/`.
+pub(crate) fn strip_trailing_punct(s: &str) -> &str {
+    let trimmed = s.trim_end_matches(|c: char| ".,;:!?)]}>'\"".contains(c));
+    trimmed
+}
+
+#[cfg(test)]
+mod url_tests {
+    use super::*;
+
+    fn extract_url(line: &str) -> &str {
+        let m = url_regex().find(line).expect("no URL in line");
+        strip_trailing_punct(m.as_str())
+    }
+
+    #[test]
+    fn extracts_bare_url() {
+        assert_eq!(
+            extract_url("see https://github.com/a/b/pull/1 next"),
+            "https://github.com/a/b/pull/1"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_period() {
+        assert_eq!(
+            extract_url("see https://github.com/a/b/pull/1."),
+            "https://github.com/a/b/pull/1"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_paren_and_quote() {
+        assert_eq!(
+            extract_url("(see https://github.com/a/b/pull/1)"),
+            "https://github.com/a/b/pull/1"
+        );
+        assert_eq!(
+            extract_url("\"https://github.com/a/b/pull/1\""),
+            "https://github.com/a/b/pull/1"
+        );
+    }
+
+    #[test]
+    fn preserves_trailing_slash() {
+        assert_eq!(
+            extract_url("https://idvorkin.github.io/posts/ai-agents/"),
+            "https://idvorkin.github.io/posts/ai-agents/"
+        );
+    }
+
+    #[test]
+    fn handles_query_and_fragment() {
+        assert_eq!(
+            extract_url("https://github.com/a/b/pull/1#discussion_r123"),
+            "https://github.com/a/b/pull/1#discussion_r123"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they pass.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::url_tests 2>&1 | /usr/bin/tail -20
+```
+
+Expected: 5 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): add URL regex and trailing punctuation strip"
+```
+
+---
+
+## Task 4 — GitHub URL categorization and canonicalization
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+Covers Pull Requests, Issues, Commits, Files, Repos. Spec reference lines 195–211 + canonicalization rules ~290-304.
+
+- [ ] **Step 1: Write failing tests for each GitHub category.**
+
+Append to `detect.rs`:
+
+```rust
+/// Classify a URL string into a GitHub Category + build an Item, or None.
+pub(crate) fn classify_github(url: &str, line_index: usize) -> Option<Item> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // Owner & repo: no slashes, alphanum + .-_
+        Regex::new(
+            r"^https?://(?:www\.)?github\.com/([\w.\-]+)/([\w.\-]+)(?:/(pull|issues|commit|blob|tree)/([^#?\s]+))?(#\S*)?$"
+        ).unwrap()
+    });
+
+    let caps = re.captures(url.trim_end_matches('/'))?;
+    let owner = caps.get(1)?.as_str();
+    let repo = caps.get(2)?.as_str();
+    let kind = caps.get(3).map(|m| m.as_str());
+    let tail = caps.get(4).map(|m| m.as_str());
+    let fragment = caps.get(5).map(|m| m.as_str()).unwrap_or("");
+
+    let owner_repo = format!("{owner}/{repo}");
+    let canonical_base = format!("https://github.com/{owner_repo}");
+
+    match kind {
+        None => Some(Item {
+            category: Category::Repo,
+            canonical: canonical_base,
+            key: owner.to_string(),
+            repo_or_host: repo.to_string(),
+            line_index,
+        }),
+        Some("pull") => {
+            let num = tail?.split('/').next()?;
+            // Strip non-#LN fragments from PR URLs (canonical form drops them).
+            Some(Item {
+                category: Category::PullRequest,
+                canonical: format!("{canonical_base}/pull/{num}"),
+                key: format!("#{num}"),
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        Some("issues") => {
+            let num = tail?.split('/').next()?;
+            Some(Item {
+                category: Category::Issue,
+                canonical: format!("{canonical_base}/issues/{num}"),
+                key: format!("#{num}"),
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        Some("commit") => {
+            let sha = tail?;
+            if sha.len() < 7 || !sha.chars().all(|c| c.is_ascii_hexdigit()) {
+                return None;
+            }
+            let short = &sha[..7.min(sha.len())];
+            Some(Item {
+                category: Category::Commit,
+                canonical: format!("{canonical_base}/commit/{sha}"),
+                key: short.to_string(),
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        Some("blob") | Some("tree") => {
+            let tail = tail?; // "ref/path/to/file.rs"
+            let basename = tail.rsplit('/').next().unwrap_or(tail);
+            // Line anchor: #L42 or #L42-L60 preserves only Lstart in key.
+            let key = if let Some(l) = fragment.strip_prefix("#L") {
+                let lstart = l.split('-').next().unwrap_or(l);
+                format!("{basename}:L{lstart}")
+            } else {
+                basename.to_string()
+            };
+            Some(Item {
+                category: Category::File,
+                canonical: format!("{canonical_base}/{}/{tail}{}", kind.unwrap(), if fragment.starts_with("#L") { fragment } else { "" }),
+                key,
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod github_tests {
+    use super::*;
+
+    #[test]
+    fn classifies_pull_request() {
+        let item = classify_github("https://github.com/idvorkin-ai-tools/settings/pull/68", 0).unwrap();
+        assert_eq!(item.category, Category::PullRequest);
+        assert_eq!(item.key, "#68");
+        assert_eq!(item.repo_or_host, "settings");
+        assert_eq!(item.canonical, "https://github.com/idvorkin-ai-tools/settings/pull/68");
+    }
+
+    #[test]
+    fn strips_pr_discussion_fragment() {
+        let item = classify_github(
+            "https://github.com/a/b/pull/1#discussion_r123", 0,
+        ).unwrap();
+        assert_eq!(item.canonical, "https://github.com/a/b/pull/1");
+    }
+
+    #[test]
+    fn classifies_issue() {
+        let item = classify_github("https://github.com/a/b/issues/42", 0).unwrap();
+        assert_eq!(item.category, Category::Issue);
+        assert_eq!(item.key, "#42");
+    }
+
+    #[test]
+    fn classifies_commit_with_short_sha() {
+        let item = classify_github("https://github.com/a/b/commit/a22bc17", 0).unwrap();
+        assert_eq!(item.category, Category::Commit);
+        assert_eq!(item.key, "a22bc17");
+    }
+
+    #[test]
+    fn rejects_non_hex_commit() {
+        assert!(classify_github("https://github.com/a/b/commit/NOTHEX", 0).is_none());
+    }
+
+    #[test]
+    fn classifies_file_with_line_anchor() {
+        let item = classify_github(
+            "https://github.com/a/b/blob/main/src/picker.rs#L42", 0,
+        ).unwrap();
+        assert_eq!(item.category, Category::File);
+        assert_eq!(item.key, "picker.rs:L42");
+    }
+
+    #[test]
+    fn classifies_file_line_range_uses_start() {
+        let item = classify_github(
+            "https://github.com/a/b/blob/main/src/picker.rs#L42-L60", 0,
+        ).unwrap();
+        assert_eq!(item.key, "picker.rs:L42");
+    }
+
+    #[test]
+    fn classifies_bare_repo() {
+        let item = classify_github("https://github.com/idvorkin-ai-tools/settings", 0).unwrap();
+        assert_eq!(item.category, Category::Repo);
+        assert_eq!(item.key, "idvorkin-ai-tools");
+        assert_eq!(item.repo_or_host, "settings");
+    }
+
+    #[test]
+    fn collapses_www_github_com() {
+        let item = classify_github("https://www.github.com/a/b/pull/1", 0).unwrap();
+        assert_eq!(item.canonical, "https://github.com/a/b/pull/1");
+    }
+
+    #[test]
+    fn rejects_non_github_host() {
+        assert!(classify_github("https://gitlab.com/a/b", 0).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run and iterate until green.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::github_tests 2>&1 | /usr/bin/tail -40
+```
+
+Expected: 10 passes. If any fail, adjust the regex or match arms — don't skip the test.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): classify GitHub PRs, issues, commits, files, repos"
+```
+
+---
+
+## Task 5 — Blog, Other links, and URL fallthrough
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+- [ ] **Step 1: Write tests.**
+
+Append:
+
+```rust
+/// Blog host allowlist. v1 is a compile-time constant; v2 will be configurable.
+pub(crate) const BLOG_HOSTS: &[&str] = &["idvorkin.github.io"];
+
+/// Classify a non-GitHub URL into Blog or OtherLink.
+pub(crate) fn classify_other_url(url: &str, line_index: usize) -> Option<Item> {
+    let host_end = url.find("://")? + 3;
+    let rest = &url[host_end..];
+    let slash_at = rest.find('/').unwrap_or(rest.len());
+    let host = &rest[..slash_at];
+    let path = &rest[slash_at..];
+
+    let category = if BLOG_HOSTS.iter().any(|b| host.eq_ignore_ascii_case(b)) {
+        Category::Blog
+    } else {
+        Category::OtherLink
+    };
+
+    // Key = last non-empty path segment, or host if path is empty
+    let last_seg = path
+        .trim_end_matches('/')
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or(host)
+        .to_string();
+
+    Some(Item {
+        category,
+        canonical: url.to_string(),
+        key: last_seg,
+        repo_or_host: host.to_string(),
+        line_index,
+    })
+}
+
+#[cfg(test)]
+mod other_url_tests {
+    use super::*;
+
+    #[test]
+    fn blog_host_is_categorized_as_blog() {
+        let item = classify_other_url("https://idvorkin.github.io/posts/ai-agents/", 0).unwrap();
+        assert_eq!(item.category, Category::Blog);
+        assert_eq!(item.repo_or_host, "idvorkin.github.io");
+        assert_eq!(item.key, "ai-agents");
+    }
+
+    #[test]
+    fn non_blog_host_is_other_link() {
+        let item = classify_other_url("https://stackoverflow.com/q/12345", 0).unwrap();
+        assert_eq!(item.category, Category::OtherLink);
+        assert_eq!(item.repo_or_host, "stackoverflow.com");
+    }
+
+    #[test]
+    fn bare_host_uses_host_as_key() {
+        let item = classify_other_url("https://example.com", 0).unwrap();
+        assert_eq!(item.key, "example.com");
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::other_url_tests 2>&1 | /usr/bin/tail -20
+```
+
+Expected: 3 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): classify blog and other URLs with host allowlist"
+```
+
+---
+
+## Task 6 — Server detection (ssh context + Tailscale)
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+Spec reference: lines ~318-345 for the two regexes + dedup rule.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append:
+
+```rust
+pub(crate) fn find_servers(line: &str, line_index: usize) -> Vec<Item> {
+    static SSH_RE: OnceLock<Regex> = OnceLock::new();
+    static TS_HOST_RE: OnceLock<Regex> = OnceLock::new();
+    static TS_NET_RE: OnceLock<Regex> = OnceLock::new();
+    let ssh = SSH_RE.get_or_init(|| {
+        // `ssh` token, optional flags, optional user@, then host
+        Regex::new(
+            r"\bssh\b(?:\s+-\S+)*\s+(?:[a-zA-Z_][\w-]*@)?([a-zA-Z0-9][\w.\-]*[a-zA-Z0-9])\b",
+        )
+        .unwrap()
+    });
+    let ts_host = TS_HOST_RE.get_or_init(|| Regex::new(r"\bc-\d{4,5}\b").unwrap());
+    let ts_net = TS_NET_RE.get_or_init(|| Regex::new(r"\b[a-z][a-z0-9-]*\.ts\.net\b").unwrap());
+
+    let mut out = Vec::new();
+    for cap in ssh.captures_iter(line) {
+        if let Some(h) = cap.get(1) {
+            out.push(mk_server(h.as_str(), line_index));
+        }
+    }
+    for m in ts_host.find_iter(line) {
+        out.push(mk_server(m.as_str(), line_index));
+    }
+    for m in ts_net.find_iter(line) {
+        out.push(mk_server(m.as_str(), line_index));
+    }
+    out
+}
+
+fn mk_server(host: &str, line_index: usize) -> Item {
+    Item {
+        category: Category::Server,
+        canonical: host.to_string(),
+        key: host.to_string(),
+        repo_or_host: "—".to_string(),
+        line_index,
+    }
+}
+
+#[cfg(test)]
+mod server_tests {
+    use super::*;
+
+    #[test]
+    fn extracts_ssh_bare_host() {
+        let items = find_servers("ssh c-5001 \"uname -a\"", 0);
+        assert_eq!(items.len(), 2, "ssh + tailscale regex both match c-5001");
+        assert!(items.iter().any(|i| i.canonical == "c-5001"));
+    }
+
+    #[test]
+    fn extracts_ssh_user_at_host_stripping_user() {
+        let items = find_servers("ssh igor@dev.example.com", 0);
+        assert_eq!(items[0].canonical, "dev.example.com");
+    }
+
+    #[test]
+    fn extracts_ssh_with_options() {
+        let items = find_servers("ssh -i ~/.ssh/id_ed25519 -p 2222 build.host", 0);
+        assert!(items.iter().any(|i| i.canonical == "build.host"));
+    }
+
+    #[test]
+    fn extracts_tailscale_c_pattern() {
+        let items = find_servers("Tailscale peer c-5001 is up", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].canonical, "c-5001");
+    }
+
+    #[test]
+    fn rejects_c_numbers_outside_range() {
+        let items = find_servers("c-2 c-123456", 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn extracts_ts_net_hostname() {
+        let items = find_servers("ping mydev.ts.net", 0);
+        assert!(items.iter().any(|i| i.canonical == "mydev.ts.net"));
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::server_tests 2>&1 | /usr/bin/tail -30
+```
+
+Expected: 6 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): detect ssh hosts and Tailscale names"
+```
+
+---
+
+## Task 7 — IPv4 detection with version-string suppression
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+Spec reference lines ~348-364.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append:
+
+```rust
+pub(crate) fn find_ips(line: &str, line_index: usize) -> Vec<Item> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Dotted-quad with bounded octets, no look-around (Rust regex limitation).
+    // We do boundary + version-prefix checks in code.
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?:\d{1,3}\.){3}\d{1,3}").unwrap()
+    });
+
+    let bytes = line.as_bytes();
+    let mut out = Vec::new();
+    for m in re.find_iter(line) {
+        let start = m.start();
+        let end = m.end();
+
+        // Reject: preceded by `v` or `V` (version string)
+        if start > 0 && matches!(bytes[start - 1], b'v' | b'V') {
+            continue;
+        }
+        // Reject: preceded by word-char or `.`
+        if start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'.') {
+            continue;
+        }
+        // Reject: followed by `.<digit>` (longer sequence)
+        if end < bytes.len() && bytes[end] == b'.' {
+            if end + 1 < bytes.len() && bytes[end + 1].is_ascii_digit() {
+                continue;
+            }
+        }
+        // Reject: followed by word-char
+        if end < bytes.len() && bytes[end].is_ascii_alphanumeric() {
+            continue;
+        }
+        // Validate octets
+        let text = m.as_str();
+        let octets: Vec<u16> = text.split('.').map(|s| s.parse().unwrap_or(u16::MAX)).collect();
+        if octets.iter().any(|o| *o > 255) {
+            continue;
+        }
+        out.push(Item {
+            category: Category::Ip,
+            canonical: text.to_string(),
+            key: text.to_string(),
+            repo_or_host: "—".to_string(),
+            line_index,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod ip_tests {
+    use super::*;
+
+    #[test]
+    fn extracts_simple_ipv4() {
+        let items = find_ips("Tailscale peer 100.64.1.5 is online", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].canonical, "100.64.1.5");
+    }
+
+    #[test]
+    fn suppresses_version_prefixed() {
+        let items = find_ips("claude-opus v4.6.0.1 released", 0);
+        assert!(items.is_empty(), "v-prefixed not an IP");
+    }
+
+    #[test]
+    fn suppresses_longer_dotted_sequence() {
+        let items = find_ips("value = 1.2.3.4.5 not an IP", 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn rejects_octet_over_255() {
+        let items = find_ips("nope 300.1.1.1", 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn keeps_edge_addresses() {
+        let items = find_ips("range 0.0.0.0 to 255.255.255.255", 0);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn does_not_filter_private_ranges() {
+        let items = find_ips("local 192.168.1.1", 0);
+        assert_eq!(items.len(), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::ip_tests 2>&1 | /usr/bin/tail -30
+```
+
+Expected: 6 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): detect IPv4 with version-string suppression"
+```
+
+---
+
+## Task 8 — Line scanner assembly (GitHub + Blog/Other + Server + IP)
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+Per spec line 727 this should use `regex::RegexSet` for performance on megabyte scrollbacks. For v1 we can use a simpler single-pass over matches from `url_regex().find_iter(line)` followed by the server/IP passes — the per-line cost is dominated by the URL regex walk anyway and RegexSet is an optimization we can add if profiling shows it's needed. Spec line 727 is aspirational; we'll comment accordingly.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append:
+
+```rust
+/// Scan one scrollback line and return all detected items in that line.
+/// A single line can contribute to multiple categories.
+pub(crate) fn scan_line(line: &str, line_index: usize) -> Vec<Item> {
+    let mut out = Vec::new();
+
+    // URLs (cascade through GitHub → Blog/Other).
+    for m in url_regex().find_iter(line) {
+        let raw = strip_trailing_punct(m.as_str());
+        if let Some(item) = classify_github(raw, line_index) {
+            out.push(item);
+        } else if let Some(item) = classify_other_url(raw, line_index) {
+            out.push(item);
+        }
+    }
+
+    // Servers (ssh + Tailscale; two Tailscale regexes may double-match).
+    out.extend(find_servers(line, line_index));
+    // IPs
+    out.extend(find_ips(line, line_index));
+
+    out
+}
+
+#[cfg(test)]
+mod scan_line_tests {
+    use super::*;
+
+    #[test]
+    fn scans_pr_url_in_context() {
+        let items = scan_line("Merge pull request #68 https://github.com/a/b/pull/68 ok", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].category, Category::PullRequest);
+    }
+
+    #[test]
+    fn mixes_url_and_ip_on_same_line() {
+        let items = scan_line("curl https://example.com from 10.0.0.1", 0);
+        assert!(items.iter().any(|i| i.category == Category::OtherLink));
+        assert!(items.iter().any(|i| i.category == Category::Ip));
+    }
+
+    #[test]
+    fn no_cross_category_for_pr_url() {
+        // A PR URL must NOT also appear under OtherLink.
+        let items = scan_line("https://github.com/a/b/pull/1", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].category, Category::PullRequest);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::scan_line_tests 2>&1 | /usr/bin/tail -20
+```
+
+Expected: 3 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): scan one scrollback line across all categories"
+```
+
+---
+
+## Task 9 — Dedup, recency ordering, context extraction, `parse`
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/detect.rs`
+
+This finishes detect.rs with the top-level `parse(raw: &str) -> Vec<Row>` the orchestrator calls.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append:
+
+```rust
+use std::collections::HashMap;
+use unicode_width::UnicodeWidthStr;
+
+/// Strip an anchor substring from a line, collapse whitespace, trim, truncate to max display width.
+pub(crate) fn make_context(line: &str, anchor: &str, max_width: usize) -> String {
+    // Remove the anchor substring; collapse runs of whitespace to single space.
+    let removed = line.replacen(anchor, "", 1);
+    let collapsed: String = removed.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_to_width(&collapsed, max_width)
+}
+
+pub(crate) fn truncate_to_width(s: &str, max: usize) -> String {
+    let w = UnicodeWidthStr::width(s);
+    if w <= max {
+        return s.to_string();
+    }
+    // Walk characters, accumulating width, until we reach max-1 (room for `…`).
+    let budget = max.saturating_sub(1);
+    let mut acc = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let cw = UnicodeWidthStr::width(ch.to_string().as_str());
+        if used + cw > budget {
+            break;
+        }
+        acc.push(ch);
+        used += cw;
+    }
+    acc.push('…');
+    acc
+}
+
+/// Top-level detection: parse the whole scrollback and return deduped,
+/// recency-ordered rows.
+pub fn parse(raw: &str) -> Vec<Row> {
+    // Collect items + keep a reference to the line for context extraction.
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut items_by_key: HashMap<(Category, String), Vec<Item>> = HashMap::new();
+    for (idx, line) in lines.iter().enumerate() {
+        for item in scan_line(line, idx) {
+            items_by_key
+                .entry((item.category, item.canonical.clone()))
+                .or_default()
+                .push(item);
+        }
+    }
+
+    // Build rows: most_recent_line = max line_index in the group.
+    let mut rows: Vec<Row> = items_by_key
+        .into_iter()
+        .map(|((category, canonical), group)| {
+            let count = group.len();
+            let most_recent = group.iter().map(|i| i.line_index).max().unwrap_or(0);
+            let exemplar = group.iter().find(|i| i.line_index == most_recent).unwrap();
+            let context = make_context(lines[most_recent], &canonical, 60);
+            Row {
+                category,
+                canonical,
+                key: exemplar.key.clone(),
+                repo_or_host: exemplar.repo_or_host.clone(),
+                context,
+                enriched: None,
+                count,
+                most_recent_line: most_recent,
+            }
+        })
+        .collect();
+
+    // Sort: category ASC (display order), then most_recent_line DESC,
+    // ties broken by canonical ASC for determinism.
+    rows.sort_by(|a, b| {
+        (a.category as u8, std::cmp::Reverse(a.most_recent_line), &a.canonical)
+            .cmp(&(b.category as u8, std::cmp::Reverse(b.most_recent_line), &b.canonical))
+    });
+
+    rows
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn dedups_same_server_across_sources() {
+        let raw = "ssh c-5001 \"pwd\"\nssh igor@c-5001 \"ls\"\npeer c-5001 up\n";
+        let rows = parse(raw);
+        let servers: Vec<&Row> = rows.iter().filter(|r| r.category == Category::Server).collect();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].canonical, "c-5001");
+        assert!(servers[0].count >= 3);
+    }
+
+    #[test]
+    fn orders_by_recency_within_category() {
+        let raw = "https://github.com/a/b/pull/1\nhttps://github.com/a/b/pull/2\n";
+        let rows = parse(raw);
+        let prs: Vec<&Row> = rows.iter().filter(|r| r.category == Category::PullRequest).collect();
+        assert_eq!(prs.len(), 2);
+        // Most recent (pull/2, line 1) comes first
+        assert_eq!(prs[0].key, "#2");
+        assert_eq!(prs[1].key, "#1");
+    }
+
+    #[test]
+    fn pr_url_does_not_leak_to_other_links() {
+        let raw = "see https://github.com/a/b/pull/1 now\n";
+        let rows = parse(raw);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].category, Category::PullRequest);
+    }
+
+    #[test]
+    fn context_strips_url_and_collapses_whitespace() {
+        let raw = "Merge pull request   #68   https://github.com/a/b/pull/68   idvorkin\n";
+        let rows = parse(raw);
+        let pr = rows.iter().find(|r| r.category == Category::PullRequest).unwrap();
+        assert!(!pr.context.contains("https://"));
+        assert!(!pr.context.contains("   ")); // no runs of whitespace
+        assert!(pr.context.contains("Merge pull request"));
+    }
+
+    #[test]
+    fn context_truncates_with_ellipsis() {
+        let long = "a".repeat(200);
+        let raw = format!("{long} https://example.com rest\n");
+        let rows = parse(&raw);
+        let row = rows.iter().find(|r| r.category == Category::OtherLink).unwrap();
+        assert!(row.context.ends_with('…'));
+        assert!(UnicodeWidthStr::width(row.context.as_str()) <= 60);
+    }
+
+    #[test]
+    fn parse_is_idempotent() {
+        let raw = "ssh c-5001\nhttps://github.com/a/b/pull/1\n";
+        let a = parse(raw);
+        let b = parse(raw);
+        assert_eq!(a, b);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests.**
+
+```bash
+cargo test -p rmux_helper link_picker::detect::parse_tests 2>&1 | /usr/bin/tail -40
+```
+
+Expected: 6 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/detect.rs
+git commit -m "feat(link-picker): dedup, recency order, context column, top-level parse"
+```
+
+---
+
+## Task 10 — gh-links cache: load, atomic write, TTL
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/enrich.rs`
+
+Spec reference: Cache format lines ~395-410, concurrent-writers contract ~416-420.
+
+- [ ] **Step 1: Write tests and implementation.**
+
+Replace `enrich.rs` with:
+
+```rust
+//! Parallel `gh` enrichment with a shared deadline and on-disk cache.
+
+use crate::link_picker::detect::{EnrichedTitle, GhState};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CACHE_VERSION: u32 = 1;
+const TTL_SECONDS: u64 = 3600; // 1 hour
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CacheFile {
+    pub version: u32,
+    pub entries: HashMap<String, CacheEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CacheEntry {
+    pub fetched_at: u64, // unix seconds
+    pub title: String,
+    pub state: GhState,
+    pub author: Option<String>,
+}
+
+impl CacheFile {
+    pub fn empty() -> Self {
+        Self { version: CACHE_VERSION, entries: HashMap::new() }
+    }
+
+    pub fn path() -> Option<PathBuf> {
+        let base = dirs::cache_dir()?;
+        Some(base.join("rmux_helper").join("gh-links.json"))
+    }
+
+    /// Load from disk. Returns `CacheFile::empty()` on any failure (missing, corrupt, wrong version).
+    pub fn load_or_reset() -> Self {
+        let Some(path) = Self::path() else { return Self::empty() };
+        let Ok(bytes) = std::fs::read(&path) else { return Self::empty() };
+        let parsed: Result<CacheFile, _> = serde_json::from_slice(&bytes);
+        match parsed {
+            Ok(cf) if cf.version == CACHE_VERSION => cf,
+            _ => {
+                // Delete corrupt or wrong-version file silently.
+                let _ = std::fs::remove_file(&path);
+                Self::empty()
+            }
+        }
+    }
+
+    /// Atomic write via temp-file + rename.
+    pub fn save(&self) -> Result<()> {
+        let Some(path) = Self::path() else { return Ok(()) };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).context("create cache dir")?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        let json = serde_json::to_vec_pretty(self)?;
+        std::fs::write(&tmp, json).context("write cache tmp")?;
+        std::fs::rename(&tmp, &path).context("rename cache tmp")?;
+        Ok(())
+    }
+
+    /// Look up a cache hit for `canonical_url`. Returns `None` if missing or past TTL.
+    pub fn lookup(&self, canonical_url: &str) -> Option<EnrichedTitle> {
+        let entry = self.entries.get(canonical_url)?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        if now.saturating_sub(entry.fetched_at) > TTL_SECONDS {
+            return None;
+        }
+        Some(EnrichedTitle {
+            title: entry.title.clone(),
+            state: entry.state,
+            author: entry.author.clone(),
+        })
+    }
+
+    pub fn insert(&mut self, canonical_url: String, enrichment: &EnrichedTitle) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        self.entries.insert(
+            canonical_url,
+            CacheEntry {
+                fetched_at: now,
+                title: enrichment.title.clone(),
+                state: enrichment.state,
+                author: enrichment.author.clone(),
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty_cache() {
+        let cf = CacheFile::empty();
+        let json = serde_json::to_string(&cf).unwrap();
+        let back: CacheFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.version, CACHE_VERSION);
+        assert!(back.entries.is_empty());
+    }
+
+    #[test]
+    fn lookup_respects_ttl() {
+        let mut cf = CacheFile::empty();
+        let url = "https://github.com/a/b/pull/1".to_string();
+        let enrichment = EnrichedTitle {
+            title: "test".into(),
+            state: GhState::Open,
+            author: Some("alice".into()),
+        };
+        cf.insert(url.clone(), &enrichment);
+        assert!(cf.lookup(&url).is_some());
+
+        // Force-expire by mutating fetched_at
+        cf.entries.get_mut(&url).unwrap().fetched_at = 0;
+        assert!(cf.lookup(&url).is_none());
+    }
+
+    #[test]
+    fn version_mismatch_resets() {
+        // Write a v999 cache to the real cache path is destructive; instead, test serde path
+        let bad = r#"{"version":999,"entries":{}}"#;
+        let parsed: Result<CacheFile, _> = serde_json::from_str(bad);
+        assert!(parsed.is_ok());
+        assert_ne!(parsed.unwrap().version, CACHE_VERSION);
+        // The `load_or_reset` path tests this against a real file; see integration tests in Task 13.
+    }
+}
+```
+
+- [ ] **Step 2: Run tests.**
+
+```bash
+cargo test -p rmux_helper link_picker::enrich::cache_tests 2>&1 | /usr/bin/tail -20
+```
+
+Expected: 3 passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/enrich.rs
+git commit -m "feat(link-picker): gh-links cache with TTL and atomic write"
+```
+
+---
+
+## Task 11 — `gh` call wrappers for PR / Issue / Commit
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/enrich.rs`
+
+Parses the `gh --json` output into `EnrichedTitle`. Handles missing `gh`, non-zero exit, malformed JSON — all as row-level `Ok(None)` fallbacks.
+
+- [ ] **Step 1: Write tests (stub binary) and implementation.**
+
+Append to `enrich.rs`:
+
+```rust
+use serde::Deserialize;
+use tokio::process::Command;
+
+#[derive(Debug, Deserialize)]
+struct GhPrJson {
+    title: String,
+    state: String,
+    #[serde(default)]
+    author: Option<GhUser>,
+    #[serde(rename = "isDraft", default)]
+    is_draft: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhIssueJson {
+    title: String,
+    state: String,
+    #[serde(default)]
+    author: Option<GhUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhUser {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCommitJson {
+    title: String,
+    #[serde(default)]
+    author: Option<String>,
+}
+
+/// Parse a GitHub canonical URL of the form `https://github.com/OWNER/REPO/(pull|issues|commit)/ID`.
+pub(crate) fn parse_gh_target(url: &str) -> Option<(String, String, GhKind, String)> {
+    let rest = url.strip_prefix("https://github.com/")?;
+    let mut parts = rest.splitn(4, '/');
+    let owner = parts.next()?.to_string();
+    let repo = parts.next()?.to_string();
+    let kind_str = parts.next()?;
+    let id = parts.next()?.to_string();
+    let kind = match kind_str {
+        "pull" => GhKind::Pr,
+        "issues" => GhKind::Issue,
+        "commit" => GhKind::Commit,
+        _ => return None,
+    };
+    Some((owner, repo, kind, id))
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum GhKind { Pr, Issue, Commit }
+
+/// Call `gh` for one canonical URL. Returns `Ok(None)` on any recoverable failure.
+/// Only unrecoverable (panics, tokio plumbing) would be returned as `Err`.
+pub(crate) async fn call_gh(canonical_url: &str) -> Result<Option<EnrichedTitle>> {
+    let Some((owner, repo, kind, id)) = parse_gh_target(canonical_url) else {
+        return Ok(None);
+    };
+    let owner_repo = format!("{owner}/{repo}");
+
+    let output = match kind {
+        GhKind::Pr => Command::new("gh")
+            .args(["pr", "view", &id, "-R", &owner_repo, "--json", "title,state,author,isDraft"])
+            .output()
+            .await,
+        GhKind::Issue => Command::new("gh")
+            .args(["issue", "view", &id, "-R", &owner_repo, "--json", "title,state,author"])
+            .output()
+            .await,
+        GhKind::Commit => Command::new("gh")
+            .args([
+                "api",
+                &format!("repos/{owner_repo}/commits/{id}"),
+                "--jq",
+                "{title: (.commit.message | split(\"\\n\")[0]), author: .commit.author.name}",
+            ])
+            .output()
+            .await,
+    };
+
+    let output = match output {
+        Ok(o) => o,
+        Err(_) => return Ok(None), // gh not on PATH
+    };
+    if !output.status.success() {
+        return Ok(None); // 404, auth failure, etc.
+    }
+
+    match kind {
+        GhKind::Pr => {
+            let Ok(p) = serde_json::from_slice::<GhPrJson>(&output.stdout) else {
+                return Ok(None);
+            };
+            let state = if p.is_draft {
+                GhState::Draft
+            } else {
+                match p.state.as_str() {
+                    "OPEN" => GhState::Open,
+                    "MERGED" => GhState::MergedPr,
+                    "CLOSED" => GhState::Closed,
+                    _ => GhState::Open,
+                }
+            };
+            Ok(Some(EnrichedTitle {
+                title: p.title,
+                state,
+                author: p.author.map(|u| u.login),
+            }))
+        }
+        GhKind::Issue => {
+            let Ok(i) = serde_json::from_slice::<GhIssueJson>(&output.stdout) else {
+                return Ok(None);
+            };
+            let state = match i.state.as_str() {
+                "OPEN" => GhState::Open,
+                "CLOSED" => GhState::Closed,
+                _ => GhState::Open,
+            };
+            Ok(Some(EnrichedTitle {
+                title: i.title,
+                state,
+                author: i.author.map(|u| u.login),
+            }))
+        }
+        GhKind::Commit => {
+            let Ok(c) = serde_json::from_slice::<GhCommitJson>(&output.stdout) else {
+                return Ok(None);
+            };
+            Ok(Some(EnrichedTitle {
+                title: c.title,
+                state: GhState::Commit,
+                author: c.author,
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod gh_call_tests {
+    use super::*;
+
+    #[test]
+    fn parse_gh_target_pr() {
+        let (o, r, k, id) = parse_gh_target("https://github.com/a/b/pull/42").unwrap();
+        assert_eq!((o.as_str(), r.as_str(), id.as_str()), ("a", "b", "42"));
+        assert!(matches!(k, GhKind::Pr));
+    }
+
+    #[test]
+    fn parse_gh_target_rejects_non_gh_host() {
+        assert!(parse_gh_target("https://gitlab.com/a/b/pull/1").is_none());
+    }
+
+    #[test]
+    fn parse_gh_target_rejects_repo_home() {
+        // Repo home has no kind/id, so enrichment doesn't apply.
+        assert!(parse_gh_target("https://github.com/a/b").is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests.**
+
+```bash
+cargo test -p rmux_helper link_picker::enrich::gh_call_tests 2>&1 | /usr/bin/tail -20
+```
+
+Expected: 3 passes. (Full integration tests against a stub `gh` binary are deferred — the parse helpers are the unit-testable core.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/enrich.rs
+git commit -m "feat(link-picker): call gh for PR/issue/commit enrichment"
+```
+
+---
+
+## Task 12 — Parallel fan-out with semaphore + deadline
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/enrich.rs`
+
+- [ ] **Step 1: Append the fan-out and entry point.**
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+const MAX_CONCURRENT: usize = 8;
+
+/// Enrich rows in place. Synchronous wrapper around the tokio runtime.
+/// Returns the rows with `enriched` filled where possible.
+pub fn enrich_rows(mut rows: Vec<crate::link_picker::detect::Row>, deadline_ms: u64) -> Vec<crate::link_picker::detect::Row> {
+    if deadline_ms == 0 {
+        return rows;
+    }
+
+    // Load cache synchronously (fast, no async needed).
+    let mut cache = CacheFile::load_or_reset();
+
+    // Apply cache hits immediately.
+    let mut needs_fetch: Vec<usize> = Vec::new();
+    for (idx, row) in rows.iter_mut().enumerate() {
+        if parse_gh_target(&row.canonical).is_none() {
+            continue; // Not an enrichable category
+        }
+        if let Some(hit) = cache.lookup(&row.canonical) {
+            row.enriched = Some(hit);
+        } else {
+            needs_fetch.push(idx);
+        }
+    }
+
+    if needs_fetch.is_empty() {
+        return rows;
+    }
+
+    // Build a single-thread tokio runtime and fan out.
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(_) => return rows, // Runtime build failed; degrade silently
+    };
+
+    let deadline = Duration::from_millis(deadline_ms);
+    let fetched: Vec<(usize, Option<EnrichedTitle>)> = rt.block_on(async move {
+        let sem = Arc::new(Semaphore::new(MAX_CONCURRENT));
+        let mut handles = Vec::new();
+        for idx in needs_fetch {
+            let sem = sem.clone();
+            let url = rows[idx].canonical.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = sem.acquire_owned().await.ok()?;
+                call_gh(&url).await.ok().flatten().map(|e| (idx, e))
+            }));
+        }
+        let all = futures_join(handles);
+        match tokio::time::timeout(deadline, all).await {
+            Ok(results) => results,
+            Err(_) => Vec::new(), // global deadline hit → zero results used
+        }
+    });
+
+    // Apply fetched results + update cache.
+    for (idx, enrichment) in &fetched {
+        if let Some(enrichment) = enrichment {
+            cache.insert(rows[*idx].canonical.clone(), enrichment);
+            rows[*idx].enriched = Some(enrichment.clone());
+        }
+    }
+    let _ = cache.save(); // swallow errors silently
+    rows
+}
+
+// We don't want the `futures` crate for one helper. Minimal join_all on JoinHandles:
+async fn futures_join<T>(handles: Vec<tokio::task::JoinHandle<Option<T>>>) -> Vec<T> {
+    let mut out = Vec::new();
+    for h in handles {
+        if let Ok(Some(v)) = h.await {
+            out.push(v);
+        }
+    }
+    out
+}
+```
+
+Wait — the above `futures_join` serializes awaits. That kills parallelism. Replace it with a `FuturesUnordered`-style collect using `tokio::select!` or, simpler, drive all handles concurrently via a loop over `JoinSet`. Use `tokio::task::JoinSet` which is in the `rt` feature.
+
+Replace the fan-out section with:
+
+```rust
+use tokio::task::JoinSet;
+
+    let fetched: Vec<(usize, EnrichedTitle)> = rt.block_on(async move {
+        let sem = Arc::new(Semaphore::new(MAX_CONCURRENT));
+        let mut set: JoinSet<Option<(usize, EnrichedTitle)>> = JoinSet::new();
+        for idx in needs_fetch {
+            let sem = sem.clone();
+            let url = rows[idx].canonical.clone();
+            set.spawn(async move {
+                let _permit = sem.acquire_owned().await.ok()?;
+                call_gh(&url).await.ok().flatten().map(|e| (idx, e))
+            });
+        }
+        let mut out = Vec::new();
+        let drain = async {
+            while let Some(res) = set.join_next().await {
+                if let Ok(Some(pair)) = res {
+                    out.push(pair);
+                }
+            }
+            out
+        };
+        tokio::time::timeout(deadline, drain).await.unwrap_or_default()
+    });
+```
+
+(Delete the `futures_join` helper.)
+
+- [ ] **Step 2: Fix the borrow-checker issue: `rows[idx].canonical` can't be moved from a shared borrow inside a spawn. Resolve by cloning the URL into an owned string before the spawn, as shown above. Also note that `rows` is captured by the outer `block_on` closure — make sure rows is moved in (`move` keyword) only if the outer closure truly needs it; otherwise use `rows.iter()` for URL extraction before spawning and hand the results back via `(idx, enrichment)` tuples as shown.**
+
+The corrected structure is already reflected in the Step 1 code block; the borrow is avoided because we build `needs_fetch: Vec<usize>` upfront and clone `canonical` out per-iter inside the `set.spawn` call.
+
+- [ ] **Step 3: Run tests (compile check only — full integration tested in Task 13).**
+
+```bash
+cargo build -p rmux_helper 2>&1 | /usr/bin/tail -30
+```
+
+Expected: clean build. If you see `borrow of moved value: rows`, the fix is to iterate `needs_fetch` with URL pre-clone *before* `set.spawn` closes over anything that borrows `rows`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/enrich.rs
+git commit -m "feat(link-picker): parallel gh fan-out with semaphore and deadline"
+```
+
+---
+
+## Task 13 — Scrollback capture + `pick_links()` orchestration
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/mod.rs`
+
+Implements steps 1–3 and 7 of the Execution Flow (lines 55–106 of the spec). The TUI wiring in step 5 is stubbed here and replaced in Task 14.
+
+- [ ] **Step 1: Write tests and implementation.**
+
+Replace `mod.rs` with:
+
+```rust
+//! Scrollback link picker — top-level orchestration.
+//! See spec docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md §Execution Flow.
+
+pub mod detect;
+pub mod enrich;
+pub mod tui;
+
+use anyhow::{anyhow, Result};
+use std::env;
+use std::process::Command;
+
+/// Entry point for `rmux_helper pick-links`. See spec §Execution Flow.
+pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
+    // 1. Resolve pane
+    let pane_id = resolve_pane_id()?;
+
+    // 2. Capture (sync, fallible)
+    let raw = capture_pane(&pane_id)?;
+
+    // 3. Detect
+    let rows = detect::parse(&raw);
+
+    if json {
+        // --json short-circuit: skip enrich + TUI entirely.
+        println!("{}", serde_json::to_string(&rows)?);
+        return Ok(());
+    }
+
+    // 4. Enrich (blocks inside tokio, then drops runtime before TUI)
+    let rows = enrich::enrich_rows(rows, enrich_deadline_ms);
+
+    // 5. TUI (stub in this task; real implementation in Task 14-15)
+    if rows.is_empty() {
+        eprintln!("pick-links: no links, servers, or IPs in scrollback");
+        return Ok(());
+    }
+    let _action = tui::run(rows)?;
+
+    // 6-7. Teardown + dispatch happen inside tui::run + action handler in Task 16.
+    Ok(())
+}
+
+/// Resolve the tmux pane id to capture. See spec §Scrollback Capture.
+fn resolve_pane_id() -> Result<String> {
+    if let Ok(p) = env::var("TMUX_PANE") {
+        if !p.is_empty() {
+            return Ok(p);
+        }
+    }
+    if env::var("TMUX").is_err() {
+        return Err(anyhow!("pick-links: not inside tmux; nothing to capture"));
+    }
+    // Fallback: ask tmux directly.
+    let out = Command::new("tmux")
+        .args(["display-message", "-p", "-t", "#{client_active_pane}", "#{pane_id}"])
+        .output()
+        .map_err(|e| anyhow!("tmux display-message failed: {e}"))?;
+    if !out.status.success() {
+        return Err(anyhow!("tmux display-message returned nonzero"));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Capture the full scrollback of `pane_id` via `tmux capture-pane`.
+fn capture_pane(pane_id: &str) -> Result<String> {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-p", "-J", "-e", "-S", "-", "-E", "-", "-t", pane_id])
+        .output()
+        .map_err(|e| anyhow!("tmux capture-pane failed: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(anyhow!(
+            "tmux capture-pane -t {pane_id} returned nonzero: {err}"
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+// Replace the placeholder tui stub so `tui::run` compiles. This gets replaced in Task 14.
+```
+
+Update `tui.rs` to a compile-only stub that returns a placeholder:
+
+```rust
+//! Ratatui TUI for the link picker. Replaced in Task 14.
+
+use crate::link_picker::detect::Row;
+use anyhow::Result;
+
+/// Placeholder action enum — extended in Task 16.
+pub enum Action {
+    Quit,
+}
+
+pub fn run(_rows: Vec<Row>) -> Result<Action> {
+    // Temporary: immediately return Quit so `pick-links` without `--json`
+    // is still callable from tests without a TTY.
+    Ok(Action::Quit)
+}
+```
+
+- [ ] **Step 2: Add an integration smoke test that parses a fake scrollback into JSON.**
+
+Add to `mod.rs`:
+
+```rust
+#[cfg(test)]
+mod orchestration_tests {
+    use super::*;
+
+    #[test]
+    fn parses_json_output_from_fake_scrollback() {
+        let raw = "Merge https://github.com/a/b/pull/1\nssh c-5001\n";
+        let rows = detect::parse(raw);
+        let json = serde_json::to_string(&rows).unwrap();
+        assert!(json.contains("\"category\":\"pull_request\""));
+        assert!(json.contains("\"category\":\"server\""));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests and verify end-to-end `--json` output.**
+
+```bash
+cargo test -p rmux_helper link_picker:: 2>&1 | /usr/bin/tail -15
+cargo install --path . --force 2>&1 | /usr/bin/tail -5
+# Verify json mode works against real scrollback (run inside tmux):
+# rmux_helper pick-links --json | /usr/bin/head -40
+```
+
+Expected: all tests pass; `cargo install` rebuilds; `pick-links --json` inside tmux emits a JSON array.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/mod.rs rust/tmux_helper/src/link_picker/tui.rs
+git commit -m "feat(link-picker): orchestration + tmux capture + --json mode"
+```
+
+---
+
+## Task 14 — TUI skeleton: app state, layout, rendering
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/tui.rs`
+
+Mirrors `picker.rs` chrome closely. Refer to `picker.rs:692-870` for the existing draw function and steal the column/color idioms directly.
+
+- [ ] **Step 1: Replace `tui.rs` with the full rendering skeleton.**
+
+```rust
+//! Ratatui TUI for the link picker. See spec §Layout & Display and §Navigation.
+
+use crate::link_picker::detect::{Category, Row, GhState};
+use anyhow::Result;
+use ansi_to_tui::IntoText;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    prelude::*,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    Terminal,
+};
+use std::io;
+use unicode_width::UnicodeWidthStr;
+
+/// Action returned from the TUI to the orchestrator. See spec §Actions.
+#[derive(Debug)]
+pub enum Action {
+    Quit,
+    Yank(Row),
+    Open(Row),
+    GhWeb(Row),
+    Ssh(Row),
+    SwapToPickTui,
+}
+
+struct App {
+    rows: Vec<Row>,
+    filtered: Vec<usize>, // indices into rows in display order (including separators)
+    categories_present: Vec<Category>, // non-empty categories
+    list_state: ListState,
+    query: String,
+    drilled_in: Option<Category>,
+    horizontal: bool,
+    action: Option<Action>,
+    error_msg: Option<String>,
+}
+
+impl App {
+    fn new(rows: Vec<Row>) -> Self {
+        let mut app = Self {
+            rows,
+            filtered: Vec::new(),
+            categories_present: Vec::new(),
+            list_state: ListState::default(),
+            query: String::new(),
+            drilled_in: None,
+            horizontal: true,
+            action: None,
+            error_msg: None,
+        };
+        app.rebuild_filter();
+        app
+    }
+
+    /// Rebuild `filtered` + `categories_present` based on query + drill state.
+    fn rebuild_filter(&mut self) {
+        self.categories_present.clear();
+        self.filtered.clear();
+
+        let tokens = tokenize(&self.query);
+        let matches: Vec<usize> = self
+            .rows
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| match_row(r, &tokens))
+            .filter(|(_, r)| self.drilled_in.map_or(true, |c| r.category == c))
+            .map(|(i, _)| i)
+            .collect();
+
+        // Sentinel indexing: we insert separators as usize::MAX entries and category
+        // headers as (usize::MAX - 1 - category_idx). We disambiguate when rendering.
+        let mut last_cat: Option<Category> = None;
+        for idx in &matches {
+            let cat = self.rows[*idx].category;
+            if Some(cat) != last_cat {
+                if self.drilled_in.is_none() {
+                    self.filtered.push(header_sentinel(cat));
+                }
+                self.categories_present.push(cat);
+                last_cat = Some(cat);
+            }
+            self.filtered.push(*idx);
+        }
+
+        // Snap selection to the first leaf (if any).
+        if self.filtered.is_empty() {
+            self.list_state.select(None);
+        } else {
+            let first_leaf = self
+                .filtered
+                .iter()
+                .position(|&i| i < SENTINEL_BASE)
+                .unwrap_or(0);
+            self.list_state.select(Some(first_leaf));
+        }
+    }
+}
+
+/// Sentinel values above the real index space mean "not a leaf".
+const SENTINEL_BASE: usize = usize::MAX - 100;
+fn header_sentinel(cat: Category) -> usize {
+    SENTINEL_BASE + (cat as usize)
+}
+fn sentinel_to_category(s: usize) -> Option<Category> {
+    if s < SENTINEL_BASE {
+        return None;
+    }
+    match s - SENTINEL_BASE {
+        1 => Some(Category::PullRequest),
+        2 => Some(Category::Issue),
+        3 => Some(Category::Commit),
+        4 => Some(Category::File),
+        5 => Some(Category::Repo),
+        6 => Some(Category::Blog),
+        7 => Some(Category::OtherLink),
+        8 => Some(Category::Server),
+        9 => Some(Category::Ip),
+        _ => None,
+    }
+}
+
+// ----- Filter tokenization (see spec §Filtering semantics, Divergence 1 & 2) -----
+
+/// Divergence 1 from pick-tui: multi-digit tokens are NOT split per-digit,
+/// because splitting would cause PR-number matches to misfire.
+pub(crate) fn tokenize(query: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for word in query.split_whitespace() {
+        // Split letter/digit boundaries ONCE per transition (not per character).
+        let mut cur = String::new();
+        let mut cur_is_digit = None;
+        for ch in word.chars() {
+            let this_is_digit = ch.is_ascii_digit();
+            if cur_is_digit.map_or(false, |d: bool| d != this_is_digit) && !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+            cur.push(ch);
+            cur_is_digit = Some(this_is_digit);
+        }
+        if !cur.is_empty() {
+            out.push(cur);
+        }
+    }
+    out
+}
+
+/// Divergence 2: the category short-name tag is prepended to the row's
+/// search string with a `\x1f` unit separator so substring matches can't
+/// leak from the tag into the body.
+pub(crate) fn row_search_string(r: &Row) -> String {
+    // tag \x1f key repo-or-host context canonical
+    format!(
+        "{}\x1f{} {} {} {}",
+        r.category.tag(),
+        r.key,
+        r.repo_or_host,
+        r.context,
+        r.canonical
+    )
+}
+
+pub(crate) fn match_row(r: &Row, tokens: &[String]) -> bool {
+    if tokens.is_empty() {
+        return true;
+    }
+    let hay = row_search_string(r).to_lowercase();
+    // Key column alone for digit tokens:
+    let key_lc = r.key.to_lowercase();
+    for tok in tokens {
+        let t = tok.to_lowercase();
+        if tok.chars().all(|c| c.is_ascii_digit()) {
+            if !key_lc.contains(&t) {
+                return false;
+            }
+        } else if !hay.contains(&t) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::*;
+
+    fn mk(cat: Category, key: &str, context: &str) -> Row {
+        Row {
+            category: cat,
+            canonical: format!("https://github.com/a/b/pull/{key}"),
+            key: key.to_string(),
+            repo_or_host: "b".to_string(),
+            context: context.to_string(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 0,
+        }
+    }
+
+    #[test]
+    fn tokenize_splits_letter_digit_boundary_once() {
+        assert_eq!(tokenize("pr68"), vec!["pr", "68"]);
+        assert_eq!(tokenize("14 cl"), vec!["14", "cl"]);
+    }
+
+    #[test]
+    fn multi_digit_token_not_split_per_digit() {
+        assert_eq!(tokenize("1234"), vec!["1234"]);
+    }
+
+    #[test]
+    fn tag_leak_is_prevented_by_unit_separator() {
+        let r = mk(Category::PullRequest, "#68", "writing prose all day");
+        // "pr" tag should NOT leak into matching against "prose"
+        let s = row_search_string(&r);
+        assert!(s.starts_with("pr\x1f"));
+        assert!(!s[..3].contains("prose"));
+    }
+
+    #[test]
+    fn digit_token_matches_key_only() {
+        let r = mk(Category::PullRequest, "#68", "context 68 somewhere");
+        assert!(match_row(&r, &[String::from("68")])); // in key
+        let r2 = mk(Category::PullRequest, "#99", "context 68 somewhere");
+        assert!(!match_row(&r2, &[String::from("68")])); // not in key
+    }
+
+    #[test]
+    fn category_tag_matches_at_start() {
+        let r = mk(Category::PullRequest, "#1", "");
+        assert!(match_row(&r, &[String::from("pr")]));
+        let r2 = mk(Category::Issue, "#1", "");
+        assert!(!match_row(&r2, &[String::from("pr")]));
+    }
+}
+
+// ----- Run loop + rendering -----
+
+pub fn run(rows: Vec<Row>) -> Result<Action> {
+    if rows.is_empty() {
+        return Ok(Action::Quit);
+    }
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(rows);
+    let result = event_loop(&mut app, &mut terminal);
+
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    drop(terminal);
+
+    result
+}
+
+fn event_loop<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> Result<Action> {
+    loop {
+        terminal.draw(|f| draw(f, app))?;
+        if let Event::Key(k) = event::read()? {
+            if k.kind != KeyEventKind::Press {
+                continue;
+            }
+            handle_key(app, k.modifiers, k.code);
+            if let Some(action) = app.action.take() {
+                return Ok(action);
+            }
+        }
+    }
+}
+
+fn draw(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let main = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(5)])
+        .split(area);
+
+    // Top bar with breadcrumb or flat hints.
+    let top = if let Some(cat) = app.drilled_in {
+        format!(
+            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back F2:sess ?:help",
+            app.query,
+            cat.display()
+        )
+    } else {
+        format!(
+            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh F2:sess ?:help",
+            app.query
+        )
+    };
+    f.render_widget(
+        Paragraph::new(top).style(Style::default().fg(Color::Yellow)),
+        main[0],
+    );
+
+    // Split content horizontally or vertically
+    let content_chunks = if app.horizontal {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(main[1])
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(65), Constraint::Percentage(35)])
+            .split(main[1])
+    };
+
+    // List
+    let items: Vec<ListItem> = app
+        .filtered
+        .iter()
+        .map(|&idx| render_item(app, idx))
+        .collect();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title("Links"))
+        .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+        .highlight_symbol("▶ ");
+    f.render_stateful_widget(list, content_chunks[0], &mut app.list_state);
+
+    // Preview
+    let preview_text = preview_for_selection(app);
+    let preview = Paragraph::new(preview_text)
+        .block(Block::default().borders(Borders::ALL).title("Preview"))
+        .wrap(Wrap { trim: false });
+    f.render_widget(preview, content_chunks[1]);
+}
+
+fn render_item(app: &App, idx: usize) -> ListItem<'static> {
+    if let Some(cat) = sentinel_to_category(idx) {
+        let count = app
+            .filtered
+            .iter()
+            .filter(|i| **i < SENTINEL_BASE && app.rows[**i].category == cat)
+            .count();
+        return ListItem::new(format!("⊟ {} ({count})", cat.display()))
+            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+    }
+    let r = &app.rows[idx];
+    let tree = "├─ ";
+    let glyph = r.enriched.as_ref().map(|e| state_glyph(e.state)).unwrap_or("");
+    let title = r.enriched.as_ref().map(|e| e.title.as_str()).unwrap_or(&r.context);
+    let count = if r.count > 1 { format!("  ×{}", r.count) } else { String::new() };
+    let spans = vec![
+        Span::styled(tree, Style::default().fg(Color::DarkGray)),
+        Span::styled(format!("{:<8} ", r.key), Style::default().fg(Color::LightYellow)),
+        Span::styled(format!("{:<16} ", r.repo_or_host), Style::default().fg(Color::LightGreen)),
+        Span::styled(format!("{glyph} "), Style::default().fg(glyph_color(r.enriched.as_ref().map(|e| e.state)))),
+        Span::styled(title.to_string(), Style::default().fg(Color::LightMagenta)),
+        Span::styled(count, Style::default().fg(Color::LightCyan)),
+    ];
+    ListItem::new(Line::from(spans))
+}
+
+fn state_glyph(s: GhState) -> &'static str {
+    match s {
+        GhState::Open => "◉",
+        GhState::MergedPr => "●",
+        GhState::Closed => "✕",
+        GhState::Draft => "◐",
+        GhState::Commit => "⎇",
+    }
+}
+
+fn glyph_color(s: Option<GhState>) -> Color {
+    match s {
+        Some(GhState::Open) => Color::LightGreen,
+        Some(GhState::MergedPr) => Color::LightMagenta,
+        Some(GhState::Closed) => Color::DarkGray,
+        Some(GhState::Draft) => Color::LightYellow,
+        Some(GhState::Commit) => Color::LightBlue,
+        None => Color::Reset,
+    }
+}
+
+fn preview_for_selection(app: &App) -> Text<'static> {
+    let Some(pos) = app.list_state.selected() else {
+        return Text::raw("");
+    };
+    let Some(&idx) = app.filtered.get(pos) else {
+        return Text::raw("");
+    };
+    if let Some(cat) = sentinel_to_category(idx) {
+        return Text::raw(format!("Category: {} (header)", cat.display()));
+    }
+    let r = &app.rows[idx];
+    let body = format!(
+        "{}\n\ncanonical: {}\nkey: {}\nrepo/host: {}\ncount: {}",
+        r.context, r.canonical, r.key, r.repo_or_host, r.count
+    );
+    body.into_text().unwrap_or_else(|_| Text::raw(body))
+}
+
+// Key handling is stubbed here for Task 14; wired in Task 15.
+fn handle_key(app: &mut App, _mods: KeyModifiers, code: KeyCode) {
+    if matches!(code, KeyCode::Esc) {
+        app.action = Some(Action::Quit);
+    }
+}
+```
+
+- [ ] **Step 2: Build the crate.**
+
+```bash
+cargo build -p rmux_helper 2>&1 | /usr/bin/tail -30
+```
+
+Expected: clean build. Fix any compile errors (likely borrow-checker issues in `render_item` around ownership of `title`/`glyph`).
+
+- [ ] **Step 3: Run filter tests.**
+
+```bash
+cargo test -p rmux_helper link_picker::tui::filter_tests 2>&1 | /usr/bin/tail -20
+```
+
+Expected: 5 passes.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/tui.rs
+git commit -m "feat(link-picker): TUI skeleton with filter tokenizer and row render"
+```
+
+---
+
+## Task 15 — TUI key handling: navigation, drill-in, filter input
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/tui.rs`
+
+Expands `handle_key` to the full navigation model from spec §Navigation (lines ~530-600).
+
+- [ ] **Step 1: Replace `handle_key` and add helper methods on `App`.**
+
+Replace the `handle_key` stub with:
+
+```rust
+fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
+    // Esc: drill-out or quit
+    if matches!(code, KeyCode::Esc) {
+        if app.drilled_in.is_some() {
+            app.drilled_in = None;
+            app.rebuild_filter();
+        } else {
+            app.action = Some(Action::Quit);
+        }
+        return;
+    }
+
+    // Ctrl-C: clear query or quit
+    if matches!(code, KeyCode::Char('c')) && mods.contains(KeyModifiers::CONTROL) {
+        if !app.query.is_empty() {
+            app.query.clear();
+            app.rebuild_filter();
+        } else {
+            app.action = Some(Action::Quit);
+        }
+        return;
+    }
+
+    // Navigation
+    match code {
+        KeyCode::Down | KeyCode::Char('\x0e') => app.move_selection(1),
+        KeyCode::Up | KeyCode::Char('\x10') => app.move_selection(-1),
+        KeyCode::Right => app.drill_in(),
+        KeyCode::Left => {
+            if app.drilled_in.is_some() {
+                app.drilled_in = None;
+                app.rebuild_filter();
+            }
+        }
+        KeyCode::Enter => app.on_enter(),
+        KeyCode::F(2) => app.action = Some(Action::SwapToPickTui),
+        KeyCode::F(1) => { /* help overlay — TODO v1.1 */ }
+        KeyCode::Backspace => {
+            app.query.pop();
+            app.rebuild_filter();
+        }
+        KeyCode::Char('l') if mods.contains(KeyModifiers::CONTROL) => {
+            app.horizontal = !app.horizontal;
+        }
+        KeyCode::Char('n') if mods.contains(KeyModifiers::CONTROL) => app.move_selection(1),
+        KeyCode::Char('p') if mods.contains(KeyModifiers::CONTROL) => app.move_selection(-1),
+        // Digit 1-9: jump to Nth category drilled-in view
+        KeyCode::Char(c @ '1'..='9') if mods.is_empty() && app.query.is_empty() => {
+            let n = (c as u8 - b'0') as usize;
+            if let Some(cat) = app.categories_present.get(n - 1) {
+                app.drilled_in = Some(*cat);
+                app.rebuild_filter();
+            }
+        }
+        KeyCode::Char(c) if c.is_ascii_graphic() || c == ' ' => {
+            app.query.push(c);
+            app.rebuild_filter();
+        }
+        _ => {}
+    }
+}
+
+impl App {
+    fn move_selection(&mut self, delta: i32) {
+        let Some(cur) = self.list_state.selected() else { return };
+        let len = self.filtered.len();
+        if len == 0 {
+            return;
+        }
+        let mut next = cur as i32 + delta;
+        // Skip headers while moving
+        while (0..len as i32).contains(&next) {
+            if self.filtered[next as usize] < SENTINEL_BASE {
+                break;
+            }
+            next += delta.signum();
+        }
+        if (0..len as i32).contains(&next) {
+            self.list_state.select(Some(next as usize));
+        }
+    }
+
+    fn drill_in(&mut self) {
+        if self.drilled_in.is_some() {
+            return;
+        }
+        let Some(cur) = self.list_state.selected() else { return };
+        let Some(&idx) = self.filtered.get(cur) else { return };
+        let cat = if let Some(c) = sentinel_to_category(idx) {
+            c
+        } else {
+            self.rows[idx].category
+        };
+        self.drilled_in = Some(cat);
+        self.rebuild_filter();
+    }
+
+    fn on_enter(&mut self) {
+        let Some(cur) = self.list_state.selected() else { return };
+        let Some(&idx) = self.filtered.get(cur) else { return };
+        if let Some(cat) = sentinel_to_category(idx) {
+            // Header: drill in
+            self.drilled_in = Some(cat);
+            self.rebuild_filter();
+            return;
+        }
+        // Leaf: default action
+        let row = self.rows[idx].clone();
+        self.action = Some(default_action(&row));
+    }
+}
+
+/// Default Enter action per category (see spec §Actions → Default).
+pub(crate) fn default_action(row: &Row) -> Action {
+    match row.category {
+        Category::Server | Category::Ip => Action::Ssh(row.clone()),
+        _ => Action::Yank(row.clone()),
+    }
+}
+```
+
+- [ ] **Step 2: Build and run existing tests.**
+
+```bash
+cargo test -p rmux_helper link_picker:: 2>&1 | /usr/bin/tail -20
+```
+
+Expected: all prior tests pass, no new regressions.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/tui.rs
+git commit -m "feat(link-picker): navigation, drill-in, filter input keys"
+```
+
+---
+
+## Task 16 — Actions + OSC 52 yank + override keys
+
+**Files:**
+- Modify: `rust/tmux_helper/src/link_picker/mod.rs`
+- Modify: `rust/tmux_helper/src/link_picker/tui.rs`
+
+Implements steps 6-7 of the Execution Flow: post-TUI teardown, OSC 52 yank with correct ordering, action dispatch.
+
+- [ ] **Step 1: Add override-key handling in `tui.rs::handle_key` before the catch-all printable branch:**
+
+```rust
+        // Override keys (on selected leaf only)
+        KeyCode::Char('y') if mods.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Yank(row));
+            }
+        }
+        KeyCode::Char('o') if mods.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Open(row));
+            }
+        }
+        KeyCode::Char('g') if mods.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                if matches!(
+                    row.category,
+                    Category::PullRequest
+                        | Category::Issue
+                        | Category::Commit
+                        | Category::File
+                        | Category::Repo
+                ) {
+                    app.action = Some(Action::GhWeb(row));
+                } else {
+                    app.error_msg = Some("g: not a GitHub row".into());
+                }
+            }
+        }
+        KeyCode::Char('s') if mods.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Ssh(row));
+            }
+        }
+```
+
+Add the `selected_leaf` helper on `App`:
+
+```rust
+    fn selected_leaf(&self) -> Option<Row> {
+        let cur = self.list_state.selected()?;
+        let &idx = self.filtered.get(cur)?;
+        if idx >= SENTINEL_BASE {
+            return None;
+        }
+        Some(self.rows[idx].clone())
+    }
+```
+
+**Wait:** `y`/`o`/`g`/`s` are lowercase letters and the catch-all `KeyCode::Char(c)` branch above would type them into the search query first. Move the override branches BEFORE the printable-ASCII catch-all in the match. Since this would make them unreachable while typing a query (e.g., searching for "yes"), gate them on `app.query.is_empty()` — override keys only fire when the query is empty. Document this constraint in `LINK_PICKER_SPEC.md`.
+
+Final ordering: move the 4 override branches above the `KeyCode::Char(c) if c.is_ascii_graphic()...` branch, and gate each on `app.query.is_empty()`:
+
+```rust
+        KeyCode::Char('y') if mods.is_empty() && app.query.is_empty() => { /* ... */ }
+```
+
+- [ ] **Step 2: Update `mod.rs::pick_links` to handle the action from `tui::run`.**
+
+Replace the stub `let _action = tui::run(rows)?;` block with:
+
+```rust
+    // 5. TUI
+    let action = tui::run(rows)?;
+
+    // 6-7. Dispatch post-TUI (terminal already restored by tui::run).
+    match action {
+        tui::Action::Quit => std::process::exit(130),
+        tui::Action::Yank(row) => {
+            yank_osc52(&row.canonical)?;
+            println!("{}", row.canonical);
+        }
+        tui::Action::Open(row) => open_url(&row.canonical)?,
+        tui::Action::GhWeb(row) => gh_web(&row)?,
+        tui::Action::Ssh(row) => ssh_host(&row)?,
+        tui::Action::SwapToPickTui => {
+            use std::os::unix::process::CommandExt;
+            // execvp: never returns on success
+            let err = Command::new("rmux_helper").arg("pick-tui").exec();
+            return Err(anyhow!("exec pick-tui failed: {err}"));
+        }
+    }
+    Ok(())
+}
+
+fn yank_osc52(payload: &str) -> Result<()> {
+    use base64::Engine;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+    let mut tty = OpenOptions::new().write(true).open("/dev/tty")?;
+    write!(tty, "\x1b]52;c;{b64}\x1b\\")?;
+    tty.flush()?;
+    Ok(())
+}
+
+fn open_url(url: &str) -> Result<()> {
+    let cmd = if cfg!(target_os = "macos") { "open" } else { "xdg-open" };
+    Command::new(cmd).arg(url).status()?;
+    Ok(())
+}
+
+fn gh_web(row: &detect::Row) -> Result<()> {
+    use detect::Category as C;
+    let subcmd = match row.category {
+        C::PullRequest => "pr",
+        C::Issue => "issue",
+        C::Commit | C::File | C::Repo => {
+            // Fall through to plain open — gh doesn't have a generic "view" for these
+            return open_url(&row.canonical);
+        }
+        _ => return Ok(()),
+    };
+    // row.key is "#N" for PR/Issue — strip "#" for gh arg.
+    let id = row.key.trim_start_matches('#');
+    // repo_or_host is just the repo name; owner not carried on Row in v1.
+    // Parse from canonical: https://github.com/OWNER/REPO/...
+    let owner_repo = row
+        .canonical
+        .strip_prefix("https://github.com/")
+        .and_then(|s| s.splitn(3, '/').take(2).collect::<Vec<_>>().join("/").into())
+        .unwrap_or_else(|| row.repo_or_host.clone());
+    Command::new("gh")
+        .args([subcmd, "view", id, "-R", &owner_repo, "--web"])
+        .status()?;
+    Ok(())
+}
+
+fn ssh_host(row: &detect::Row) -> Result<()> {
+    // Use tmux new-window in the originating pane's session.
+    let pane = env::var("TMUX_PANE").unwrap_or_default();
+    let host_arg = format!("ssh {}", row.canonical);
+    Command::new("tmux")
+        .args(["new-window", "-t", &pane, &host_arg])
+        .status()?;
+    Ok(())
+}
+```
+
+Note: `gh_web`'s owner-repo extraction is a bit fragile; consider pushing `owner` onto `Row` in a follow-up if this causes pain. For v1 the parse from `canonical` is sufficient because canonical URLs are normalized.
+
+- [ ] **Step 3: Build and verify.**
+
+```bash
+cargo build -p rmux_helper 2>&1 | /usr/bin/tail -30
+cargo test -p rmux_helper link_picker:: 2>&1 | /usr/bin/tail -15
+```
+
+Expected: clean build; all tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add rust/tmux_helper/src/link_picker/
+git commit -m "feat(link-picker): OSC 52 yank, contextual Enter, override keys"
+```
+
+---
+
+## Task 17 — F2 cross-picker, PICKER_SPEC update, tmux binding, LINK_PICKER_SPEC
+
+**Files:**
+- Modify: `rust/tmux_helper/src/picker.rs` (around line 650 — key handler)
+- Modify: `rust/tmux_helper/PICKER_SPEC.md`
+- Modify: `shared/.tmux.conf`
+- Create: `rust/tmux_helper/LINK_PICKER_SPEC.md`
+
+This task closes the loop: `pick-tui` can jump to `pick-links` via `F2`, the tmux binding lives in `.tmux.conf`, and the behavior contract is documented.
+
+- [ ] **Step 1: Add F2 handler to `picker.rs` key handling.**
+
+Find the F1/help binding in `rust/tmux_helper/src/picker.rs` around line 650:
+
+```rust
+                (_, KeyCode::F(1)) | (KeyModifiers::CONTROL, KeyCode::Char('/')) => {
+```
+
+Add a sibling branch *before* it:
+
+```rust
+                (_, KeyCode::F(2)) => {
+                    // Cross-picker swap: exec pick-links. See spec §Cross-picker shortcut.
+                    app.should_quit = true;
+                    app.selected_target = Some("__swap_to_pick_links__".into());
+                }
+```
+
+Then find the `pick_tui()` function's post-loop handling (around the teardown in lines ~686-690). After `disable_raw_mode` + `LeaveAlternateScreen`, intercept the sentinel and exec:
+
+```rust
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    drop(terminal);
+    if matches!(app.selected_target.as_deref(), Some("__swap_to_pick_links__")) {
+        use std::os::unix::process::CommandExt;
+        let err = std::process::Command::new("rmux_helper")
+            .arg("pick-links")
+            .exec();
+        return Err(anyhow::anyhow!("exec pick-links failed: {err}"));
+    }
+```
+
+Adjust to match the actual return type. If `selected_target: Option<String>` is threaded through a different path, switch the "string sentinel" to a dedicated enum variant when follow-up refactoring hits.
+
+- [ ] **Step 2: Update `PICKER_SPEC.md` with the F2 entry.**
+
+Under the `## Actions` section, add:
+
+```markdown
+- `F2`: Swap to link picker (`rmux_helper pick-links`) — exec-based handoff, terminal is restored first. Bidirectional: `F2` in `pick-links` returns here.
+```
+
+- [ ] **Step 3: Add the tmux binding, help-section entry, and command alias in `shared/.tmux.conf`.**
+
+At the help section near the top of the file (following the existing `C-a w` help line), add:
+
+```tmux
+#   C-a L                - Launch scrollback link picker popup (rmux_helper pick-links)
+```
+
+And in the alias-section (search for `set -s command-alias`):
+
+```tmux
+set -s command-alias[NN] pick-links='run-shell "rmux_helper pick-links"'
+```
+
+Replace `NN` with the next free alias index.
+
+Add the bind-key near `C-a w`:
+
+```tmux
+bind-key L display-popup -E -w 95% -h 95% \
+  "TMUX_PANE=#{pane_id} rmux_helper pick-links"
+```
+
+- [ ] **Step 4: Create `rust/tmux_helper/LINK_PICKER_SPEC.md`.**
+
+Write the behavior contract mirroring `PICKER_SPEC.md`'s style. Do not re-derive the design — this is a behavior reference for future changes. Minimum content:
+
+```markdown
+# rmux_helper pick-links Specification
+
+## Categories (fixed display order)
+
+1. Pull Requests — `github.com/OWNER/REPO/pull/N`
+2. Issues — `github.com/OWNER/REPO/issues/N`
+3. Commits — `github.com/OWNER/REPO/commit/SHA`
+4. Files — `github.com/OWNER/REPO/(blob|tree)/REF/PATH`
+5. Repos — `github.com/OWNER/REPO` (bare)
+6. Blog — host ∈ `BLOG_HOSTS` (v1: `idvorkin.github.io`)
+7. Other links — any `https?://` not matched above
+8. Servers — `ssh` context + Tailscale (`c-NNNN`, `*.ts.net`)
+9. IPs — IPv4 with version-string suppression
+
+## Dedup
+
+Row key = `(category, canonical)`. Duplicates collapse into one row with a `×N` count.
+
+## Ordering
+
+Categories: fixed order above. Within a category: most-recent line first (closest to bottom).
+
+## Columns
+
+| Col | Color | Content |
+|---|---|---|
+| key | LightYellow | `#N`, `SHA[:7]`, filename, host, IP |
+| repo-or-host | LightGreen | repo name, host, or `—` |
+| glyph + title | state-colored + LightMagenta | state glyph from enriched gh view; `context` line otherwise |
+| count | LightCyan | `×N` only when N > 1 |
+
+## Navigation
+
+- `↑`/`↓` or `C-p`/`C-n`: move selection
+- `→` or `Enter` on category header: drill into that category
+- `1`–`9`: jump into Nth non-empty category (query must be empty)
+- `←`: drill out (in drilled-in mode)
+- `Esc`: drill out (first press) or quit (if already flat)
+- `Tab` / `S-Tab`: reserved, no-op
+- `F2`: swap to `pick-tui` (bidirectional)
+- `F1`: help (reserved)
+- `C-l`: toggle layout (horizontal/vertical)
+- `C-c`: clear query or quit
+
+## Actions
+
+Default `Enter`:
+- URL categories → OSC 52 yank + print URL to stdout
+- Servers / IPs → `tmux new-window -t "$TMUX_PANE" "ssh <host>"`
+
+Override keys (query must be empty):
+- `y` — yank (OSC 52)
+- `o` — `open`/`xdg-open`
+- `g` — `gh <kind> view --web -R OWNER/REPO <id>` (GitHub rows only)
+- `s` — force ssh
+
+## Filtering
+
+Token-based substring match. Tokens split on whitespace; letter/digit boundaries split once per transition (multi-digit tokens stay whole — Divergence 1 from `pick-tui`).
+
+Category tag `pr`/`issue`/`commit`/`file`/`repo`/`blog`/`link`/`server`/`ip` prefixes each row's search string with a `\x1f` separator (Divergence 2).
+
+Digit-only tokens match the `key` column only.
+
+## Divergences from `PICKER_SPEC.md`
+
+1. **Multi-digit tokens are NOT split per digit.** `pick-tui` splits `14` → `[1,4]` to match tmux index `1;4`; the link picker treats `14` as one token because PR number `14` must not match `#1;4`.
+2. **Tag prefix uses `\x1f` separator.** Ensures the category tag is matched as a whole word, not as a substring leaking into titles.
+
+## Cross-picker shortcut
+
+`F2` cleanly tears down the TUI (`disable_raw_mode` + `LeaveAlternateScreen` + drop terminal + flush) then `execvp`s the sibling binary with `TMUX_PANE` forwarded. OSC 52 is NOT written on `F2` — it's a swap, not an action.
+
+## OSC 52 timing
+
+Write sequence, in order: TUI exits → `disable_raw_mode` → `LeaveAlternateScreen` → drop `Terminal` → flush stdout/stderr → open `/dev/tty` → write `\e]52;c;<base64>\e\\` → flush tty → `exit(0)`.
+```
+
+- [ ] **Step 5: Build + install + manual smoke.**
+
+```bash
+cd rust/tmux_helper
+cargo build 2>&1 | /usr/bin/tail -20
+cargo install --path . --force 2>&1 | /usr/bin/tail -5
+```
+
+Inside tmux, reload config and test:
+
+```bash
+tmux source-file ~/.tmux.conf
+# Press C-a L — popup should appear
+# In the popup, press F2 — should swap to session picker
+# Press F2 again — should swap back to link picker
+# Press Esc — should exit cleanly
+```
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add rust/tmux_helper/src/picker.rs \
+        rust/tmux_helper/PICKER_SPEC.md \
+        rust/tmux_helper/LINK_PICKER_SPEC.md \
+        shared/.tmux.conf
+git commit -m "feat(link-picker): F2 cross-picker, tmux binding, behavior spec"
+```
+
+- [ ] **Step 7: Open PR.**
+
+```bash
+gh pr create --title "feat(link-picker): scrollback link picker subcommand" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- New `rmux_helper pick-links` subcommand: ratatui TUI that scans the current tmux pane's scrollback for GitHub links (PRs, issues, commits, files, repos), blog posts, other URLs, ssh servers, and IP addresses
+- Parallel `gh` enrichment with shared 3s deadline + on-disk cache for real PR/issue/commit titles
+- `F2` bidirectional cross-picker between `pick-tui` and `pick-links`
+- OSC 52 clipboard bridge (devvm → Mac host via iTerm)
+- `C-a L` popup binding in `shared/.tmux.conf`
+
+Design spec: `docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md`
+Behavior contract: `rust/tmux_helper/LINK_PICKER_SPEC.md`
+
+## Test plan
+
+- [ ] `cargo test -p rmux_helper link_picker::` passes (detection + filter invariants)
+- [ ] `rmux_helper pick-links --json` inside tmux emits valid JSON
+- [ ] `C-a L` opens the popup from a pane with PR URLs in scrollback
+- [ ] Enter on a PR row yanks to clipboard (verify with `pbpaste` on Mac host)
+- [ ] Enter on a server row opens `tmux new-window ssh …`
+- [ ] `F2` from `pick-links` lands in `pick-tui` and vice versa
+- [ ] Drill-in via `→` and drill-out via `Esc` preserve the query
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- §Execution Flow → Task 13 (capture, detect, --json short-circuit, enrich, TUI handoff) + Task 16 (post-TUI dispatch + OSC 52 + F2 exec branch). ✓
+- §Scrollback Capture (`tmux capture-pane -pJe -S- -E-`, `$TMUX_PANE` fallback) → Task 13. ✓
+- §Categories & Detection → Tasks 2–9. ✓
+- §Enrichment (pipeline, cache, fan-out, deadline, degradation) → Tasks 10–12. ✓
+- §Layout & Display (chrome, columns, glyphs, preview, H/V layout) → Task 14. ✓
+- §Navigation (flat mode, drilled-in mode, F2) → Task 15 + Task 17. ✓
+- §Filtering semantics (tokens, Divergences 1 and 2) → Task 14 + tests. ✓
+- §Actions (default, override keys, OSC 52 timing) → Task 16. ✓
+- §Clipboard Bridge → Task 16 `yank_osc52`. ✓
+- §Configuration (`BLOG_HOSTS` constant) → Task 5. ✓
+- §File Layout → matches plan's File Structure section. ✓
+- §Error Handling → covered inline in Tasks 13, 16 (not inside tmux, capture fail, action fail, F2 exec fail). ✓
+- §Invariants (detection / enrichment / action-layer) → covered as test cases in Tasks 2–12. Concurrent-writers cache invariant is not directly tested (inherently hard), noted in spec §Invariants already.
+
+**Placeholder scan:** no "TBD", no "implement later". Task 14's `F1` help overlay is explicitly stubbed with a comment pointing at v1.1; acceptable because `F1` is listed in the key table but spec §Navigation says "help overlay" without mandating it for v1.
+
+**Type consistency check:**
+- `Row`, `Item`, `Category`, `EnrichedTitle`, `GhState` are defined once in Task 2, imported elsewhere consistently.
+- `Action` defined in Task 14 (`tui.rs`), imported in Task 16 (`mod.rs`). Same variants throughout.
+- `yank_osc52` is `fn`, not a method — called as free function in Task 16. Matches.
+- `enrich_rows` signature `(Vec<Row>, u64) -> Vec<Row>` is stable across Tasks 12 and 13. ✓
+- `parse(raw: &str) -> Vec<Row>` defined in Task 9, called in Task 13. ✓
+
+**Gaps found and fixed inline:**
+- Task 16 `gh_web` originally assumed `owner` on `Row`; corrected to parse from `canonical`.
+- Task 16 override keys initially conflicted with the search-input catch-all; gated on `app.query.is_empty()` and reordered match arms.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-12-scrollback-link-picker.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for a 17-task plan with strict TDD loops — keeps context clean and prevents drift.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Faster for simple tasks, but this plan's size will burn context if run inline.
+
+**Which approach?**
+
+If you want to split the work: Phase A (Tasks 1–9, pure detection — standalone) could be one session, Phase B (Tasks 10–17, enrichment + TUI + integration — depends on Phase A) a second. Phase A gives you a working `pick-links --json` end-to-end; Phase B adds the TUI and all interactive polish.

--- a/docs/superpowers/specs/2026-04-12-scrollback-link-picker-design-changelog.md
+++ b/docs/superpowers/specs/2026-04-12-scrollback-link-picker-design-changelog.md
@@ -1,0 +1,94 @@
+# Scrollback Link Picker Design — Changelog
+
+Spec: /home/developer/settings/docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md
+
+## Architect Review — 2026-04-12 20:30
+
+### Convergence Tracking
+
+| Pass | Changes |
+| ---- | ------- |
+| 1    | 11      |
+| 2    | 5       |
+| 3    | 0       |
+
+### Pass 1 — 2026-04-12
+
+**Architectural edits**
+
+1. **Tightened the "works from anywhere" claim** in Goals — it's actually "works from any tmux pane"; non-tmux terminals are explicitly out in v1.
+2. **Added explicit pipeline phasing narrative** at the top of Enrichment → Pipeline: capture/parse sync, one `Runtime::new()?.block_on(enrich)` boundary, TUI never re-enters tokio. Pins the tokio runtime placement.
+3. **Added concurrent-writers contract** to cache handling: last-writer-wins, no flock in v1, with rationale.
+4. **Added SIGINT-during-enrichment behavior**: SIGINT works normally pre-TUI, process exits 130, `gh` children are reaped by init. No custom signal handler.
+5. **Fixed filter-semantics conflict with `pick-tui`**: called out that multi-digit tokens do _not_ split per-digit here (would cause spurious PR-number matches), and marked this as a deliberate Divergence 1.
+6. **Fixed category short-name tag leaking into content match**: introduced a `\x1f` unit-separator between tag and content so typing `pr` doesn't accidentally match "prose" in a context line. Marked as Divergence 2.
+7. **Made F2 exec sequence concrete**: enumerated the 5-step teardown (`disable_raw_mode` → `LeaveAlternateScreen` → drop terminal → flush stdout/stderr → `exec`), added explicit "never yank on F2" rule, noted there's no runtime-shutdown step in v1 because the tokio runtime has already returned before the TUI starts.
+8. **Added Unicode width invariant** for dynamic columns (CJK / emoji in enriched PR titles is real and would break naive `str::len` column math). Commits to `unicode-width` crate.
+9. **Added detection-performance note**: precompiled `regex::RegexSet` single-pass over each scrollback line, not 9 independent regex walks. Makes the "works on megabyte scrollbacks" claim defensible.
+10. **Added New Cargo Dependencies subsection** listing tokio, regex, serde(\_json), unicode-width, base64, dirs — none currently in the crate — with the single-thread tokio runtime choice pinned. Reconciled with File Layout's earlier feature-gate language, which was misleading.
+11. **Added missing testable invariants**: filter-tag leak, digit-token substring, unicode column widths, context truncation idempotency, F2-never-yanks, SIGINT-before-TUI. Also tightened the `$TMUX_PANE` unset fallback (use `client_active_pane`, handle the pane-killed-mid-flight race) and noted the `C-a L` default-binding override.
+
+**Reviewed but deliberately left unchanged**
+
+- **`--json` mode in v1** — spec references it under Invariants (idempotent detection over fixture strings is cleanest to assert via JSON round-trip), so it's earning its keep as a test-harness hook even if no user would invoke it directly.
+- **Glyph system for PR state** — five glyphs is small, and the color mapping lines up 1:1 with GitHub's state model. Not over-engineered.
+- **Override keys `y` / `o` / `g` / `s`** — each does a semantically different thing (clipboard vs browser vs gh CLI vs force-ssh). No consolidation would improve things.
+- **Single-level drill-down (no repo subgrouping)** — matches the v1 non-goals block and keeps navigation minimal. Right call.
+- **Dedicated `LINK_PICKER_SPEC.md`** — mirroring `PICKER_SPEC.md` is the right pattern for this repo.
+- **No frecency / no multi-select / no streaming enrichment** — all correctly parked under v2 roadmap with justification.
+- **OSC 52 as the only clipboard path** — avoiding `pbcopy`/`xclip`/`wl-copy` shelling is the right call for cross-boundary (devvm → Mac host) operation. Write-ordering nuance is already captured in the body and now in invariants.
+
+**Assessment**
+
+After pass 1, the spec is close to implementation-ready. The pipeline seams are clean, the filter divergences from `pick-tui` are now named and justified, the F2 exec path is mechanically specified, the dep surface is called out, and the concurrency/signal edges are covered.
+
+**Highest-priority thing still missing going into pass 2:** a concrete sketch of the top-level `pick-links` error flow (ordering of: capture → detect → enrich → TUI exit → OSC 52 flush → stdout print → process exit), shown as a single pseudocode sequence. Right now the pieces are distributed across Enrichment, Clipboard Bridge, Actions, and Error Handling, and the reader has to reconstruct the happy path and error paths mentally. A 30-line sequence would make the whole thing click and would catch any remaining ordering bugs before implementation.
+
+### Pass 2 — 2026-04-12
+
+**Architectural edits**
+
+1. **Added `## Execution Flow` section** near the top of the spec (after Non-goals, before Invocation) with a ~50-line pseudocode sequence for `pick_links()` covering pane resolve → capture → detect → enrich (single `block_on`) → TUI → teardown → dispatch, plus four ordering invariants called out explicitly (OSC 52 timing, F2-no-yank, no runtime-at-F2, SIGINT-before-TUI). This is pass 1's primary ask — the ordering was previously distributed across Enrichment, Clipboard Bridge, Actions, and Error Handling, and now lives in one place as the canonical reference.
+2. **Fixed stale "no live enrichment" non-goal reference** on the `g` key action. Pass 1 inverted enrichment from non-goal to goal but left the `g`-key blurb claiming GitHub-web is "consistent with the v1 non-goal of 'no live enrichment'" — that non-goal no longer exists. Rewrote the note to contrast `g` (shell out, no data parsing) with the blocking pre-TUI enrichment fan-out, which is the real distinction.
+3. **Added malformed-`gh`-JSON degradation clause** to the Degradation list: schema drift, truncation, and non-UTF-8 are treated as row-level errors (fall back to context, no panic, no global abort). Previously this error class was hand-waved under "individual call errors" but JSON parse failure is distinct from HTTP failure and deserves explicit mention because `serde_json::from_slice` is the touchpoint.
+4. **Added corresponding malformed-JSON invariant** under Enrichment invariants so the behavior has a test hook, not just prose.
+5. **Added four UX/navigation invariants** with no prior automated coverage: empty-category-hides-header, fixed category display order, query-preserved-across-drill, and Esc-double-press-to-quit-from-drill. All four are claimed in the body of the spec but had no invariant entry, so implementations could quietly regress them.
+
+**Reviewed but deliberately left unchanged**
+
+- **`\x1f` unit-separator for filter tag isolation** — I considered challenging this as over-engineering (you could instead carry `tag: &str` as a side-channel next to the row's search string and match it against non-digit tokens explicitly). Rejected the simplification because the whole point of the existing `pick-tui` filter abstraction is a single flat search string per row, and introducing a side-channel for one field would fork the filter code. `\x1f` is a 1-byte insertion that preserves the substring-match invariant. Pass 1 got it right.
+- **Divergence 1 / Divergence 2 wording in Filtering semantics body** — the body already introduces them by name (lines 581+). The Invariants section references them semantically ("documented divergence from `pick-tui`") without restating the number; I considered tightening that but decided it's fine — the reader who gets to Invariants has read the body.
+- **File Layout vs New Cargo dependencies** — looked for a seam here (pass 1 said it had "reconciled with File Layout's earlier feature-gate language, which was misleading") and confirmed the current text is consistent: File Layout describes module structure, the Cargo deps subsection explicitly says "not gated behind a Cargo feature". No fix needed.
+- **`bind-key L` override justification** — pass 1 added "is intentional — the new link picker is more useful day-to-day than 'switch to last client,' which is already reachable via other means." That's sufficient. Not adding more.
+- **Concurrent-writers cache contract vs "no frecency" non-goal** — checked for contradiction per pass 2 instructions. No conflict: the cache is an enrichment-latency optimization (gh titles), not a usage history. Frecency would track user-opened links, which is a separate datastore.
+- **F2 invariants vs exec teardown sequence** — checked; they mirror each other. The 5-step teardown in Cross-picker shortcut matches the three F2 invariants in the Action layer (no-yank, exec cleanliness, no runtime shutdown).
+- **`--enrich-deadline-ms` default** — already explicit ("default 3000, `0` disables enrichment entirely"). No fix needed.
+- **Cache format** — JSON structure is fully specified with a concrete example. No hand-wave.
+- **OSC 52 byte-level shape** — fully specified in Clipboard Bridge with the exact escape sequence. No hand-wave.
+
+**Assessment**
+
+The spec is implementation-ready. The Execution Flow pseudocode eliminates the last major reader-reassembly burden and makes the OSC 52 / F2 ordering mechanically obvious. Invariants now have near-complete coverage of body claims. The only remaining soft edges are (a) the concurrent-writers cache contract has no direct test invariant — it's inherently hard to test without racing subprocesses — and (b) the "50ms detection budget" is explicitly soft (target, not hard deadline), which is fine but means there's no CI regression gate on detection performance.
+
+**Suggested focus for pass 3 (if one happens):** this may be the pass to stop. Pass 1 was structural, pass 2 was consistency+flow, and the remaining gaps are either inherently hard to automate (concurrent cache write) or already explicitly soft-budgeted. Pass 3 should either (a) bless the spec as done, or (b) focus narrowly on the `cargo install --path . --force` smoke test plan — verifying the new `pick-links` subcommand integrates cleanly with `pick-tui`'s existing dispatch in `main.rs` and the F2 bidirectional binding exists in `picker.rs`. That's integration-level and might surface a real seam the design didn't anticipate.
+
+### Pass 3 — 2026-04-12
+
+**Mode:** A (declare done). Read the spec end-to-end cold, then verified the four Mode B integration seams against the actual `main.rs` and `picker.rs` source. All four check out.
+
+**Architectural edits: 0 (zero).**
+
+**Integration seams verified against source:**
+
+1. **`main.rs` dispatch** — the clap `Subcommand` enum (L41) is a flat list; adding `PickLinks { json, enrich_deadline_ms }` and a dispatch arm at L1819 is a two-line, mechanical extension. No seam.
+2. **F2 teardown at `picker.rs:686`** — the existing teardown (`disable_raw_mode` + `LeaveAlternateScreen` + return) is a direct subset of the spec's 5-step F2 sequence. F2 in the key handler can call the full teardown then `exec`, which never returns, so the existing `Ok(app.selected_target)` return path is untouched. No `Option<String>` return-shape change required, so the spec's silence on that field is correct — not a gap.
+3. **Module hierarchy** — `main.rs` L1 is `mod picker;` (flat). The spec's `mod link_picker { mod.rs, detect.rs, enrich.rs, tui.rs }` is standard Rust subdirectory module form and coexists trivially with the flat `picker.rs`.
+4. **Test harness** — `picker.rs:990` already has a `#[cfg(test)] mod tests` block with in-tree fixture tests. The spec's detection invariants slot into an identical block in `link_picker/detect.rs`, runnable via `cargo test -p rmux_helper detect::` (which the spec explicitly names). Not hand-wavy.
+
+**Also verified:** `F(1)` is the only function key currently bound in `picker.rs` (L650), so `F(2)` is free. The spec correctly flags that `PICKER_SPEC.md` must be updated in the same changeset.
+
+**End-to-end coherence check:** Execution Flow → Enrichment → Actions → Clipboard Bridge → Cross-picker shortcut → Invariants all tell the same ordering story. OSC 52 timing, F2-no-yank, no-runtime-at-F2, and SIGINT-before-TUI are stated in prose, cross-referenced in Execution Flow, and asserted as invariants — three-way coverage with no contradiction. The `\x1f` tag-separator trick, unicode-width column math, last-writer-wins cache contract, malformed-gh-JSON row-level fallback, and the four navigation invariants all have matching entries. Pipeline is coherent end-to-end.
+
+**Assessment**
+
+**Converged, implementation-ready.** Convergence trend 11 → 5 → 0 is clean. The pull toward making edits was weak — nothing rises to "blocking implementation." The remaining minor items (naming the future `Option<String>` → enum shift, etc.) are implementation mechanics a senior engineer will make in the first 5 minutes of coding. Recommend starting implementation rather than running pass 4.

--- a/docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md
+++ b/docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md
@@ -1,0 +1,871 @@
+# Scrollback Link Picker Design
+
+## Summary
+
+A ratatui-based TUI picker that scans the current tmux pane's scrollback for
+actionable items (GitHub PRs, issues, commits, files, repos, blog posts, other
+URLs, ssh servers, IP addresses), groups them by category, and lets you
+fuzzy-filter, drill into one category, and act on the selected row. Invoked
+from tmux (bound to `C-a L`) or as a standalone shell command.
+
+Sits alongside the existing `rmux_helper pick-tui` session picker — same
+chrome, same keymap family, same dynamic-column layout — but over scrollback
+items instead of tmux units.
+
+## Goals
+
+- **Find any recent link in seconds**, without manual scrollback + mouse selection.
+- **Meaningful titles via parallel `gh` enrichment** — GitHub PRs, issues,
+  and commits show their real title, state, and author pulled from `gh`
+  calls fanned out concurrently, bounded by a global deadline. The TUI
+  shows rich titles when enrichment lands in time and falls back to the
+  scrollback `context` line when it doesn't.
+- **Context-aware actions** — `ssh` a server, open a URL, view a PR in the browser.
+- **Works from any tmux pane** — Mac host tmux, devvm tmux, nested tmux — because the underlying capture is `tmux capture-pane`, not iTerm-specific. Non-tmux terminals are unsupported in v1 (see Error Handling: "Not inside tmux" exits with a message); an iTerm2 Python-API fallback is tracked under v2 roadmap.
+- **Reachable from `pick-tui`** — pressing `F2` in the session picker
+  jumps straight into the link picker for the currently highlighted pane,
+  without returning to the shell. Bidirectional: `F2` in the link picker
+  returns to the session picker.
+
+## Non-goals (v1)
+
+- Fetching a URL's content and walking its outbound links ("recursive link
+  walking"). v2, if ever.
+- Blog-post title scraping (HTML `<title>` fetch). Blog rows show URL path
+  only in v1.
+- IPv6 address detection.
+- Bare commit SHAs (without a surrounding URL). False positives from log hex
+  are too common.
+- General FQDN detection from free text. Only `ssh`-context hostnames and
+  Tailscale-shaped names are trusted.
+- Multi-select / batch actions.
+- Frecency / history of previously-opened links.
+- Streaming enrichment updates into the TUI after launch. v1 blocks on
+  the enrichment deadline, then launches the TUI with a frozen snapshot.
+  v2 may stream updates as they arrive.
+
+## Execution Flow
+
+Happy path and error exits for `rmux_helper pick-links`, in order. This is
+the canonical sequence — subsystem sections below refine individual steps
+but must not reorder them. Ordering matters most around the OSC 52 flush
+(which must land after the TUI's terminal restore) and the `F2` exec path
+(which must skip OSC 52 entirely).
+
+```text
+fn pick_links(args) -> ExitCode {
+  // 1. Resolve pane
+  pane_id = env("TMUX_PANE")
+         ?? tmux_display_message("#{client_active_pane}")   // if $TMUX set
+         ?? return exit(1, "not inside tmux")
+
+  // 2. Capture (sync, fallible)
+  raw = tmux_capture_pane(pane_id)
+        .map_err(|e| return exit(1, e))                     // pane killed race
+
+  // 3. Detect (sync, pure, ~50ms budget, RegexSet single-pass)
+  rows = detect::parse(raw)                                 // Vec<Row>, canonical+deduped
+  if args.json { println!(json(rows)); return exit(0) }     // --json short-circuit
+  if rows.is_empty() { /* fall through to TUI with empty-state message */ }
+
+  // 4. Enrich (async boundary, single block_on)
+  //    SIGINT here -> process exits 130; gh children reaped by init.
+  rows = Runtime::new()?.block_on(async {
+    let cache = cache::load_or_reset();                     // corrupt -> silently reset
+    let (hits, misses) = cache.split(rows);
+    let fresh = fanout(misses, deadline=args.enrich_deadline_ms, cap=8).await;
+    cache.merge_and_write_atomic(&fresh);                   // last-writer-wins, no flock
+    hits.chain(fresh).chain(unenriched_fallbacks).collect()
+  });
+
+  // 5. TUI (sync crossterm; tokio runtime already dropped)
+  loop {
+    event = tui.next_event();
+    match event {
+      Action(row, kind) => { action = Some((row, kind)); break }
+      F2                => { action = Some(SwapToPickTui); break }
+      Quit              => { action = None; break }
+    }
+  }
+
+  // 6. Teardown (order is load-bearing)
+  disable_raw_mode(); LeaveAlternateScreen; drop(terminal);
+  stdout.flush(); stderr.flush();
+
+  // 7. Dispatch (post-teardown so OSC 52 is not swallowed by raw mode)
+  match action {
+    None                 => exit(130),                      // Esc / C-c
+    Some((row, Yank))    => { write_osc52(row); println!("{row.url}"); exit(0) }
+    Some((row, Open))    => { spawn("open", row.url); exit(0) }
+    Some((row, GhWeb))   => { spawn("gh", ["...", "--web"]); exit(0) }
+    Some((row, Ssh))     => { tmux_new_window("ssh", row.host); exit(0) }
+    Some(SwapToPickTui)  => { execvp("rmux_helper", ["pick-tui"]) }
+    // ^ execvp never returns on success; on ENOENT/EACCES the picker loops
+    //   back to step 5 with a bottom-bar error (degenerate case; rare).
+  }
+}
+```
+
+Key ordering invariants visible in this sequence (each is also asserted
+under Invariants below):
+
+- OSC 52 is written **after** `disable_raw_mode` + `LeaveAlternateScreen`
+  and **before** `exit` — inside raw mode tmux can drop the sequence,
+  after exit the process is gone.
+- The `SwapToPickTui` branch (F2) runs `execvp` **without** first writing
+  OSC 52 — it is a picker swap, not an action.
+- `Runtime::new().block_on(...)` returns before the TUI starts, so by the
+  time F2 fires there is no tokio runtime to shut down. Revisit if v2
+  streaming enrichment moves the runtime across the TUI boundary.
+- SIGINT during step 4 exits 130 with the terminal still in cooked mode —
+  no teardown needed because the TUI has not yet taken the terminal.
+
+## Invocation
+
+```bash
+rmux_helper pick-links         # launch the TUI picker
+rmux_helper pick-links --json  # emit JSON of detected items, no TUI (for scripts/tests)
+```
+
+Tmux binding in `shared/.tmux.conf`:
+
+```tmux
+bind-key L display-popup -E -w 95% -h 95% \
+  "TMUX_PANE=#{pane_id} rmux_helper pick-links"
+```
+
+The default tmux binding for `C-a L` is `switch-client -l` (last client),
+which Igor's config does not currently rebind. Overriding it is
+intentional — the new link picker is more useful day-to-day than "switch
+to last client," which is already reachable via other means.
+
+`TMUX_PANE=#{pane_id}` is set explicitly on the bind-key so the popup's
+child process receives the originating pane ID even when tmux doesn't
+propagate `$TMUX_PANE` through the popup pty. This is the only correct
+way to identify the pane to capture — the popup is not a pane itself.
+
+Help and alias conventions follow the existing `pick-tui` pattern (help
+section at top of `.tmux.conf`, command alias in the aliases block).
+
+**Prerequisite:** `set-option -g set-clipboard on` must be set in tmux
+(already the case in `shared/.tmux.conf`) so OSC 52 yank sequences
+propagate to the outer terminal emulator. Without it, `y` / default-Enter
+copy will silently no-op.
+
+## Scrollback Capture
+
+Source = the current tmux pane's full scrollback:
+
+```bash
+tmux capture-pane -p -J -e -S - -E - -t "$TMUX_PANE"
+```
+
+- `-S -` / `-E -`: from start of history to end of visible area.
+- `-J`: join wrapped lines (so a URL broken across two display rows is one logical line).
+- `-e`: include ANSI escapes for the preview pane.
+- `-t "$TMUX_PANE"`: the invoking pane, not the popup's own pane.
+
+If `$TMUX_PANE` is unset:
+
+- If `$TMUX` is set, ask tmux directly:
+  `tmux display-message -p -t '#{client_active_pane}' '#{pane_id}'`.
+  Note that when launched from a `display-popup`, `$TMUX_PANE` is _not_
+  reliably forwarded by tmux, which is why the key binding sets it
+  explicitly — this branch is the fallback for invocation from a plain
+  shell inside a tmux pane.
+- If `$TMUX` is unset, exit 1 with
+  `pick-links: not inside tmux; nothing to capture` on stderr.
+
+If `$TMUX_PANE` is set but `tmux capture-pane -t "$TMUX_PANE"` returns
+nonzero (pane was killed between invocation and capture), exit 1 with
+the underlying tmux error on stderr. The pane-lookup and capture are two
+separate tmux calls and the pane can vanish between them; this is not
+treated as a crash.
+
+No iTerm2 Python API fallback in v1 — keeping it cross-terminal.
+
+Capture is one-shot at launch; no live refresh.
+
+## Categories & Detection
+
+Categories are listed in this display order. Detection is applied per line;
+each line can contribute to multiple categories if multiple distinct items
+appear in it.
+
+| #   | Category          | Detection                                                         | `key` / `repo-or-host`       |
+| --- | ----------------- | ----------------------------------------------------------------- | ---------------------------- |
+| 1   | **Pull Requests** | `github.com/OWNER/REPO/pull/N(?:#\S*)?`                           | `#N` / `REPO`                |
+| 2   | **Issues**        | `github.com/OWNER/REPO/issues/N(?:#\S*)?`                         | `#N` / `REPO`                |
+| 3   | **Commits**       | `github.com/OWNER/REPO/commit/[a-f0-9]{7,40}`                     | `SHA[:7]` / `REPO`           |
+| 4   | **Files**         | `github.com/OWNER/REPO/(blob\|tree)/REF/PATH(?:#L\d+(?:-L\d+)?)?` | `basename[:Lstart]` / `REPO` |
+| 5   | **Repos**         | `github.com/OWNER/REPO` with nothing after                        | `OWNER` / `REPO`             |
+| 6   | **Blog**          | host ∈ blog allowlist (v1: `idvorkin.github.io`)                  | last path segment / host     |
+| 7   | **Other links**   | any `https?://` not matched above                                 | last path segment / host     |
+| 8   | **Servers**       | `ssh` context OR Tailscale-shaped names                           | hostname / `—`               |
+| 9   | **IPs**           | IPv4 with version-string suppression                              | dotted-quad / `—`            |
+
+The `context` column (see Layout) comes from the scrollback line where the
+item was found, not from the item itself, so every category gets a readable
+third column for free. For GitHub PR/Issue/Commit rows, the context column
+is replaced by the enriched `gh` title when enrichment succeeds (see
+Enrichment section).
+
+## Enrichment (parallel `gh` fan-out)
+
+GitHub PR, Issue, and Commit rows are enriched with real titles and state
+via parallel `gh` calls before the TUI launches.
+
+### Pipeline
+
+The pipeline is strictly phased: **capture → parse → enrich → TUI**. Each
+phase fully completes before the next begins. There are no threads feeding
+data into the running TUI in v1 (streaming enrichment is v2). Concretely:
+
+- **Capture** and **parse** are synchronous Rust on the main thread.
+- **Enrich** runs a `tokio` current-thread runtime constructed on the main
+  thread (`Runtime::new()?.block_on(enrich(...))`). The TUI is crossterm
+  (sync); it is never invoked from within an async context, and no
+  `tokio::spawn_blocking` trampoline is needed because the TUI only starts
+  after `block_on` returns.
+- **TUI** takes ownership of a `Vec<Row>` and never re-enters tokio.
+
+This phasing keeps the async boundary tiny (one function: `enrich(rows,
+deadline) -> Vec<Row>`) and lets the detection module remain a leaf crate
+with no async dependencies.
+
+1. **Parse & dedup** (fast, synchronous, <50ms). Produces the full list of
+   rows across all categories.
+2. **Cache lookup** — for each PR/Issue/Commit row, check
+   `~/.cache/rmux_helper/gh-links.json` for a cached enrichment (keyed by
+   canonical URL, TTL 1 hour). Cache hits are applied immediately.
+3. **Parallel fan-out** — for the remaining PR/Issue/Commit rows, issue
+   concurrent `gh` calls:
+   - PR: `gh pr view N -R OWNER/REPO --json title,state,author,isDraft`
+   - Issue: `gh issue view N -R OWNER/REPO --json title,state,author`
+   - Commit: `gh api repos/OWNER/REPO/commits/SHA --jq '{title: .commit.message | split("\n")[0], author: .commit.author.name}'`
+4. **Deadline** — global 3-second budget for the whole fan-out (not
+   per-call). Whatever finishes in time gets used; the rest fall back to
+   the `context` line. Budget is configurable via `--enrich-deadline-ms`
+   (default 3000, `0` disables enrichment entirely).
+5. **Cache write** — successful results are merged into the cache JSON.
+6. **TUI launch** — ratatui starts with a frozen snapshot of enriched +
+   fallback rows. No in-flight updates during the session (that's v2).
+
+### Concurrency cap
+
+`gh` calls run concurrently via a bounded semaphore (default 8 in-flight).
+This avoids opening 100+ processes if scrollback contains 100 distinct PRs,
+while still saturating typical use cases.
+
+### Degradation
+
+- **`gh` missing from PATH** — enrichment is skipped entirely; all rows
+  use context column. Top bar shows `(gh not found — install for PR titles)`
+  for one second at startup, then disappears.
+- **`gh` present but not authenticated** — same as missing. No retry.
+- **Network unreachable** — deadline hits, rows fall back to context.
+- **Individual call errors** (404, private repo without access, bad SHA) —
+  that row falls back to context silently.
+- **Malformed `gh` JSON output** (schema drift across `gh` versions, mid-
+  stream truncation, non-UTF-8) — treated as an individual call error:
+  that row falls back to context. `serde_json::from_slice` failure is
+  swallowed at the row level; no panic, no global abort, no log.
+
+### Cache format
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "https://github.com/idvorkin-ai-tools/settings/pull/68": {
+      "fetched_at": "2026-04-12T10:23:15Z",
+      "title": "rbv: show install hint when bv is missing",
+      "state": "MERGED",
+      "author": "idvorkin-ai-tools",
+      "is_draft": false
+    }
+  }
+}
+```
+
+Cache file is rewritten atomically (temp file + rename). Corrupt cache is
+deleted and rebuilt silently.
+
+**Concurrent writers.** Two pickers invoked in parallel (two panes, two
+popups) may both write the cache. The contract is last-writer-wins at the
+file level — each writer reads, merges its own new entries, and renames
+over the existing file. Entries written by one picker but not yet visible
+to the other are re-fetched on the next run; this is acceptable because
+`gh` calls are idempotent and the cache is a latency optimization, not a
+source of truth. No advisory file lock (`flock`) in v1; if contention
+becomes visible in practice, add one.
+
+**SIGINT during enrichment.** The 3-second enrichment window runs before
+the TUI acquires the terminal, so the controlling terminal's Ctrl-C still
+delivers SIGINT normally. On SIGINT the process exits 130 immediately;
+in-flight `gh` child processes are reaped by the default tokio runtime
+drop (which kills the async tasks but not the already-spawned child
+processes — they are left to finish and be reaped by init, which is fine
+because `gh` is short-lived and stateless). No custom signal handler in
+v1.
+
+### Enriched display
+
+When enrichment succeeds, the leaf row shows the enriched title in the
+`context` column, prefixed with a state glyph:
+
+| State                    | Glyph | Color          |
+| ------------------------ | ----- | -------------- |
+| Open PR / open issue     | `◉`   | `LightGreen`   |
+| Merged PR                | `●`   | `LightMagenta` |
+| Closed PR / closed issue | `✕`   | `DarkGray`     |
+| Draft PR                 | `◐`   | `LightYellow`  |
+| Commit                   | `⎇`   | `LightBlue`    |
+
+Example enriched row:
+
+```
+├─ #68  settings  ● rbv: show install hint when bv is missing  ×2
+```
+
+Non-GitHub categories (Blog, Other, Servers, IPs) are unaffected — they use
+the context line unchanged.
+
+### URL regex (shared)
+
+```
+https?://[^\s<>"'`()\[\]{}]+
+```
+
+Trailing `.,;:!?)]}>'"` is stripped after match (common punctuation artifacts
+from prose). A trailing `/` is preserved (semantically significant for some
+sites).
+
+### GitHub canonicalization
+
+All GitHub rows canonicalize to:
+
+```
+https://github.com/OWNER/REPO[/pull/N|/issues/N|/commit/SHA|/blob|tree/REF/PATH]
+```
+
+- Strip `?utm_*`, `?tab=`, `?w=`, `?notification_referrer_id`, `?diff=`
+  query params.
+- Strip URL fragment unless it's `#LN` on a file URL (line anchors are kept).
+- `github.com` and `www.github.com` collapse to the same canonical host.
+
+### Server detection
+
+Two sources:
+
+1. **ssh context** — matches of the form:
+
+   ```
+   \bssh\b(?:\s+-\S+)*\s+(?:([a-zA-Z_][\w-]*)@)?([a-zA-Z0-9][\w.-]*[a-zA-Z0-9])\b
+   ```
+
+   The `host` group is captured; the `user@` prefix is discarded for dedup
+   (so `ssh igor@c-5001` and `ssh c-5001` merge).
+
+2. **Tailscale-shaped names** — matches of:
+
+   ```
+   \bc-\d{4,5}\b
+   \b[a-z][a-z0-9-]*\.ts\.net\b
+   ```
+
+   These match even outside `ssh` context because they're unambiguous in
+   Igor's environment. (The `c-\d{4,5}` pattern is specifically chosen to
+   match `c-5001` and not match `c-2` or `c-123456`.)
+
+### IP detection
+
+```
+(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?![\w.])
+```
+
+Plus these suppressions:
+
+- Preceded by `v` with optional whitespace (version strings: `v4.6.0.1`).
+- Followed by `.\d` (longer dotted sequences: `1.2.3.4.5` → not an IP).
+- Any octet > 255 — rejected.
+- `0.0.0.0` and `255.255.255.255` — kept (valid in context).
+- Private ranges **not** filtered (Igor's Tailscale is `100.64.0.0/10`).
+
+## Deduplication & Ordering
+
+- **Row key** = `(category, canonical_string)`. `canonical_string` is the
+  canonical URL for link rows, the bare host/IP for server/IP rows.
+- Duplicates within a category collapse into a single row with a `×N`
+  occurrence count (displayed only when N > 1).
+- **Ordering within a category** = most-recent first (= largest line index
+  in the captured scrollback = closest to the bottom).
+- **Ordering of categories** = fixed as listed above. Empty categories hide
+  their header entirely.
+
+## Layout & Display
+
+Reuses the `pick-tui` chrome wholesale: ratatui frame, dynamic column widths,
+horizontal/vertical auto-switch, `ansi_to_tui` preview.
+
+### Top-bar
+
+```
+pick> {query}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh F2:sess ?:help
+```
+
+In drilled-in mode the top-bar shows a breadcrumb:
+
+```
+pick> {query}_  │ Links › Pull Requests  │ ↑↓ Enter:act ←:back F2:sess ?:help
+```
+
+### Rows
+
+Category headers are selectable (unlike session picker headers). Two row
+kinds:
+
+- **Category header**: `⊟ Category (count)` — Cyan, bold. Shows total matched
+  rows in that category post-filter.
+- **Leaf**: indented `├─`/`└─` tree prefix + four columns, same coloring as
+  `pick-tui`:
+
+  | Col            | Content                                                                                   | Color          | Min width |
+  | -------------- | ----------------------------------------------------------------------------------------- | -------------- | --------- |
+  | `key`          | `#68`, `a22bc17`, filename, host, IP                                                      | `LightYellow`  | 6         |
+  | `repo-or-host` | `settings`, `idvorkin.github.io`, `—`                                                     | `LightGreen`   | 6         |
+  | `context`      | scrollback line the item was found on, URL/host stripped, whitespace collapsed, truncated | `LightMagenta` | variable  |
+  | `count`        | `×N` (only when N > 1)                                                                    | `LightCyan`    | 0         |
+
+The `context` column is the v1 stand-in for enriched titles. It takes the
+_most recent_ scrollback line where the item appeared, removes the matched
+URL/host/IP substring, collapses internal whitespace, trims, and truncates
+with `…` to fit the column. This means a PR URL that appeared on a
+`Merge pull request #68 from idvorkin-ai-tools/rbv-install-hint` line
+displays that line as the title — free enrichment without API calls.
+
+When the scrollback line is _just_ the URL with no surrounding text, the
+context falls back to the URL path.
+
+Example (mix of enriched titles and context-line fallbacks; `context`
+column is truncated to fit):
+
+```
+⊟ Pull Requests (3)
+├─ #68    settings        ● rbv: show install hint when bv is…    ×2
+├─ #67    settings        ● feat: add `just setup` and post-merge…
+└─ #1234  claude-code     ◉ fix subagent hang on large plans
+⊟ Issues (1)
+└─ #42    settings        ◉ tmux pick hangs on M-x in drill-in
+⊟ Commits (1)
+└─ a22bc17 settings       ⎇ Merge pull request #68 from idvorkin-…
+⊟ Files (1)
+└─ picker.rs:L42 settings src/picker.rs:42 — fn draw_picker
+⊟ Blog (2)
+├─ posts  idvorkin.github.io  /posts/ai-agents/
+└─ posts  idvorkin.github.io  /posts/pro-tips/
+⊟ Servers (1)
+└─ c-5001 —                   ssh c-5001 "uname -a"                 ×7
+⊟ IPs (1)
+└─ 100.64.1.5 —               Tailscale peer 100.64.1.5 is online
+```
+
+### Preview pane
+
+Shows the scrollback context around the _most recent_ occurrence of the
+selected row: 3 lines above, the matching line, and 3 lines below, with ANSI
+colors preserved via `ansi_to_tui`. For category headers, the preview shows a
+short summary: `Category: Pull Requests — 3 matches, newest: #68`.
+
+### Layout modes
+
+Same as `pick-tui`: horizontal (list left, preview right) when
+`area.width / 2 >= list_width_needed`, otherwise vertical. `C-l` toggles.
+
+### Unicode width in dynamic columns
+
+GitHub PR titles routinely contain CJK, emoji, and combining characters.
+Column-width math uses the `unicode-width` crate (`UnicodeWidthStr::width`)
+for both the needed-width calculation and the truncation step, not
+`str::len` or `chars().count()`. The truncation ellipsis (`…`) is counted
+as width 1. This matters for the `context` column specifically, where
+enriched titles are displayed unmodified and can easily be double-width.
+
+### Detection performance
+
+Scrollback capture can exceed a megabyte on long-lived panes. Detection
+runs each line through a precompiled `regex::RegexSet` of all nine
+category regexes (one pass), then for each matching line re-runs the
+individual regex only on the matched categories. This keeps the common
+case (scrollback with no interesting content) at O(input) with a single
+DFA traversal. Detection is bounded to complete inside the 50ms budget
+mentioned under Pipeline step 1; if a pathological input overruns that,
+the budget is a target, not a hard deadline (the user just waits).
+
+## Navigation
+
+### Flat mode (default)
+
+- `↑` / `C-p` / `↓` / `C-n` — move selection, skipping separators but _not_
+  category headers (they are selectable).
+- `Enter` on a **leaf** — perform default action (see Actions below).
+- `Enter` on a **category header** — drill into that category.
+- `→` — drill into the category of the currently selected row (leaf or
+  header).
+- `1`–`9` — jump straight into the Nth non-empty category's drilled-in
+  view (1-indexed, in display order). If N exceeds the count of non-empty
+  categories, no-op.
+- `←` — no-op in flat mode.
+- `Tab` / `S-Tab` — no-op (reserved for future toggle; do not bind to
+  drill-in/out because those should be reachable without leaving the home
+  row via `→` or `Enter`).
+- `F2` — **switch to session picker** (`pick-tui`). Current picker exits;
+  session picker launches. See Cross-picker shortcut below.
+- Typing printable ASCII — append to query; filter rows and headers.
+- `C-l` — toggle layout.
+- `?` / `C-/` — help overlay.
+- `Esc` — quit. `C-c` — clear query if non-empty, else quit.
+
+### Drilled-in mode
+
+- `←` — pop back to flat mode. Query is **preserved** across the
+  transition (so you can drill in, refine, then pop out with your query
+  still active).
+- `Esc` — first press pops back to flat mode (like `←`); second press
+  quits. This keeps `Esc` as the universal "back / quit" key without
+  needing a separate drill-out binding.
+- `→` / `Enter on header` — no-op (already drilled in, no header visible).
+- Everything else — same as flat mode.
+
+Only one level of drill-down in v1. No sub-grouping by repo inside a
+category. Recursive "walk into fetched content" is v2.
+
+### Cross-picker shortcut
+
+`F2` toggles between the session picker (`pick-tui`) and the link picker
+(`pick-links`). The shortcut is bidirectional and stateless — whichever
+picker is open, `F2` closes it and launches the other against the same
+originating tmux pane.
+
+Implementation contract:
+
+- Inside `pick-tui`: `F2` cleanly tears down the TUI and execs
+  `rmux_helper pick-links`. Teardown sequence, in order:
+  1. `disable_raw_mode()`
+  2. `execute!(terminal.backend_mut(), LeaveAlternateScreen)`
+  3. drop `terminal` (forces a final crossterm flush)
+  4. `io::stdout().flush()?` and `io::stderr().flush()?`
+  5. `std::os::unix::process::CommandExt::exec()` on the target command
+     with `TMUX_PANE` forwarded in the environment
+- Inside `pick-links`: `F2` does the mirror — exec `rmux_helper pick-tui`.
+- **Never yank on F2.** The `F2` path must not write OSC 52 bytes (see
+  Clipboard Bridge) — it's a picker swap, not an action.
+- **Runtime teardown.** Inside `pick-links` the tokio runtime has already
+  returned from `block_on(enrich(...))` before the TUI started, so there
+  is no running runtime at `F2` time — nothing to shut down. If streaming
+  enrichment ever moves into v2, the F2 path will need to add a runtime
+  shutdown step before `exec`.
+- `exec` replaces the process image, so the picker's own exit code is
+  irrelevant — the incoming process owns the terminal and decides its own
+  exit. If `exec` itself fails (`ENOENT` on the target binary, `EACCES`)
+  the picker stays open and shows a bottom-bar error (see Error Handling).
+- No "restore to previous picker" on `Esc` after a `F2` swap. The user
+  exits normally with `Esc` / `C-c` and lands back at the shell (or the
+  tmux popup closes). Preserving a picker-history stack is out of scope.
+
+PICKER_SPEC.md must be updated in the same changeset to document `F2` on
+the `pick-tui` side.
+
+`F2` was chosen because function keys don't collide with the "typing
+letters filters the search" rule that both pickers share, and F1 is
+already taken for help. `Alt-L` was considered but Alt-modified keys are
+inconsistent across terminal emulators.
+
+### Filtering semantics
+
+Same token-based fuzzy match as `pick-tui`, with two deliberate
+divergences called out below. Shared rules:
+
+- Query splits on whitespace; all tokens must be present.
+- Auto-split at letter/digit boundaries: `pr68` → `pr` + `68`.
+- Non-digit tokens match the row's full search string (see below).
+- Digit tokens match **the `key` column only** (so `68` finds `#68` but not
+  a random `68` in a context line).
+- Case-insensitive.
+
+**Divergence 1 — multi-digit token rule.** `pick-tui` splits multi-digit
+tokens per-digit (`14` matches `1;4`) because tmux indices are
+one-digit-per-position. That rule is _not_ inherited here: `68` must
+substring-match the key column as `68`, so `#68` matches but `#683` also
+matches (substring), while `#86` does not. This is intentional — PR
+numbers are whole integers, not position-indexed, so per-digit splitting
+would produce spurious matches.
+
+**Divergence 2 — category short-name tag matches on prefix only.** Each
+row's search string begins with a category short-name tag followed by a
+unit-separator byte (`\x1f`):
+
+```
+<tag>\x1f<key> <repo-or-host> <context> <canonical>
+```
+
+where `<tag>` ∈ `pr`, `issue`, `commit`, `file`, `repo`, `blog`, `link`,
+`server`, `ip`. Because tokens are substring-matched and `\x1f` never
+appears in user text or in any rendered column, typing `pr` matches only
+via the tag prefix and never matches "prose" in a context line. Typing
+`link` matches the Other-links category specifically, not all URL-shaped
+rows. In drilled-in mode the tag is still present on each row but
+matching it is a no-op (you're already in one category).
+
+Columns composing the row's search string, after the `\x1f` separator, in
+order:
+
+1. The `key` column.
+2. The `repo-or-host` column.
+3. The `context` column.
+4. The canonical URL / host / IP string.
+
+In flat mode, a category header is shown iff at least one of its rows
+matches. In drilled-in mode, the header is replaced by the breadcrumb.
+
+## Actions
+
+All actions take the selected leaf and branch on category.
+
+### Default (`Enter`)
+
+| Category                                              | Action                                                                                                                                   |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| PRs / Issues / Commits / Files / Repos / Blog / Other | **Yank** (OSC 52) + **print URL to stdout**                                                                                              |
+| Servers / IPs                                         | `tmux new-window -t "$TMUX_PANE" -c '#{pane_current_path}' "ssh <host>"` — new window in the session of the invoking pane, not the popup |
+
+### Override keys (on selected leaf)
+
+- `y` — **Yank only**: copy the canonical URL or host to clipboard via OSC 52.
+  Prints `yanked: <value>` to stdout. Works across tmux/iTerm/SSH boundaries
+  because OSC 52 rides the terminal escape stream.
+- `o` — **Open**: run `open` (macOS) or `xdg-open` (Linux) on the URL. For
+  Server/IP rows, opens `http://host` in a browser (useful for admin UIs).
+  Exits the picker on success.
+- `g` — **GitHub web**: for PR / Issue / Commit / File / Repo rows, runs
+  `gh <kind> view --web -R OWNER/REPO <N-or-ref>`. No-op for non-GitHub
+  categories. Requires `gh` on PATH; on failure (gh missing, not
+  authenticated) the picker shows a one-line error in the bottom bar and
+  stays open rather than exiting. Note: this shells out to `gh` to open a
+  browser, it does not fetch or parse data — distinct from the blocking
+  pre-TUI enrichment fan-out under Enrichment above.
+- `s` — **ssh**: force ssh action on any row where a hostname can be
+  extracted (Server, IP, or a URL's host).
+
+### Exit behavior
+
+- Action success — picker exits 0 and the spawned action runs (new tmux
+  window, browser, etc.). Any output (`yanked: …`, the URL) goes to stdout
+  of the picker process so a script wrapper can consume it.
+- `Esc` / `C-c` with no pending action — exit 130 (conventional "canceled").
+
+## Clipboard Bridge (devvm → Mac host)
+
+The picker may run inside the devvm (Linux OrbStack VM) while the user's
+clipboard lives on the Mac host. Copy actions use the OSC 52 sequence:
+
+```
+\e]52;c;<base64-of-payload>\e\\
+```
+
+written directly to `/dev/tty`. Tmux must have `set-option -g set-clipboard
+on` (it does in `shared/.tmux.conf` already) so the sequence propagates to
+the outer terminal. iTerm2 honors OSC 52 by default; Ghostty honors it when
+enabled.
+
+No shell-out to `pbcopy` / `xclip` / `wl-copy` — OSC 52 is the only path that
+works uniformly across Mac-host tmux, devvm tmux, and bare shells.
+
+**Write ordering:** the OSC 52 escape must be written _after_ ratatui
+`disable_raw_mode()` + `LeaveAlternateScreen` but _before_ `std::process::exit`
+/ returning from `main`. Writing inside raw mode risks tmux dropping the
+sequence; writing after process exit is too late. Implementation: flush
+the terminal restore, open `/dev/tty` for writing, write the bytes, drop
+the handle, then exit.
+
+## Configuration
+
+v1 has a single configuration constant, a hostname allowlist for the **Blog**
+category:
+
+```rust
+const BLOG_HOSTS: &[&str] = &["idvorkin.github.io"];
+```
+
+Adding a blog site means editing this list and rebuilding. A real config file
+(TOML next to `rmux_helper`'s binary, or `$XDG_CONFIG_HOME/rmux_helper/`)
+is deferred until the list grows past ~3 entries.
+
+## File Layout
+
+```
+rust/tmux_helper/
+  src/
+    main.rs                # existing CLI dispatch — adds `pick-links` subcommand
+    picker.rs              # existing — gains F2 handler that execs pick-links
+    link_picker/
+      mod.rs               # public entry: capture → detect → enrich → TUI
+      detect.rs            # pure regex/parsing layer, unit-tested
+      enrich.rs            # parallel gh fan-out + cache, deadline-bounded
+      tui.rs               # ratatui rendering + key handling
+  LINK_PICKER_SPEC.md      # new: behavior contract (mirror of PICKER_SPEC.md style)
+  PICKER_SPEC.md           # existing — gets F2 cross-picker entry
+```
+
+Detection lives in its own module with no ratatui / tokio dependency, so
+it's unit-testable with plain `cargo test` over fixture strings. The
+enrichment module owns the tokio runtime; it is the only module that
+touches async code, keeping the TUI and detection layers sync.
+
+Cache file: `~/.cache/rmux_helper/gh-links.json` (XDG-conforming; override
+with `$XDG_CACHE_HOME`).
+
+### New Cargo dependencies
+
+This feature is the first async code in `rmux_helper`. `Cargo.toml`
+gains, at minimum:
+
+- `tokio = { version = "1", features = ["rt", "process", "time", "sync", "macros"] }` — current-thread runtime, `Command`, `timeout`, `Semaphore`. Not `rt-multi-thread`; single-thread is sufficient for `gh` fan-out.
+- `regex = "1"` — category detection.
+- `serde = { version = "1", features = ["derive"] }` and `serde_json = "1"` — cache format and `--json` output.
+- `unicode-width = "0.2"` — column math (see Layout).
+- `base64 = "0.22"` — OSC 52 payload encoding.
+- `dirs = "5"` (or manual `$XDG_CACHE_HOME`/`$HOME` lookup) — cache path resolution.
+
+These roughly double the clean release build time of the crate
+(currently small — only `ratatui`/`crossterm`/`sysinfo`). The
+`link_picker` module is **not** gated behind a Cargo feature — there's no
+"lean" build of `rmux_helper` to protect — so the deps are unconditional.
+Detection's unit tests compile only `detect.rs` + `regex` + `unicode-width`,
+so `cargo test -p rmux_helper detect::` stays fast even as the async code
+grows.
+
+## Error Handling
+
+- **Not inside tmux** — exit 1 with `pick-links: not inside tmux; nothing
+to capture` on stderr. No TUI shown.
+- **Empty scrollback / zero items** — render the TUI with a centered
+  `No links, servers, or IPs in scrollback` message; `Esc` / `Enter` exit 0.
+- **Capture failure** — exit 1 with the underlying `tmux capture-pane`
+  error on stderr.
+- **Enrichment deadline hit** — silent. Rows that didn't get back in time
+  use context-line fallback. Top bar shows `enriched M/N` briefly at
+  launch (N = rows eligible for enrichment, M = how many succeeded).
+- **`gh` missing / unauthenticated** — top bar shows
+  `(gh not found — install for PR titles)` for ~1s at launch; enrichment
+  is skipped for the session, no retries.
+- **Cache corrupt** — cache file is deleted and rebuilt silently.
+- **Action failure** (`open`, `xdg-open`, `gh`, `tmux new-window`) — bottom-
+  bar error, picker stays open. User can retry with a different key or
+  quit.
+- **`F2` cross-picker exec failure** — picker stays open, bottom-bar
+  error: `exec rmux_helper pick-tui: <errno>`.
+
+## Invariants (for tests)
+
+Detection (pure, unit-tested):
+
+- **Idempotent on the same scrollback**: two runs over the same input
+  produce the same JSON output (stable ordering = category index, then
+  most-recent-first within, ties broken by canonical string).
+- **Dedup correctness**: `ssh igor@c-5001`, `ssh c-5001`, and a bare `c-5001`
+  in a log line all merge into one Server row with `×3`.
+- **No cross-category duplication** for the same canonical URL: a PR URL
+  contributes to Pull Requests only, not to Other links, even though it
+  matches the generic URL regex.
+- **URL trailing punctuation stripped**: `"see https://github.com/a/b/pull/1."`
+  yields `…/pull/1`, not `…/pull/1.`.
+- **IP suppression**: `"claude-opus 4.6.0.1"` does not yield `4.6.0.1` as
+  an IP (prefixed with version-shaped token).
+- **Version range kept**: `"100.64.1.5 is up"` yields `100.64.1.5` as IP.
+
+Enrichment (integration-tested with `gh` stubbed):
+
+- **Deadline is a single shared wall clock, not per-call**: the 3000ms
+  budget starts when enrichment begins. Any `gh` call still in flight
+  when the budget expires is cancelled and its row falls back to the
+  context line.
+- **Cache hits skip the network**: if all eligible rows are cache-hit,
+  total enrichment time is under 50ms (file read + JSON parse).
+- **Concurrency cap is honored**: at most 8 `gh` processes in flight at
+  any moment, regardless of total row count.
+- **Fallback is row-level, not global**: one row failing to enrich does
+  not cancel the others.
+- **Malformed `gh` JSON falls back gracefully**: a `gh` call returning
+  `{"title": 42}` (wrong type), a truncated stream, or non-UTF-8 bytes is
+  treated as a row-level failure and does not panic or abort the fan-out.
+- **Cache write is atomic**: on crash mid-write, the cache file is either
+  the old version or the new version, never a truncated mix.
+
+Filtering:
+
+- **Category tag does not leak into content match**: a `context` column
+  containing the literal string `prose` does not match the `pr` token.
+  Implemented via the `\x1f`-separator trick described under Filtering
+  semantics.
+- **Digit-token substring (not per-digit split)**: token `68` matches key
+  `#68` and key `#683`, but not key `#86`. This is the documented
+  divergence from `pick-tui`.
+
+Layout / rendering:
+
+- **Unicode-aware column widths**: a `context` column containing a
+  double-width CJK title does not cause later rows to shift by one
+  character. Enforced via `unicode-width::UnicodeWidthStr::width` in
+  column-budget math; unit-testable with fixture strings.
+- **Context column truncation is canonical**: for a given column-width
+  budget, the truncated-with-ellipsis form of a row's context is stable
+  across runs (idempotent), so snapshot tests on rendered output are
+  meaningful.
+- **Empty categories render no header**: a category with zero matching
+  rows (pre-filter or post-filter) emits no `⊟ Category (0)` line.
+- **Category display order is fixed**: categories always render in the
+  order defined in the Categories table (PR, Issue, Commit, File, Repo,
+  Blog, Other, Server, IP), regardless of which was matched first in
+  scrollback.
+
+Navigation:
+
+- **Query preserved across drill transitions**: drill into a category
+  with query `foo`, press `←` to pop back — the query is still `foo` and
+  the flat-mode filter is re-applied with it.
+- **`Esc` double-press to quit from drill-in**: first `Esc` pops to flat
+  mode (equivalent to `←`), second `Esc` quits. A single `Esc` from flat
+  mode quits directly.
+
+Action layer:
+
+- **OSC 52 shape**: yanked bytes always written to `/dev/tty` directly, never
+  to stdout, so stdout stays a pure data channel for script wrappers.
+- **OSC 52 timing**: the escape sequence is written after raw mode is
+  disabled and the alternate screen is left, but before process exit.
+- **F2 does not yank**: the `F2` swap path must not write any OSC 52
+  bytes, even if the currently-selected row would have yanked on `Enter`.
+- **F2 exec terminal cleanliness**: the terminal is fully restored
+  (raw-mode off, alternate screen left, stdout/stderr flushed) before
+  `execvp`, so the incoming picker sees a clean terminal state.
+- **SIGINT before TUI**: Ctrl-C during the enrichment window exits 130
+  without rendering the TUI; no OSC 52 escape is emitted.
+
+## Out of scope (v2+ roadmap)
+
+- **Streaming enrichment updates** — push `gh` results into the running
+  TUI via an mpsc channel so rows enrich visibly after launch instead of
+  blocking on a pre-TUI deadline.
+- **Blog-post title scraping** — fetch blog URLs' HTML and extract
+  `<title>` for the `context` column. Needs its own timeout + cache story.
+- **Recursive link walking** — "walk into" a URL by fetching its content
+  and re-parsing for nested links, usable with `→` repeatedly.
+- **Frecency** — last-opened rows float to the top of their category.
+- **Multi-select + batch** — mark several rows with `Space`, act on all.
+- **IPv6 detection**.
+- **Config file** for blog allowlist, server-name patterns, enabled categories.
+- **iTerm2 Python API fallback** for non-tmux terminals, using
+  `iterm2.Session.async_get_contents` over the full scrollback range.
+- **Picker-history stack** — `Esc` after an `F2` swap could return to the
+  previous picker instead of the shell.

--- a/rust/tmux_helper/Cargo.lock
+++ b/rust/tmux_helper/Cargo.lock
@@ -87,12 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +700,6 @@ version = "0.1.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
- "base64",
  "clap",
  "crossterm 0.29.0",
  "dirs",

--- a/rust/tmux_helper/Cargo.lock
+++ b/rust/tmux_helper/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,10 +87,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cassowary"
@@ -274,6 +295,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +357,17 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -398,6 +451,15 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -510,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +605,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -587,16 +661,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rmux_helper"
 version = "0.1.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
+ "base64",
  "clap",
  "crossterm 0.29.0",
+ "dirs",
  "hostname",
  "ratatui",
+ "regex",
+ "serde",
+ "serde_json",
  "sysinfo",
+ "tokio",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -657,6 +778,49 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "signal-hook"
@@ -773,6 +937,32 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -958,11 +1148,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -976,18 +1175,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1001,15 +1215,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1025,9 +1257,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1037,12 +1281,30 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/tmux_helper/Cargo.toml
+++ b/rust/tmux_helper/Cargo.toml
@@ -15,6 +15,13 @@ ratatui = "0.29"
 crossterm = "0.29"
 ansi-to-tui = "7"
 hostname = "0.4"
+tokio = { version = "1", features = ["rt", "process", "time", "sync", "macros"] }
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+unicode-width = "0.2"
+base64 = "0.22"
+dirs = "5"
 
 [profile.release]
 opt-level = 3

--- a/rust/tmux_helper/Cargo.toml
+++ b/rust/tmux_helper/Cargo.toml
@@ -20,7 +20,6 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 unicode-width = "0.2"
-base64 = "0.22"
 dirs = "5"
 
 [profile.release]

--- a/rust/tmux_helper/LINK_PICKER_SPEC.md
+++ b/rust/tmux_helper/LINK_PICKER_SPEC.md
@@ -1,0 +1,79 @@
+# rmux_helper pick-links Specification
+
+## Categories (fixed display order)
+
+1. Pull Requests — `github.com/OWNER/REPO/pull/N`
+2. Issues — `github.com/OWNER/REPO/issues/N`
+3. Commits — `github.com/OWNER/REPO/commit/SHA`
+4. Files — `github.com/OWNER/REPO/(blob|tree)/REF/PATH`
+5. Repos — `github.com/OWNER/REPO` (bare)
+6. Blog — host ∈ `BLOG_HOSTS` (v1: `idvorkin.github.io`)
+7. Other links — any `https?://` not matched above
+8. Servers — `ssh` context + Tailscale (`c-NNNN`, `*.ts.net`)
+9. IPs — IPv4 with version-string suppression
+
+## Dedup
+
+Row key = `(category, canonical)`. Duplicates collapse into one row with a `×N` count.
+
+## Ordering
+
+Categories: fixed order above. Within a category: most-recent line first (closest to bottom).
+
+## Columns
+
+| Col           | Color                        | Content                                                     |
+| ------------- | ---------------------------- | ----------------------------------------------------------- |
+| key           | LightYellow                  | `#N`, `SHA[:7]`, filename, host, IP                         |
+| repo-or-host  | LightGreen                   | repo name, host, or `—`                                     |
+| glyph + title | state-colored + LightMagenta | state glyph from enriched gh view; `context` line otherwise |
+| count         | LightCyan                    | `×N` only when N > 1                                        |
+
+## Navigation
+
+- `↑`/`↓` or `C-p`/`C-n`: move selection (headers are selectable — do not skip)
+- `→` or `Enter` on category header: drill into that category
+- `1`–`9`: jump into Nth non-empty category (query must be empty)
+- `←`: drill out (in drilled-in mode)
+- `Esc`: drill out (first press) or quit (if already flat)
+- `Tab` / `S-Tab`: reserved, no-op
+- `F2`: swap to `pick-tui` (bidirectional)
+- `F1`: help (reserved, TODO v1.1)
+- `C-l`: toggle layout (horizontal/vertical)
+- `C-c`: clear query or quit
+
+## Actions
+
+Default `Enter` (on leaf):
+
+- URL categories → OSC 52 yank + print URL to stdout
+- Servers / IPs → `tmux new-window -t "$pane_id" -c '#{pane_current_path}' "ssh <host>"`
+
+Override keys (query must be empty — lowercase letters otherwise type into search):
+
+- `y` — yank (OSC 52)
+- `o` — `open`/`xdg-open`
+- `g` — `gh <kind> view --web -R OWNER/REPO <id>` (GitHub rows only)
+- `s` — force ssh
+
+## Filtering
+
+Token-based substring match. Tokens split on whitespace; letter/digit boundaries split once per transition (multi-digit tokens stay whole — Divergence 1 from `pick-tui`).
+
+Category tag `pr`/`issue`/`commit`/`file`/`repo`/`blog`/`link`/`server`/`ip` prefixes each row's search string with a `\x1f` separator (Divergence 2).
+
+Digit-only tokens match the `key` column only.
+
+## Divergences from `PICKER_SPEC.md`
+
+1. **Multi-digit tokens are NOT split per digit.** `pick-tui` splits `14` → `[1,4]` to match tmux index `1;4`; the link picker treats `14` as one token because PR number `14` must not match `#1;4`.
+2. **Tag prefix uses `\x1f` separator.** Ensures the category tag is matched as a whole word, not as a substring leaking into titles.
+3. **Headers are selectable.** `pick-tui` skips session headers when navigating; `pick-links` keeps category headers selectable so `Enter` on a header can drill into that category.
+
+## Cross-picker shortcut
+
+`F2` cleanly tears down the TUI (`disable_raw_mode` + `LeaveAlternateScreen` + drop terminal + flush) then `execvp`s the sibling binary with `TMUX_PANE` forwarded. OSC 52 is NOT written on `F2` — it's a swap, not an action.
+
+## OSC 52 timing
+
+Write sequence, in order: TUI exits → `disable_raw_mode` → `LeaveAlternateScreen` → drop `Terminal` → flush stdout/stderr → open `/dev/tty` → write `\e]52;c;<base64>\e\\` → flush tty → `exit(0)`.

--- a/rust/tmux_helper/LINK_PICKER_SPEC.md
+++ b/rust/tmux_helper/LINK_PICKER_SPEC.md
@@ -1,5 +1,11 @@
 # rmux_helper pick-links Specification
 
+## Invocation
+
+- `rmux_helper pick-links` — launches the TUI picker popup. Binds to `C-a L` in tmux.
+- `rmux_helper pick-links --json` — emits detected items as JSON to stdout and exits (no enrichment, no TUI). Useful for scripts and tests.
+- `rmux_helper pick-links --enrich-deadline-ms N` — overrides the default 3-second enrichment deadline. `0` disables gh enrichment entirely.
+
 ## Categories (fixed display order)
 
 1. Pull Requests — `github.com/OWNER/REPO/pull/N`
@@ -77,3 +83,7 @@ Digit-only tokens match the `key` column only.
 ## OSC 52 timing
 
 Write sequence, in order: TUI exits → `disable_raw_mode` → `LeaveAlternateScreen` → drop `Terminal` → flush stdout/stderr → open `/dev/tty` → write `\e]52;c;<base64>\e\\` → flush tty → `exit(0)`.
+
+## Empty state
+
+When scrollback contains no detectable items, the TUI is not entered. `pick_links` prints `pick-links: no links, servers, or IPs in scrollback` to stderr and exits 0.

--- a/rust/tmux_helper/LINK_PICKER_SPEC.md
+++ b/rust/tmux_helper/LINK_PICKER_SPEC.md
@@ -90,3 +90,11 @@ Write sequence, in order: TUI exits → `disable_raw_mode` → `LeaveAlternateSc
 ## Empty state
 
 When scrollback contains no detectable items, the TUI is not entered. `pick_links` prints `pick-links: no links, servers, or IPs in scrollback` to stderr and exits 0.
+
+## Scrollback capture
+
+`pick-links` scans the current tmux pane's scrollback only — no cross-pane, no cross-session, no external sources. The pane is resolved from `$TMUX_PANE`, falling back to `tmux display-message -p '#{client_active_pane}'`.
+
+History depth is **capped at 300 lines above the visible pane top** (`tmux capture-pane -J -S -300 -E -`). The visible pane content is always included in full; the cap only limits how deep into scrollback we go. This keeps results relevant to recent work — a 50 000-line `history-limit` buffer produces stale context from days-old sessions that drowns real results in noise. 300 lines is roughly several screens of recent scrollback.
+
+The `-J` flag joins soft-wrapped lines so URLs that wrapped across terminal rows read back whole. ANSI escape bytes are NOT captured (`-e` is deliberately omitted) because raw `\x1b` sequences leak through ratatui's cell rendering into the popup pty and corrupt the display.

--- a/rust/tmux_helper/LINK_PICKER_SPEC.md
+++ b/rust/tmux_helper/LINK_PICKER_SPEC.md
@@ -44,7 +44,10 @@ Categories: fixed order above. Within a category: most-recent line first (closes
 - `Esc`: drill out (first press) or quit (if already flat)
 - `Tab` / `S-Tab`: reserved, no-op
 - `F2`: swap to `pick-tui` (bidirectional)
-- `F1`: help (reserved, TODO v1.1)
+- `?` or `F1`: toggle the modal help overlay. Any key dismisses it (the
+  dismissing key is consumed, so it cannot double as a navigation or action
+  key). `?` is intercepted before the generic filter-query char handler, so
+  it does not type into the search field.
 - `C-l`: toggle layout (horizontal/vertical)
 - `C-c`: clear query or quit
 

--- a/rust/tmux_helper/PICKER_SPEC.md
+++ b/rust/tmux_helper/PICKER_SPEC.md
@@ -83,6 +83,7 @@
 - `C-r`: Rename window (of currently selected pane)
 - `C-l`: Toggle layout (horizontal/vertical)
 - `?` or `C-/`: Show help overlay
+- `F2`: Swap to link picker (`rmux_helper pick-links`) — exec-based handoff, terminal is restored first. Bidirectional: `F2` in `pick-links` returns here.
 - Type characters: Filter entries by text (printable ASCII only)
 
 ## Filtering

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -49,6 +49,7 @@ impl Category {
         }
     }
 
+    #[cfg(test)]
     pub fn all() -> &'static [Category] {
         &[
             Category::PullRequest,

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -219,3 +219,167 @@ mod url_tests {
         );
     }
 }
+
+/// Classify a URL string into a GitHub Category + build an Item, or None.
+pub(crate) fn classify_github(url: &str, line_index: usize) -> Option<Item> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // Owner & repo: no slashes, alphanum + .-_
+        Regex::new(
+            r"^https?://(?:www\.)?github\.com/([\w.\-]+)/([\w.\-]+)(?:/(pull|issues|commit|blob|tree)/([^#?\s]+))?(#\S*)?$"
+        ).unwrap()
+    });
+
+    let caps = re.captures(url.trim_end_matches('/'))?;
+    let owner = caps.get(1)?.as_str();
+    let repo = caps.get(2)?.as_str();
+    let kind = caps.get(3).map(|m| m.as_str());
+    let tail = caps.get(4).map(|m| m.as_str());
+    let fragment = caps.get(5).map(|m| m.as_str()).unwrap_or("");
+
+    let owner_repo = format!("{owner}/{repo}");
+    let canonical_base = format!("https://github.com/{owner_repo}");
+
+    match kind {
+        None => Some(Item {
+            category: Category::Repo,
+            canonical: canonical_base,
+            key: owner.to_string(),
+            repo_or_host: repo.to_string(),
+            line_index,
+        }),
+        Some("pull") => {
+            let num = tail?.split('/').next()?;
+            // Strip non-#LN fragments from PR URLs (canonical form drops them).
+            Some(Item {
+                category: Category::PullRequest,
+                canonical: format!("{canonical_base}/pull/{num}"),
+                key: format!("#{num}"),
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        Some("issues") => {
+            let num = tail?.split('/').next()?;
+            Some(Item {
+                category: Category::Issue,
+                canonical: format!("{canonical_base}/issues/{num}"),
+                key: format!("#{num}"),
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        Some("commit") => {
+            let sha = tail?;
+            if sha.len() < 7 || !sha.chars().all(|c| c.is_ascii_hexdigit()) {
+                return None;
+            }
+            let short = &sha[..7.min(sha.len())];
+            Some(Item {
+                category: Category::Commit,
+                canonical: format!("{canonical_base}/commit/{sha}"),
+                key: short.to_string(),
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        Some("blob") | Some("tree") => {
+            let tail = tail?; // "ref/path/to/file.rs"
+            let basename = tail.rsplit('/').next().unwrap_or(tail);
+            // Line anchor: #L42 or #L42-L60 preserves only Lstart in key.
+            let key = if let Some(l) = fragment.strip_prefix("#L") {
+                let lstart = l.split('-').next().unwrap_or(l);
+                format!("{basename}:L{lstart}")
+            } else {
+                basename.to_string()
+            };
+            let kind_str = kind.unwrap();
+            let frag_out = if fragment.starts_with("#L") { fragment } else { "" };
+            Some(Item {
+                category: Category::File,
+                canonical: format!("{canonical_base}/{kind_str}/{tail}{frag_out}"),
+                key,
+                repo_or_host: repo.to_string(),
+                line_index,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod github_tests {
+    use super::*;
+
+    #[test]
+    fn classifies_pull_request() {
+        let item = classify_github("https://github.com/idvorkin-ai-tools/settings/pull/68", 0).unwrap();
+        assert_eq!(item.category, Category::PullRequest);
+        assert_eq!(item.key, "#68");
+        assert_eq!(item.repo_or_host, "settings");
+        assert_eq!(item.canonical, "https://github.com/idvorkin-ai-tools/settings/pull/68");
+    }
+
+    #[test]
+    fn strips_pr_discussion_fragment() {
+        let item = classify_github(
+            "https://github.com/a/b/pull/1#discussion_r123", 0,
+        ).unwrap();
+        assert_eq!(item.canonical, "https://github.com/a/b/pull/1");
+    }
+
+    #[test]
+    fn classifies_issue() {
+        let item = classify_github("https://github.com/a/b/issues/42", 0).unwrap();
+        assert_eq!(item.category, Category::Issue);
+        assert_eq!(item.key, "#42");
+    }
+
+    #[test]
+    fn classifies_commit_with_short_sha() {
+        let item = classify_github("https://github.com/a/b/commit/a22bc17", 0).unwrap();
+        assert_eq!(item.category, Category::Commit);
+        assert_eq!(item.key, "a22bc17");
+    }
+
+    #[test]
+    fn rejects_non_hex_commit() {
+        assert!(classify_github("https://github.com/a/b/commit/NOTHEX", 0).is_none());
+    }
+
+    #[test]
+    fn classifies_file_with_line_anchor() {
+        let item = classify_github(
+            "https://github.com/a/b/blob/main/src/picker.rs#L42", 0,
+        ).unwrap();
+        assert_eq!(item.category, Category::File);
+        assert_eq!(item.key, "picker.rs:L42");
+    }
+
+    #[test]
+    fn classifies_file_line_range_uses_start() {
+        let item = classify_github(
+            "https://github.com/a/b/blob/main/src/picker.rs#L42-L60", 0,
+        ).unwrap();
+        assert_eq!(item.key, "picker.rs:L42");
+    }
+
+    #[test]
+    fn classifies_bare_repo() {
+        let item = classify_github("https://github.com/idvorkin-ai-tools/settings", 0).unwrap();
+        assert_eq!(item.category, Category::Repo);
+        assert_eq!(item.key, "idvorkin-ai-tools");
+        assert_eq!(item.repo_or_host, "settings");
+    }
+
+    #[test]
+    fn collapses_www_github_com() {
+        let item = classify_github("https://www.github.com/a/b/pull/1", 0).unwrap();
+        assert_eq!(item.canonical, "https://github.com/a/b/pull/1");
+    }
+
+    #[test]
+    fn rejects_non_github_host() {
+        assert!(classify_github("https://gitlab.com/a/b", 0).is_none());
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -280,6 +280,13 @@ pub(crate) fn classify_github(url: &str, line_index: usize) -> Option<Item> {
         }),
         Some("pull") => {
             let num = tail?.split('/').next()?;
+            // Require the id to be a positive integer. Rejects `.../pull/new`
+            // (blank template page), `.../pull/compare`, and any other
+            // non-numeric tail that would otherwise produce a garbage
+            // `#<word>` row.
+            if num.is_empty() || !num.chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
             // Strip non-#LN fragments from PR URLs (canonical form drops them).
             Some(Item {
                 category: Category::PullRequest,
@@ -291,6 +298,10 @@ pub(crate) fn classify_github(url: &str, line_index: usize) -> Option<Item> {
         }
         Some("issues") => {
             let num = tail?.split('/').next()?;
+            // Same numeric requirement as PRs — rejects `.../issues/new`.
+            if num.is_empty() || !num.chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
             Some(Item {
                 category: Category::Issue,
                 canonical: format!("{canonical_base}/issues/{num}"),
@@ -433,6 +444,29 @@ mod github_tests {
         assert!(classify_github("https://github.com/a/b/blob/main", 0).is_none());
         assert!(classify_github("https://github.com/a/b/blob/m", 0).is_none());
         assert!(classify_github("https://github.com/a/b/tree/main", 0).is_none());
+    }
+
+    #[test]
+    fn rejects_pull_new_template_page() {
+        // `.../pull/new` is GitHub's "create new PR" blank template page —
+        // not a reference to a specific PR. The literal tail `new` is not
+        // a numeric PR id, so classify_github must reject it rather than
+        // produce a garbage `#new` row.
+        assert!(classify_github("https://github.com/a/b/pull/new", 0).is_none());
+    }
+
+    #[test]
+    fn rejects_issues_new_template_page() {
+        // Same rationale for `.../issues/new` — blank issue template.
+        assert!(classify_github("https://github.com/a/b/issues/new", 0).is_none());
+    }
+
+    #[test]
+    fn still_accepts_numeric_pr_id() {
+        // Regression guard: the numeric requirement must NOT reject
+        // legitimate multi-digit PR numbers.
+        let item = classify_github("https://github.com/a/b/pull/12345", 0).unwrap();
+        assert_eq!(item.key, "#12345");
     }
 }
 
@@ -699,6 +733,19 @@ mod ip_tests {
     }
 }
 
+/// Some GitHub URLs have no informational value to a picker even though
+/// they parse as valid URLs — blank template pages, not references to a
+/// specific PR/issue/commit. Drop them entirely instead of letting them
+/// fall through to `OtherLink` noise.
+pub(crate) fn is_github_noise_url(url: &str) -> bool {
+    // Normalize trailing slash so `.../pull/new` and `.../pull/new/` both match.
+    let base = url.trim_end_matches('/');
+    // Strip query string for the suffix check (templated new-issue pages
+    // like `.../issues/new?template=bug.md` must also be dropped).
+    let without_query = base.split('?').next().unwrap_or(base);
+    without_query.ends_with("/pull/new") || without_query.ends_with("/issues/new")
+}
+
 /// Scan one scrollback line and return all detected items in that line.
 /// A single line can contribute to multiple categories.
 pub(crate) fn scan_line(line: &str, line_index: usize) -> Vec<Item> {
@@ -707,6 +754,12 @@ pub(crate) fn scan_line(line: &str, line_index: usize) -> Vec<Item> {
     // URLs (cascade through GitHub → Blog/Other).
     for m in url_regex().find_iter(line) {
         let raw = strip_trailing_punct(m.as_str());
+        // Pre-filter noise URLs before the classify chain, otherwise GitHub
+        // URLs that classify_github rejects fall through to classify_other_url
+        // and pollute the OtherLink category.
+        if is_github_noise_url(raw) {
+            continue;
+        }
         if let Some(item) = classify_github(raw, line_index) {
             out.push(item);
         } else if let Some(item) = classify_other_url(raw, line_index) {
@@ -749,6 +802,36 @@ mod scan_line_tests {
         let items = scan_line("https://github.com/a/b/pull/1", 0);
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].category, Category::PullRequest);
+    }
+
+    #[test]
+    fn drops_pull_new_and_issues_new_entirely() {
+        // "end in new don't tell us anything" — `/pull/new` and `/issues/new`
+        // are blank template pages with zero information value. They must
+        // NOT appear in any category, not even as OtherLink fallthrough.
+        assert!(scan_line("see https://github.com/a/b/pull/new thanks", 0).is_empty());
+        assert!(scan_line("see https://github.com/a/b/issues/new thanks", 0).is_empty());
+    }
+
+    #[test]
+    fn drops_pull_new_with_query_string() {
+        // Templated new-issue / new-PR pages have `?template=...` or similar
+        // query strings. Still noise.
+        let items = scan_line(
+            "https://github.com/a/b/issues/new?template=bug.md&title=crash",
+            0,
+        );
+        assert!(items.is_empty(), "templated new-issue must be dropped");
+    }
+
+    #[test]
+    fn keeps_legit_numeric_pull_request() {
+        // Regression guard for the noise filter: real PRs with numeric ids
+        // must survive.
+        let items = scan_line("real PR https://github.com/a/b/pull/42", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].category, Category::PullRequest);
+        assert_eq!(items[0].key, "#42");
     }
 }
 

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -69,9 +69,9 @@ impl Category {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Item {
     pub category: Category,
-    pub canonical: String,     // canonical URL, hostname, or IP
-    pub key: String,           // key column: "#68", "a22bc17", "picker.rs:L42", "c-5001"
-    pub repo_or_host: String,  // repo-or-host column: "settings", "idvorkin.github.io", "—"
+    pub canonical: String,    // canonical URL, hostname, or IP
+    pub key: String,          // key column: "#68", "a22bc17", "picker.rs:L42", "c-5001"
+    pub repo_or_host: String, // repo-or-host column: "settings", "idvorkin.github.io", "—"
     /// Line index in the captured scrollback where this occurrence was found.
     pub line_index: usize,
 }
@@ -83,7 +83,7 @@ pub struct Row {
     pub canonical: String,
     pub key: String,
     pub repo_or_host: String,
-    pub context: String,      // from scrollback line at most_recent_line
+    pub context: String, // from scrollback line at most_recent_line
     pub enriched: Option<EnrichedTitle>, // None in v1 detection output; filled by enrich.rs
     pub count: usize,
     pub most_recent_line: usize,
@@ -153,13 +153,17 @@ mod tests {
 use regex::Regex;
 use std::sync::OnceLock;
 
-/// Base URL regex — matches scheme + greedy body up to whitespace or URL-unsafe chars.
+/// Base URL regex — matches scheme + RFC-3986 unreserved/reserved ASCII chars.
+/// Deliberately positive (allowlist), not exclusion-based, so:
+///   - `\` (backslash) is excluded → escape sequences in scrollback source
+///     code like `"pull/1\nssh"` don't leak `\n` into canonicals.
+///   - Non-ASCII chars (e.g. `…` U+2026 from terminal truncation) are excluded.
+///   - `(`, `)`, `'`, `"`, `<`, `>`, brackets, braces are excluded so URLs
+///     embedded in prose (`(see https://.../)`) terminate cleanly.
 /// Trailing punctuation is stripped separately (see `strip_trailing_punct`).
 pub(crate) fn url_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r#"https?://[^\s<>"'`()\[\]{}]+"#).unwrap()
-    })
+    RE.get_or_init(|| Regex::new(r"https?://[A-Za-z0-9\-._~:/?#@!$&*+,;=%]+").unwrap())
 }
 
 /// Strip trailing `.,;:!?)]}>'"` from a matched URL. Preserves trailing `/`.
@@ -218,6 +222,31 @@ mod url_tests {
             extract_url("https://github.com/a/b/pull/1#discussion_r123"),
             "https://github.com/a/b/pull/1#discussion_r123"
         );
+    }
+
+    #[test]
+    fn excludes_backslash_from_url() {
+        // Rust test source often embeds `\n` as two literal characters
+        // (backslash + n) in string literals that end up in scrollback.
+        // The URL regex must not treat `\` as a URL character, or canonicals
+        // leak escaped-newline fragments like `pull/1\nssh`.
+        let line = r#"let raw = "https://github.com/a/b/pull/1\nssh c-5001\n";"#;
+        let m = url_regex().find(line).expect("URL still present");
+        let extracted = strip_trailing_punct(m.as_str());
+        assert_eq!(extracted, "https://github.com/a/b/pull/1");
+        assert!(!extracted.contains('\\'));
+    }
+
+    #[test]
+    fn excludes_non_ascii_ellipsis_from_url() {
+        // Terminals sometimes truncate URLs with `…` (U+2026) when wrapping.
+        // The regex must not include non-ASCII characters, or the truncated
+        // `…` leaks into the canonical and duplicates rows.
+        let line = "see https://idvorkin.github.io/posts/pro… for more";
+        let m = url_regex().find(line).expect("URL still present");
+        let extracted = strip_trailing_punct(m.as_str());
+        assert_eq!(extracted, "https://idvorkin.github.io/posts/pro");
+        assert!(!extracted.contains('…'));
     }
 }
 
@@ -286,6 +315,12 @@ pub(crate) fn classify_github(url: &str, line_index: usize) -> Option<Item> {
         }
         Some("blob") | Some("tree") => {
             let tail = tail?; // "ref/path/to/file.rs"
+                              // Require a file path after the ref. `blob/main` alone is a
+                              // branch-tree view, not a file; line-wrapped scrollback produces
+                              // truncated `blob/m` cases which must also be rejected.
+            if !tail.contains('/') {
+                return None;
+            }
             let basename = tail.rsplit('/').next().unwrap_or(tail);
             // Line anchor: #L42 or #L42-L60 preserves only Lstart in key.
             let key = if let Some(l) = fragment.strip_prefix("#L") {
@@ -295,7 +330,11 @@ pub(crate) fn classify_github(url: &str, line_index: usize) -> Option<Item> {
                 basename.to_string()
             };
             let kind_str = kind.unwrap();
-            let frag_out = if fragment.starts_with("#L") { fragment } else { "" };
+            let frag_out = if fragment.starts_with("#L") {
+                fragment
+            } else {
+                ""
+            };
             Some(Item {
                 category: Category::File,
                 canonical: format!("{canonical_base}/{kind_str}/{tail}{frag_out}"),
@@ -314,18 +353,20 @@ mod github_tests {
 
     #[test]
     fn classifies_pull_request() {
-        let item = classify_github("https://github.com/idvorkin-ai-tools/settings/pull/68", 0).unwrap();
+        let item =
+            classify_github("https://github.com/idvorkin-ai-tools/settings/pull/68", 0).unwrap();
         assert_eq!(item.category, Category::PullRequest);
         assert_eq!(item.key, "#68");
         assert_eq!(item.repo_or_host, "settings");
-        assert_eq!(item.canonical, "https://github.com/idvorkin-ai-tools/settings/pull/68");
+        assert_eq!(
+            item.canonical,
+            "https://github.com/idvorkin-ai-tools/settings/pull/68"
+        );
     }
 
     #[test]
     fn strips_pr_discussion_fragment() {
-        let item = classify_github(
-            "https://github.com/a/b/pull/1#discussion_r123", 0,
-        ).unwrap();
+        let item = classify_github("https://github.com/a/b/pull/1#discussion_r123", 0).unwrap();
         assert_eq!(item.canonical, "https://github.com/a/b/pull/1");
     }
 
@@ -350,18 +391,16 @@ mod github_tests {
 
     #[test]
     fn classifies_file_with_line_anchor() {
-        let item = classify_github(
-            "https://github.com/a/b/blob/main/src/picker.rs#L42", 0,
-        ).unwrap();
+        let item =
+            classify_github("https://github.com/a/b/blob/main/src/picker.rs#L42", 0).unwrap();
         assert_eq!(item.category, Category::File);
         assert_eq!(item.key, "picker.rs:L42");
     }
 
     #[test]
     fn classifies_file_line_range_uses_start() {
-        let item = classify_github(
-            "https://github.com/a/b/blob/main/src/picker.rs#L42-L60", 0,
-        ).unwrap();
+        let item =
+            classify_github("https://github.com/a/b/blob/main/src/picker.rs#L42-L60", 0).unwrap();
         assert_eq!(item.key, "picker.rs:L42");
     }
 
@@ -382,6 +421,18 @@ mod github_tests {
     #[test]
     fn rejects_non_github_host() {
         assert!(classify_github("https://gitlab.com/a/b", 0).is_none());
+    }
+
+    #[test]
+    fn rejects_blob_without_path() {
+        // `blob/main` (or any truncated `blob/X` with no file path after the
+        // ref) is not a File URL — it's a branch/tree view. Line-wrapped
+        // scrollback produces cases like `blob/m` where the URL was cut off.
+        // classify_github must return None so these don't pollute the Files
+        // category; they fall through to OtherLink.
+        assert!(classify_github("https://github.com/a/b/blob/main", 0).is_none());
+        assert!(classify_github("https://github.com/a/b/blob/m", 0).is_none());
+        assert!(classify_github("https://github.com/a/b/tree/main", 0).is_none());
     }
 }
 
@@ -462,7 +513,16 @@ pub(crate) fn find_servers(line: &str, line_index: usize) -> Vec<Item> {
     let mut out = Vec::new();
     for cap in ssh.captures_iter(line) {
         if let Some(h) = cap.get(1) {
-            out.push(mk_server(h.as_str(), line_index));
+            let host = h.as_str();
+            // Suppress bare English words after the `ssh` verb ("URLs and
+            // ssh servers and IPs" → not a real host). Require the host to
+            // either contain a `.` (FQDN / dotted form) or match the
+            // Tailscale short form `c-NNNN`. Config-alias hosts without a
+            // dot are accepted only when they also appear in the separate
+            // Tailscale regexes below.
+            if host.contains('.') || ts_host.is_match(host) {
+                out.push(mk_server(host, line_index));
+            }
         }
     }
     for m in ts_host.find_iter(line) {
@@ -525,15 +585,33 @@ mod server_tests {
         let items = find_servers("ping mydev.ts.net", 0);
         assert!(items.iter().any(|i| i.canonical == "mydev.ts.net"));
     }
+
+    #[test]
+    fn rejects_bare_english_word_after_ssh_verb() {
+        // Prose like "URLs, ssh servers, IPs" or "scrapes ssh in the docs"
+        // must NOT produce servers named `servers`, `for`, `context`, etc.
+        // Require the host to look like a real hostname: contain `.` or
+        // match the Tailscale short form.
+        assert!(find_servers("URLs and ssh servers and IPs", 0).is_empty());
+        assert!(find_servers("- scrapes scrollback for ssh for context", 0).is_empty());
+        assert!(find_servers("when ssh lands in the pane", 0).is_empty());
+        assert!(find_servers("force ssh action on any row", 0).is_empty());
+    }
+
+    #[test]
+    fn still_extracts_dotted_host_after_ssh() {
+        // Regression guard for the fix above: dotted hostnames must still
+        // be picked up.
+        let items = find_servers("ssh dev.example.com", 0);
+        assert!(items.iter().any(|i| i.canonical == "dev.example.com"));
+    }
 }
 
 pub(crate) fn find_ips(line: &str, line_index: usize) -> Vec<Item> {
     static RE: OnceLock<Regex> = OnceLock::new();
     // Dotted-quad with bounded octets, no look-around (Rust regex limitation).
     // We do boundary + version-prefix checks in code.
-    let re = RE.get_or_init(|| {
-        Regex::new(r"(?:\d{1,3}\.){3}\d{1,3}").unwrap()
-    });
+    let re = RE.get_or_init(|| Regex::new(r"(?:\d{1,3}\.){3}\d{1,3}").unwrap());
 
     let bytes = line.as_bytes();
     let mut out = Vec::new();
@@ -561,7 +639,10 @@ pub(crate) fn find_ips(line: &str, line_index: usize) -> Vec<Item> {
         }
         // Validate octets
         let text = m.as_str();
-        let octets: Vec<u16> = text.split('.').map(|s| s.parse().unwrap_or(u16::MAX)).collect();
+        let octets: Vec<u16> = text
+            .split('.')
+            .map(|s| s.parse().unwrap_or(u16::MAX))
+            .collect();
         if octets.iter().any(|o| *o > 255) {
             continue;
         }
@@ -647,7 +728,10 @@ mod scan_line_tests {
 
     #[test]
     fn scans_pr_url_in_context() {
-        let items = scan_line("Merge pull request #68 https://github.com/a/b/pull/68 ok", 0);
+        let items = scan_line(
+            "Merge pull request #68 https://github.com/a/b/pull/68 ok",
+            0,
+        );
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].category, Category::PullRequest);
     }
@@ -739,8 +823,16 @@ pub fn parse(raw: &str) -> Vec<Row> {
     // Sort: category ASC (display order), then most_recent_line DESC,
     // ties broken by canonical ASC for determinism.
     rows.sort_by(|a, b| {
-        (a.category as u8, std::cmp::Reverse(a.most_recent_line), &a.canonical)
-            .cmp(&(b.category as u8, std::cmp::Reverse(b.most_recent_line), &b.canonical))
+        (
+            a.category as u8,
+            std::cmp::Reverse(a.most_recent_line),
+            &a.canonical,
+        )
+            .cmp(&(
+                b.category as u8,
+                std::cmp::Reverse(b.most_recent_line),
+                &b.canonical,
+            ))
     });
 
     rows
@@ -754,7 +846,10 @@ mod parse_tests {
     fn dedups_same_server_across_sources() {
         let raw = "ssh c-5001 \"pwd\"\nssh igor@c-5001 \"ls\"\npeer c-5001 up\n";
         let rows = parse(raw);
-        let servers: Vec<&Row> = rows.iter().filter(|r| r.category == Category::Server).collect();
+        let servers: Vec<&Row> = rows
+            .iter()
+            .filter(|r| r.category == Category::Server)
+            .collect();
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].canonical, "c-5001");
         assert!(servers[0].count >= 3);
@@ -764,7 +859,10 @@ mod parse_tests {
     fn orders_by_recency_within_category() {
         let raw = "https://github.com/a/b/pull/1\nhttps://github.com/a/b/pull/2\n";
         let rows = parse(raw);
-        let prs: Vec<&Row> = rows.iter().filter(|r| r.category == Category::PullRequest).collect();
+        let prs: Vec<&Row> = rows
+            .iter()
+            .filter(|r| r.category == Category::PullRequest)
+            .collect();
         assert_eq!(prs.len(), 2);
         // Most recent (pull/2, line 1) comes first
         assert_eq!(prs[0].key, "#2");
@@ -783,7 +881,10 @@ mod parse_tests {
     fn context_strips_url_and_collapses_whitespace() {
         let raw = "Merge pull request   #68   https://github.com/a/b/pull/68   idvorkin\n";
         let rows = parse(raw);
-        let pr = rows.iter().find(|r| r.category == Category::PullRequest).unwrap();
+        let pr = rows
+            .iter()
+            .find(|r| r.category == Category::PullRequest)
+            .unwrap();
         assert!(!pr.context.contains("https://"));
         assert!(!pr.context.contains("   ")); // no runs of whitespace
         assert!(pr.context.contains("Merge pull request"));
@@ -794,7 +895,10 @@ mod parse_tests {
         let long = "a".repeat(200);
         let raw = format!("{long} https://example.com rest\n");
         let rows = parse(&raw);
-        let row = rows.iter().find(|r| r.category == Category::OtherLink).unwrap();
+        let row = rows
+            .iter()
+            .find(|r| r.category == Category::OtherLink)
+            .unwrap();
         assert!(row.context.ends_with('…'));
         assert!(UnicodeWidthStr::width(row.context.as_str()) <= 60);
     }

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -616,3 +616,53 @@ mod ip_tests {
         assert_eq!(items.len(), 1);
     }
 }
+
+/// Scan one scrollback line and return all detected items in that line.
+/// A single line can contribute to multiple categories.
+pub(crate) fn scan_line(line: &str, line_index: usize) -> Vec<Item> {
+    let mut out = Vec::new();
+
+    // URLs (cascade through GitHub → Blog/Other).
+    for m in url_regex().find_iter(line) {
+        let raw = strip_trailing_punct(m.as_str());
+        if let Some(item) = classify_github(raw, line_index) {
+            out.push(item);
+        } else if let Some(item) = classify_other_url(raw, line_index) {
+            out.push(item);
+        }
+    }
+
+    // Servers (ssh + Tailscale; two Tailscale regexes may double-match).
+    out.extend(find_servers(line, line_index));
+    // IPs
+    out.extend(find_ips(line, line_index));
+
+    out
+}
+
+#[cfg(test)]
+mod scan_line_tests {
+    use super::*;
+
+    #[test]
+    fn scans_pr_url_in_context() {
+        let items = scan_line("Merge pull request #68 https://github.com/a/b/pull/68 ok", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].category, Category::PullRequest);
+    }
+
+    #[test]
+    fn mixes_url_and_ip_on_same_line() {
+        let items = scan_line("curl https://example.com from 10.0.0.1", 0);
+        assert!(items.iter().any(|i| i.category == Category::OtherLink));
+        assert!(items.iter().any(|i| i.category == Category::Ip));
+    }
+
+    #[test]
+    fn no_cross_category_for_pr_url() {
+        // A PR URL must NOT also appear under OtherLink.
+        let items = scan_line("https://github.com/a/b/pull/1", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].category, Category::PullRequest);
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -666,3 +666,143 @@ mod scan_line_tests {
         assert_eq!(items[0].category, Category::PullRequest);
     }
 }
+
+use std::collections::HashMap;
+use unicode_width::UnicodeWidthStr;
+
+/// Strip an anchor substring from a line, collapse whitespace, trim, truncate to max display width.
+pub(crate) fn make_context(line: &str, anchor: &str, max_width: usize) -> String {
+    // Remove the anchor substring; collapse runs of whitespace to single space.
+    let removed = line.replacen(anchor, "", 1);
+    let collapsed: String = removed.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_to_width(&collapsed, max_width)
+}
+
+pub(crate) fn truncate_to_width(s: &str, max: usize) -> String {
+    let w = UnicodeWidthStr::width(s);
+    if w <= max {
+        return s.to_string();
+    }
+    // Walk characters, accumulating width, until we reach max-1 (room for `…`).
+    let budget = max.saturating_sub(1);
+    let mut acc = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let cw = UnicodeWidthStr::width(ch.to_string().as_str());
+        if used + cw > budget {
+            break;
+        }
+        acc.push(ch);
+        used += cw;
+    }
+    acc.push('…');
+    acc
+}
+
+/// Top-level detection: parse the whole scrollback and return deduped,
+/// recency-ordered rows.
+pub fn parse(raw: &str) -> Vec<Row> {
+    // Collect items + keep a reference to the line for context extraction.
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut items_by_key: HashMap<(Category, String), Vec<Item>> = HashMap::new();
+    for (idx, line) in lines.iter().enumerate() {
+        for item in scan_line(line, idx) {
+            items_by_key
+                .entry((item.category, item.canonical.clone()))
+                .or_default()
+                .push(item);
+        }
+    }
+
+    // Build rows: most_recent_line = max line_index in the group.
+    let mut rows: Vec<Row> = items_by_key
+        .into_iter()
+        .map(|((category, canonical), group)| {
+            let count = group.len();
+            let most_recent = group.iter().map(|i| i.line_index).max().unwrap_or(0);
+            let exemplar = group.iter().find(|i| i.line_index == most_recent).unwrap();
+            let context = make_context(lines[most_recent], &canonical, 60);
+            Row {
+                category,
+                canonical,
+                key: exemplar.key.clone(),
+                repo_or_host: exemplar.repo_or_host.clone(),
+                context,
+                enriched: None,
+                count,
+                most_recent_line: most_recent,
+            }
+        })
+        .collect();
+
+    // Sort: category ASC (display order), then most_recent_line DESC,
+    // ties broken by canonical ASC for determinism.
+    rows.sort_by(|a, b| {
+        (a.category as u8, std::cmp::Reverse(a.most_recent_line), &a.canonical)
+            .cmp(&(b.category as u8, std::cmp::Reverse(b.most_recent_line), &b.canonical))
+    });
+
+    rows
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn dedups_same_server_across_sources() {
+        let raw = "ssh c-5001 \"pwd\"\nssh igor@c-5001 \"ls\"\npeer c-5001 up\n";
+        let rows = parse(raw);
+        let servers: Vec<&Row> = rows.iter().filter(|r| r.category == Category::Server).collect();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].canonical, "c-5001");
+        assert!(servers[0].count >= 3);
+    }
+
+    #[test]
+    fn orders_by_recency_within_category() {
+        let raw = "https://github.com/a/b/pull/1\nhttps://github.com/a/b/pull/2\n";
+        let rows = parse(raw);
+        let prs: Vec<&Row> = rows.iter().filter(|r| r.category == Category::PullRequest).collect();
+        assert_eq!(prs.len(), 2);
+        // Most recent (pull/2, line 1) comes first
+        assert_eq!(prs[0].key, "#2");
+        assert_eq!(prs[1].key, "#1");
+    }
+
+    #[test]
+    fn pr_url_does_not_leak_to_other_links() {
+        let raw = "see https://github.com/a/b/pull/1 now\n";
+        let rows = parse(raw);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].category, Category::PullRequest);
+    }
+
+    #[test]
+    fn context_strips_url_and_collapses_whitespace() {
+        let raw = "Merge pull request   #68   https://github.com/a/b/pull/68   idvorkin\n";
+        let rows = parse(raw);
+        let pr = rows.iter().find(|r| r.category == Category::PullRequest).unwrap();
+        assert!(!pr.context.contains("https://"));
+        assert!(!pr.context.contains("   ")); // no runs of whitespace
+        assert!(pr.context.contains("Merge pull request"));
+    }
+
+    #[test]
+    fn context_truncates_with_ellipsis() {
+        let long = "a".repeat(200);
+        let raw = format!("{long} https://example.com rest\n");
+        let rows = parse(&raw);
+        let row = rows.iter().find(|r| r.category == Category::OtherLink).unwrap();
+        assert!(row.context.ends_with('…'));
+        assert!(UnicodeWidthStr::width(row.context.as_str()) <= 60);
+    }
+
+    #[test]
+    fn parse_is_idempotent() {
+        let raw = "ssh c-5001\nhttps://github.com/a/b/pull/1\n";
+        let a = parse(raw);
+        let b = parse(raw);
+        assert_eq!(a, b);
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -1,1 +1,150 @@
 //! Pure scrollback detection. No I/O, no async.
+
+use serde::Serialize;
+use std::fmt;
+
+/// Categories in fixed display order. Numeric value doubles as the
+/// display position (1-indexed in the spec) and the 1-9 drill-down key.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Category {
+    PullRequest = 1,
+    Issue = 2,
+    Commit = 3,
+    File = 4,
+    Repo = 5,
+    Blog = 6,
+    OtherLink = 7,
+    Server = 8,
+    Ip = 9,
+}
+
+impl Category {
+    /// Short-name filter tag (see spec "Filtering semantics").
+    pub fn tag(self) -> &'static str {
+        match self {
+            Category::PullRequest => "pr",
+            Category::Issue => "issue",
+            Category::Commit => "commit",
+            Category::File => "file",
+            Category::Repo => "repo",
+            Category::Blog => "blog",
+            Category::OtherLink => "link",
+            Category::Server => "server",
+            Category::Ip => "ip",
+        }
+    }
+
+    pub fn display(self) -> &'static str {
+        match self {
+            Category::PullRequest => "Pull Requests",
+            Category::Issue => "Issues",
+            Category::Commit => "Commits",
+            Category::File => "Files",
+            Category::Repo => "Repos",
+            Category::Blog => "Blog",
+            Category::OtherLink => "Other links",
+            Category::Server => "Servers",
+            Category::Ip => "IPs",
+        }
+    }
+
+    pub fn all() -> &'static [Category] {
+        &[
+            Category::PullRequest,
+            Category::Issue,
+            Category::Commit,
+            Category::File,
+            Category::Repo,
+            Category::Blog,
+            Category::OtherLink,
+            Category::Server,
+            Category::Ip,
+        ]
+    }
+}
+
+/// One detected item, pre-dedup. `canonical` is the dedup key within a category.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct Item {
+    pub category: Category,
+    pub canonical: String,     // canonical URL, hostname, or IP
+    pub key: String,           // key column: "#68", "a22bc17", "picker.rs:L42", "c-5001"
+    pub repo_or_host: String,  // repo-or-host column: "settings", "idvorkin.github.io", "—"
+    /// Line index in the captured scrollback where this occurrence was found.
+    pub line_index: usize,
+}
+
+/// A finished row the TUI renders. One per unique (category, canonical).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct Row {
+    pub category: Category,
+    pub canonical: String,
+    pub key: String,
+    pub repo_or_host: String,
+    pub context: String,      // from scrollback line at most_recent_line
+    pub enriched: Option<EnrichedTitle>, // None in v1 detection output; filled by enrich.rs
+    pub count: usize,
+    pub most_recent_line: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct EnrichedTitle {
+    pub title: String,
+    pub state: GhState,
+    pub author: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GhState {
+    Open,
+    MergedPr,
+    Closed,
+    Draft,
+    Commit, // not a PR state; used for the ⎇ glyph
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_all_is_in_display_order() {
+        let nums: Vec<u8> = Category::all().iter().map(|c| *c as u8).collect();
+        assert_eq!(nums, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn category_tags_are_unique_and_lowercase() {
+        let mut seen = std::collections::HashSet::new();
+        for c in Category::all() {
+            let tag = c.tag();
+            assert_eq!(tag, tag.to_lowercase());
+            assert!(seen.insert(tag), "duplicate tag: {}", tag);
+        }
+    }
+
+    #[test]
+    fn row_is_serializable_to_json() {
+        let row = Row {
+            category: Category::PullRequest,
+            canonical: "https://github.com/a/b/pull/1".into(),
+            key: "#1".into(),
+            repo_or_host: "b".into(),
+            context: "Merge pull request #1".into(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 42,
+        };
+        let json = serde_json::to_string(&row).unwrap();
+        assert!(json.contains("\"category\":\"pull_request\""));
+        assert!(json.contains("\"canonical\":\"https://github.com/a/b/pull/1\""));
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -1,0 +1,1 @@
+//! Pure scrollback detection. No I/O, no async.

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -443,3 +443,85 @@ mod other_url_tests {
         assert_eq!(item.key, "example.com");
     }
 }
+
+pub(crate) fn find_servers(line: &str, line_index: usize) -> Vec<Item> {
+    static SSH_RE: OnceLock<Regex> = OnceLock::new();
+    static TS_HOST_RE: OnceLock<Regex> = OnceLock::new();
+    static TS_NET_RE: OnceLock<Regex> = OnceLock::new();
+    let ssh = SSH_RE.get_or_init(|| {
+        // `ssh` token, optional flags (with optional value args for short opts), optional user@, then host
+        Regex::new(
+            r"\bssh\b(?:\s+(?:-[a-zA-Z]\s+\S+|-\S+))*\s+(?:[a-zA-Z_][\w-]*@)?([a-zA-Z0-9][\w.\-]*[a-zA-Z0-9])\b",
+        )
+        .unwrap()
+    });
+    let ts_host = TS_HOST_RE.get_or_init(|| Regex::new(r"\bc-\d{4,5}\b").unwrap());
+    let ts_net = TS_NET_RE.get_or_init(|| Regex::new(r"\b[a-z][a-z0-9-]*\.ts\.net\b").unwrap());
+
+    let mut out = Vec::new();
+    for cap in ssh.captures_iter(line) {
+        if let Some(h) = cap.get(1) {
+            out.push(mk_server(h.as_str(), line_index));
+        }
+    }
+    for m in ts_host.find_iter(line) {
+        out.push(mk_server(m.as_str(), line_index));
+    }
+    for m in ts_net.find_iter(line) {
+        out.push(mk_server(m.as_str(), line_index));
+    }
+    out
+}
+
+fn mk_server(host: &str, line_index: usize) -> Item {
+    Item {
+        category: Category::Server,
+        canonical: host.to_string(),
+        key: host.to_string(),
+        repo_or_host: "—".to_string(),
+        line_index,
+    }
+}
+
+#[cfg(test)]
+mod server_tests {
+    use super::*;
+
+    #[test]
+    fn extracts_ssh_bare_host() {
+        let items = find_servers("ssh c-5001 \"uname -a\"", 0);
+        assert_eq!(items.len(), 2, "ssh + tailscale regex both match c-5001");
+        assert!(items.iter().any(|i| i.canonical == "c-5001"));
+    }
+
+    #[test]
+    fn extracts_ssh_user_at_host_stripping_user() {
+        let items = find_servers("ssh igor@dev.example.com", 0);
+        assert_eq!(items[0].canonical, "dev.example.com");
+    }
+
+    #[test]
+    fn extracts_ssh_with_options() {
+        let items = find_servers("ssh -i ~/.ssh/id_ed25519 -p 2222 build.host", 0);
+        assert!(items.iter().any(|i| i.canonical == "build.host"));
+    }
+
+    #[test]
+    fn extracts_tailscale_c_pattern() {
+        let items = find_servers("Tailscale peer c-5001 is up", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].canonical, "c-5001");
+    }
+
+    #[test]
+    fn rejects_c_numbers_outside_range() {
+        let items = find_servers("c-2 c-123456", 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn extracts_ts_net_hostname() {
+        let items = find_servers("ping mydev.ts.net", 0);
+        assert!(items.iter().any(|i| i.canonical == "mydev.ts.net"));
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -525,3 +525,94 @@ mod server_tests {
         assert!(items.iter().any(|i| i.canonical == "mydev.ts.net"));
     }
 }
+
+pub(crate) fn find_ips(line: &str, line_index: usize) -> Vec<Item> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Dotted-quad with bounded octets, no look-around (Rust regex limitation).
+    // We do boundary + version-prefix checks in code.
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?:\d{1,3}\.){3}\d{1,3}").unwrap()
+    });
+
+    let bytes = line.as_bytes();
+    let mut out = Vec::new();
+    for m in re.find_iter(line) {
+        let start = m.start();
+        let end = m.end();
+
+        // Reject: preceded by `v` or `V` (version string)
+        if start > 0 && matches!(bytes[start - 1], b'v' | b'V') {
+            continue;
+        }
+        // Reject: preceded by word-char or `.`
+        if start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'.') {
+            continue;
+        }
+        // Reject: followed by `.<digit>` (longer sequence)
+        if end < bytes.len() && bytes[end] == b'.' {
+            if end + 1 < bytes.len() && bytes[end + 1].is_ascii_digit() {
+                continue;
+            }
+        }
+        // Reject: followed by word-char
+        if end < bytes.len() && bytes[end].is_ascii_alphanumeric() {
+            continue;
+        }
+        // Validate octets
+        let text = m.as_str();
+        let octets: Vec<u16> = text.split('.').map(|s| s.parse().unwrap_or(u16::MAX)).collect();
+        if octets.iter().any(|o| *o > 255) {
+            continue;
+        }
+        out.push(Item {
+            category: Category::Ip,
+            canonical: text.to_string(),
+            key: text.to_string(),
+            repo_or_host: "—".to_string(),
+            line_index,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod ip_tests {
+    use super::*;
+
+    #[test]
+    fn extracts_simple_ipv4() {
+        let items = find_ips("Tailscale peer 100.64.1.5 is online", 0);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].canonical, "100.64.1.5");
+    }
+
+    #[test]
+    fn suppresses_version_prefixed() {
+        let items = find_ips("claude-opus v4.6.0.1 released", 0);
+        assert!(items.is_empty(), "v-prefixed not an IP");
+    }
+
+    #[test]
+    fn suppresses_longer_dotted_sequence() {
+        let items = find_ips("value = 1.2.3.4.5 not an IP", 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn rejects_octet_over_255() {
+        let items = find_ips("nope 300.1.1.1", 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn keeps_edge_addresses() {
+        let items = find_ips("range 0.0.0.0 to 255.255.255.255", 0);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn does_not_filter_private_ranges() {
+        let items = find_ips("local 192.168.1.1", 0);
+        assert_eq!(items.len(), 1);
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -148,3 +148,74 @@ mod tests {
         assert!(json.contains("\"canonical\":\"https://github.com/a/b/pull/1\""));
     }
 }
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Base URL regex — matches scheme + greedy body up to whitespace or URL-unsafe chars.
+/// Trailing punctuation is stripped separately (see `strip_trailing_punct`).
+pub(crate) fn url_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"https?://[^\s<>"'`()\[\]{}]+"#).unwrap()
+    })
+}
+
+/// Strip trailing `.,;:!?)]}>'"` from a matched URL. Preserves trailing `/`.
+pub(crate) fn strip_trailing_punct(s: &str) -> &str {
+    s.trim_end_matches(|c: char| ".,;:!?)]}>'\"".contains(c))
+}
+
+#[cfg(test)]
+mod url_tests {
+    use super::*;
+
+    fn extract_url(line: &str) -> &str {
+        let m = url_regex().find(line).expect("no URL in line");
+        strip_trailing_punct(m.as_str())
+    }
+
+    #[test]
+    fn extracts_bare_url() {
+        assert_eq!(
+            extract_url("see https://github.com/a/b/pull/1 next"),
+            "https://github.com/a/b/pull/1"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_period() {
+        assert_eq!(
+            extract_url("see https://github.com/a/b/pull/1."),
+            "https://github.com/a/b/pull/1"
+        );
+    }
+
+    #[test]
+    fn strips_trailing_paren_and_quote() {
+        assert_eq!(
+            extract_url("(see https://github.com/a/b/pull/1)"),
+            "https://github.com/a/b/pull/1"
+        );
+        assert_eq!(
+            extract_url("\"https://github.com/a/b/pull/1\""),
+            "https://github.com/a/b/pull/1"
+        );
+    }
+
+    #[test]
+    fn preserves_trailing_slash() {
+        assert_eq!(
+            extract_url("https://idvorkin.github.io/posts/ai-agents/"),
+            "https://idvorkin.github.io/posts/ai-agents/"
+        );
+    }
+
+    #[test]
+    fn handles_query_and_fragment() {
+        assert_eq!(
+            extract_url("https://github.com/a/b/pull/1#discussion_r123"),
+            "https://github.com/a/b/pull/1#discussion_r123"
+        );
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -383,3 +383,63 @@ mod github_tests {
         assert!(classify_github("https://gitlab.com/a/b", 0).is_none());
     }
 }
+
+/// Blog host allowlist. v1 is a compile-time constant; v2 will be configurable.
+pub(crate) const BLOG_HOSTS: &[&str] = &["idvorkin.github.io"];
+
+/// Classify a non-GitHub URL into Blog or OtherLink.
+pub(crate) fn classify_other_url(url: &str, line_index: usize) -> Option<Item> {
+    let host_end = url.find("://")? + 3;
+    let rest = &url[host_end..];
+    let slash_at = rest.find('/').unwrap_or(rest.len());
+    let host = &rest[..slash_at];
+    let path = &rest[slash_at..];
+
+    let category = if BLOG_HOSTS.iter().any(|b| host.eq_ignore_ascii_case(b)) {
+        Category::Blog
+    } else {
+        Category::OtherLink
+    };
+
+    // Key = last non-empty path segment, or host if path is empty
+    let last_seg = path
+        .trim_end_matches('/')
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or(host)
+        .to_string();
+
+    Some(Item {
+        category,
+        canonical: url.to_string(),
+        key: last_seg,
+        repo_or_host: host.to_string(),
+        line_index,
+    })
+}
+
+#[cfg(test)]
+mod other_url_tests {
+    use super::*;
+
+    #[test]
+    fn blog_host_is_categorized_as_blog() {
+        let item = classify_other_url("https://idvorkin.github.io/posts/ai-agents/", 0).unwrap();
+        assert_eq!(item.category, Category::Blog);
+        assert_eq!(item.repo_or_host, "idvorkin.github.io");
+        assert_eq!(item.key, "ai-agents");
+    }
+
+    #[test]
+    fn non_blog_host_is_other_link() {
+        let item = classify_other_url("https://stackoverflow.com/q/12345", 0).unwrap();
+        assert_eq!(item.category, Category::OtherLink);
+        assert_eq!(item.repo_or_host, "stackoverflow.com");
+    }
+
+    #[test]
+    fn bare_host_uses_host_as_key() {
+        let item = classify_other_url("https://example.com", 0).unwrap();
+        assert_eq!(item.key, "example.com");
+    }
+}

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -95,7 +95,7 @@ pub struct EnrichedTitle {
     pub author: Option<String>,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GhState {
     Open,

--- a/rust/tmux_helper/src/link_picker/detect.rs
+++ b/rust/tmux_helper/src/link_picker/detect.rs
@@ -738,12 +738,21 @@ mod ip_tests {
 /// specific PR/issue/commit. Drop them entirely instead of letting them
 /// fall through to `OtherLink` noise.
 pub(crate) fn is_github_noise_url(url: &str) -> bool {
-    // Normalize trailing slash so `.../pull/new` and `.../pull/new/` both match.
-    let base = url.trim_end_matches('/');
-    // Strip query string for the suffix check (templated new-issue pages
-    // like `.../issues/new?template=bug.md` must also be dropped).
-    let without_query = base.split('?').next().unwrap_or(base);
-    without_query.ends_with("/pull/new") || without_query.ends_with("/issues/new")
+    // Strip fragment and query string before the suffix check — both
+    // `?template=bug.md` and `#section-1` (and a combined
+    // `?template=x#section`) would otherwise push the `/pull/new` suffix
+    // out of `ends_with` range and let the URL leak through. Fragment is
+    // stripped first because it follows the query.
+    let path = url
+        .split('#')
+        .next()
+        .unwrap_or(url)
+        .split('?')
+        .next()
+        .unwrap_or(url)
+        // Normalize `.../pull/new/` and `.../pull/new` to the same form.
+        .trim_end_matches('/');
+    path.ends_with("/pull/new") || path.ends_with("/issues/new")
 }
 
 /// Scan one scrollback line and return all detected items in that line.
@@ -832,6 +841,100 @@ mod scan_line_tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].category, Category::PullRequest);
         assert_eq!(items[0].key, "#42");
+    }
+
+    #[test]
+    fn drops_pull_new_with_fragment() {
+        // Regression: the noise filter originally only stripped `?query` not
+        // `#fragment`, so `https://github.com/a/b/pull/new#discussion` slipped
+        // past `ends_with("/pull/new")` and got recategorized as OtherLink.
+        // Fragment-bearing new-PR/issue links must also be dropped entirely.
+        assert!(scan_line("see https://github.com/a/b/pull/new#section-1", 0).is_empty());
+        assert!(scan_line("see https://github.com/a/b/issues/new#tips", 0).is_empty());
+    }
+
+    #[test]
+    fn drops_pull_new_with_query_and_fragment_combined() {
+        // The nasty case: `?template=…#section` — both fragment-then-query
+        // and query-then-fragment forms must drop cleanly.
+        assert!(scan_line(
+            "https://github.com/a/b/issues/new?template=bug.md#form-top",
+            0
+        )
+        .is_empty());
+    }
+}
+
+#[cfg(test)]
+mod noise_url_tests {
+    use super::*;
+
+    // Direct unit tests for `is_github_noise_url`. The `scan_line` tests
+    // already cover the end-to-end "dropped from picker" contract; these
+    // pin the helper's decision boundary without going through the regex
+    // and classify chain.
+
+    #[test]
+    fn flags_bare_pull_new_and_issues_new() {
+        assert!(is_github_noise_url("https://github.com/a/b/pull/new"));
+        assert!(is_github_noise_url("https://github.com/a/b/issues/new"));
+    }
+
+    #[test]
+    fn flags_with_trailing_slash() {
+        assert!(is_github_noise_url("https://github.com/a/b/pull/new/"));
+        assert!(is_github_noise_url("https://github.com/a/b/issues/new/"));
+    }
+
+    #[test]
+    fn flags_with_query_string() {
+        assert!(is_github_noise_url(
+            "https://github.com/a/b/issues/new?template=bug.md"
+        ));
+        assert!(is_github_noise_url(
+            "https://github.com/a/b/pull/new?quick_pull=1"
+        ));
+    }
+
+    #[test]
+    fn flags_with_fragment() {
+        // The bug this function was fixed for: fragments like
+        // `#discussion_r123` must NOT bypass the noise check.
+        assert!(is_github_noise_url(
+            "https://github.com/a/b/pull/new#top"
+        ));
+        assert!(is_github_noise_url(
+            "https://github.com/a/b/issues/new#form"
+        ));
+    }
+
+    #[test]
+    fn flags_with_query_and_fragment() {
+        assert!(is_github_noise_url(
+            "https://github.com/a/b/issues/new?template=bug.md#form"
+        ));
+    }
+
+    #[test]
+    fn does_not_flag_numbered_pr_or_issue() {
+        // Real PRs/issues must not be mistaken for noise, even if the id
+        // string happens to contain "new" as a substring (e.g. a repo
+        // called `newsletter` has a PR URL that contains "new").
+        assert!(!is_github_noise_url("https://github.com/a/b/pull/42"));
+        assert!(!is_github_noise_url("https://github.com/a/b/issues/123"));
+        assert!(!is_github_noise_url(
+            "https://github.com/a/newsletter/pull/1"
+        ));
+    }
+
+    #[test]
+    fn does_not_flag_unrelated_paths_ending_in_new() {
+        // Substrings that happen to end in "new" but aren't `/pull/new`
+        // or `/issues/new` must not be flagged — conservative by design.
+        assert!(!is_github_noise_url("https://github.com/a/b/tree/new"));
+        assert!(!is_github_noise_url(
+            "https://github.com/a/b/blob/main/src/new"
+        ));
     }
 }
 

--- a/rust/tmux_helper/src/link_picker/enrich.rs
+++ b/rust/tmux_helper/src/link_picker/enrich.rs
@@ -286,3 +286,84 @@ mod gh_call_tests {
         assert!(parse_gh_target("https://github.com/a/b").is_none());
     }
 }
+
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+const MAX_CONCURRENT: usize = 8;
+
+/// Enrich rows in place. Synchronous wrapper around the tokio runtime.
+/// Returns the rows with `enriched` filled where possible.
+pub fn enrich_rows(mut rows: Vec<crate::link_picker::detect::Row>, deadline_ms: u64) -> Vec<crate::link_picker::detect::Row> {
+    if deadline_ms == 0 {
+        return rows;
+    }
+
+    // Load cache synchronously (fast, no async needed).
+    let mut cache = CacheFile::load_or_reset();
+
+    // Apply cache hits immediately.
+    let mut needs_fetch: Vec<usize> = Vec::new();
+    for (idx, row) in rows.iter_mut().enumerate() {
+        if parse_gh_target(&row.canonical).is_none() {
+            continue; // Not an enrichable category
+        }
+        if let Some(hit) = cache.lookup(&row.canonical) {
+            row.enriched = Some(hit);
+        } else {
+            needs_fetch.push(idx);
+        }
+    }
+
+    if needs_fetch.is_empty() {
+        return rows;
+    }
+
+    // Build a single-thread tokio runtime and fan out.
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(_) => return rows, // Runtime build failed; degrade silently
+    };
+
+    // Pre-collect URLs by index so the spawn closures only capture owned strings.
+    let fetch_list: Vec<(usize, String)> = needs_fetch
+        .iter()
+        .map(|&idx| (idx, rows[idx].canonical.clone()))
+        .collect();
+
+    let deadline = Duration::from_millis(deadline_ms);
+    let fetched: Vec<(usize, EnrichedTitle)> = rt.block_on(async move {
+        let sem = Arc::new(Semaphore::new(MAX_CONCURRENT));
+        let mut set: JoinSet<Option<(usize, EnrichedTitle)>> = JoinSet::new();
+        for (idx, url) in fetch_list {
+            let sem = sem.clone();
+            set.spawn(async move {
+                let _permit = sem.acquire_owned().await.ok()?;
+                call_gh(&url).await.ok().flatten().map(|e| (idx, e))
+            });
+        }
+        let drain = async {
+            let mut out = Vec::new();
+            while let Some(res) = set.join_next().await {
+                if let Ok(Some(pair)) = res {
+                    out.push(pair);
+                }
+            }
+            out
+        };
+        tokio::time::timeout(deadline, drain).await.unwrap_or_default()
+    });
+
+    // Apply fetched results + update cache.
+    for (idx, enrichment) in &fetched {
+        cache.insert(rows[*idx].canonical.clone(), enrichment);
+        rows[*idx].enriched = Some(enrichment.clone());
+    }
+    let _ = cache.save(); // swallow errors silently
+    rows
+}

--- a/rust/tmux_helper/src/link_picker/enrich.rs
+++ b/rust/tmux_helper/src/link_picker/enrich.rs
@@ -1,0 +1,1 @@
+//! Parallel `gh` enrichment with a shared deadline.

--- a/rust/tmux_helper/src/link_picker/enrich.rs
+++ b/rust/tmux_helper/src/link_picker/enrich.rs
@@ -128,3 +128,161 @@ mod cache_tests {
         assert_ne!(parsed.unwrap().version, CACHE_VERSION);
     }
 }
+
+use tokio::process::Command;
+
+#[derive(Debug, Deserialize)]
+struct GhPrJson {
+    title: String,
+    state: String,
+    #[serde(default)]
+    author: Option<GhUser>,
+    #[serde(rename = "isDraft", default)]
+    is_draft: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhIssueJson {
+    title: String,
+    state: String,
+    #[serde(default)]
+    author: Option<GhUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhUser {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCommitJson {
+    title: String,
+    #[serde(default)]
+    author: Option<String>,
+}
+
+/// Parse a GitHub canonical URL of the form `https://github.com/OWNER/REPO/(pull|issues|commit)/ID`.
+pub(crate) fn parse_gh_target(url: &str) -> Option<(String, String, GhKind, String)> {
+    let rest = url.strip_prefix("https://github.com/")?;
+    let mut parts = rest.splitn(4, '/');
+    let owner = parts.next()?.to_string();
+    let repo = parts.next()?.to_string();
+    let kind_str = parts.next()?;
+    let id = parts.next()?.to_string();
+    let kind = match kind_str {
+        "pull" => GhKind::Pr,
+        "issues" => GhKind::Issue,
+        "commit" => GhKind::Commit,
+        _ => return None,
+    };
+    Some((owner, repo, kind, id))
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum GhKind { Pr, Issue, Commit }
+
+/// Call `gh` for one canonical URL. Returns `Ok(None)` on any recoverable failure.
+pub(crate) async fn call_gh(canonical_url: &str) -> Result<Option<EnrichedTitle>> {
+    let Some((owner, repo, kind, id)) = parse_gh_target(canonical_url) else {
+        return Ok(None);
+    };
+    let owner_repo = format!("{owner}/{repo}");
+
+    let output = match kind {
+        GhKind::Pr => Command::new("gh")
+            .args(["pr", "view", &id, "-R", &owner_repo, "--json", "title,state,author,isDraft"])
+            .output()
+            .await,
+        GhKind::Issue => Command::new("gh")
+            .args(["issue", "view", &id, "-R", &owner_repo, "--json", "title,state,author"])
+            .output()
+            .await,
+        GhKind::Commit => Command::new("gh")
+            .args([
+                "api",
+                &format!("repos/{owner_repo}/commits/{id}"),
+                "--jq",
+                "{title: (.commit.message | split(\"\\n\")[0]), author: .commit.author.name}",
+            ])
+            .output()
+            .await,
+    };
+
+    let output = match output {
+        Ok(o) => o,
+        Err(_) => return Ok(None), // gh not on PATH
+    };
+    if !output.status.success() {
+        return Ok(None); // 404, auth failure, etc.
+    }
+
+    match kind {
+        GhKind::Pr => {
+            let Ok(p) = serde_json::from_slice::<GhPrJson>(&output.stdout) else {
+                return Ok(None);
+            };
+            let state = if p.is_draft {
+                GhState::Draft
+            } else {
+                match p.state.as_str() {
+                    "OPEN" => GhState::Open,
+                    "MERGED" => GhState::MergedPr,
+                    "CLOSED" => GhState::Closed,
+                    _ => GhState::Open,
+                }
+            };
+            Ok(Some(EnrichedTitle {
+                title: p.title,
+                state,
+                author: p.author.map(|u| u.login),
+            }))
+        }
+        GhKind::Issue => {
+            let Ok(i) = serde_json::from_slice::<GhIssueJson>(&output.stdout) else {
+                return Ok(None);
+            };
+            let state = match i.state.as_str() {
+                "OPEN" => GhState::Open,
+                "CLOSED" => GhState::Closed,
+                _ => GhState::Open,
+            };
+            Ok(Some(EnrichedTitle {
+                title: i.title,
+                state,
+                author: i.author.map(|u| u.login),
+            }))
+        }
+        GhKind::Commit => {
+            let Ok(c) = serde_json::from_slice::<GhCommitJson>(&output.stdout) else {
+                return Ok(None);
+            };
+            Ok(Some(EnrichedTitle {
+                title: c.title,
+                state: GhState::Commit,
+                author: c.author,
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod gh_call_tests {
+    use super::*;
+
+    #[test]
+    fn parse_gh_target_pr() {
+        let (o, r, k, id) = parse_gh_target("https://github.com/a/b/pull/42").unwrap();
+        assert_eq!((o.as_str(), r.as_str(), id.as_str()), ("a", "b", "42"));
+        assert!(matches!(k, GhKind::Pr));
+    }
+
+    #[test]
+    fn parse_gh_target_rejects_non_gh_host() {
+        assert!(parse_gh_target("https://gitlab.com/a/b/pull/1").is_none());
+    }
+
+    #[test]
+    fn parse_gh_target_rejects_repo_home() {
+        assert!(parse_gh_target("https://github.com/a/b").is_none());
+    }
+}

--- a/rust/tmux_helper/src/link_picker/enrich.rs
+++ b/rust/tmux_helper/src/link_picker/enrich.rs
@@ -1,1 +1,130 @@
-//! Parallel `gh` enrichment with a shared deadline.
+//! Parallel `gh` enrichment with a shared deadline and on-disk cache.
+
+use crate::link_picker::detect::{EnrichedTitle, GhState};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CACHE_VERSION: u32 = 1;
+const TTL_SECONDS: u64 = 3600; // 1 hour
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CacheFile {
+    pub version: u32,
+    pub entries: HashMap<String, CacheEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CacheEntry {
+    pub fetched_at: u64, // unix seconds
+    pub title: String,
+    pub state: GhState,
+    pub author: Option<String>,
+}
+
+impl CacheFile {
+    pub fn empty() -> Self {
+        Self { version: CACHE_VERSION, entries: HashMap::new() }
+    }
+
+    pub fn path() -> Option<PathBuf> {
+        let base = dirs::cache_dir()?;
+        Some(base.join("rmux_helper").join("gh-links.json"))
+    }
+
+    /// Load from disk. Returns `CacheFile::empty()` on any failure (missing, corrupt, wrong version).
+    pub fn load_or_reset() -> Self {
+        let Some(path) = Self::path() else { return Self::empty() };
+        let Ok(bytes) = std::fs::read(&path) else { return Self::empty() };
+        let parsed: Result<CacheFile, _> = serde_json::from_slice(&bytes);
+        match parsed {
+            Ok(cf) if cf.version == CACHE_VERSION => cf,
+            _ => {
+                // Delete corrupt or wrong-version file silently.
+                let _ = std::fs::remove_file(&path);
+                Self::empty()
+            }
+        }
+    }
+
+    /// Atomic write via temp-file + rename.
+    pub fn save(&self) -> Result<()> {
+        let Some(path) = Self::path() else { return Ok(()) };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).context("create cache dir")?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        let json = serde_json::to_vec_pretty(self)?;
+        std::fs::write(&tmp, json).context("write cache tmp")?;
+        std::fs::rename(&tmp, &path).context("rename cache tmp")?;
+        Ok(())
+    }
+
+    /// Look up a cache hit for `canonical_url`. Returns `None` if missing or past TTL.
+    pub fn lookup(&self, canonical_url: &str) -> Option<EnrichedTitle> {
+        let entry = self.entries.get(canonical_url)?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        if now.saturating_sub(entry.fetched_at) > TTL_SECONDS {
+            return None;
+        }
+        Some(EnrichedTitle {
+            title: entry.title.clone(),
+            state: entry.state,
+            author: entry.author.clone(),
+        })
+    }
+
+    pub fn insert(&mut self, canonical_url: String, enrichment: &EnrichedTitle) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        self.entries.insert(
+            canonical_url,
+            CacheEntry {
+                fetched_at: now,
+                title: enrichment.title.clone(),
+                state: enrichment.state,
+                author: enrichment.author.clone(),
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty_cache() {
+        let cf = CacheFile::empty();
+        let json = serde_json::to_string(&cf).unwrap();
+        let back: CacheFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.version, CACHE_VERSION);
+        assert!(back.entries.is_empty());
+    }
+
+    #[test]
+    fn lookup_respects_ttl() {
+        let mut cf = CacheFile::empty();
+        let url = "https://github.com/a/b/pull/1".to_string();
+        let enrichment = EnrichedTitle {
+            title: "test".into(),
+            state: GhState::Open,
+            author: Some("alice".into()),
+        };
+        cf.insert(url.clone(), &enrichment);
+        assert!(cf.lookup(&url).is_some());
+
+        // Force-expire by mutating fetched_at
+        cf.entries.get_mut(&url).unwrap().fetched_at = 0;
+        assert!(cf.lookup(&url).is_none());
+    }
+
+    #[test]
+    fn version_mismatch_resets() {
+        let bad = r#"{"version":999,"entries":{}}"#;
+        let parsed: Result<CacheFile, _> = serde_json::from_str(bad);
+        assert!(parsed.is_ok());
+        assert_ne!(parsed.unwrap().version, CACHE_VERSION);
+    }
+}

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -58,10 +58,11 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
 
 /// Build the argv for `tmux set-buffer -w <payload>`. Pulled out of
 /// `yank_to_clipboard` so a unit test can pin the flags across refactors —
-/// specifically, that `-w` stays (without it tmux would set only its own
-/// internal buffer and skip OSC 52 emission to clients, silently breaking
-/// the Mac-clipboard hop), and that `payload` is passed as a single
-/// argument so whitespace-containing URLs don't get split.
+/// specifically, that `-w` stays (without it tmux sets only its own
+/// internal buffer and skips OSC 52 emission to attached clients, silently
+/// breaking the hop to the outer terminal's clipboard), and that `payload`
+/// is passed as a single argument so whitespace-containing URLs don't get
+/// split.
 pub(crate) fn yank_to_clipboard_args(payload: &str) -> Vec<String> {
     vec![
         "set-buffer".to_string(),
@@ -72,16 +73,18 @@ pub(crate) fn yank_to_clipboard_args(payload: &str) -> Vec<String> {
 
 /// Push `payload` onto the clipboard via `tmux set-buffer -w`.
 ///
-/// The `-w` flag tells tmux to also emit OSC 52 to each attached client's
-/// pty, which is the path verified end-to-end (devvm → tmux server →
-/// terminal emulator → OS clipboard). The earlier direct write to
-/// `/dev/tty` also worked but went through a different code path and was
-/// harder to diagnose when intermediate links broke; routing through tmux
-/// unifies yank with the rest of `rmux_helper`'s "everything goes through
-/// tmux" architecture (capture-pane, display-message, new-window).
+/// The `-w` flag tells tmux to emit OSC 52 to each attached client's pty;
+/// without it, only tmux's internal paste buffer would be set and the
+/// escape never reaches the outer terminal. Success here means tmux
+/// accepted the command and will queue the escape — it does NOT guarantee
+/// the outer terminal actually forwarded OSC 52 to the OS clipboard (some
+/// terminal emulators gate OSC 52 writing behind config options).
 ///
-/// Requires tmux to be running — but so does the whole picker (scrollback
-/// capture fails earlier without it), so this introduces no new dependency.
+/// Routing clipboard writes through tmux also matches the rest of
+/// `rmux_helper`'s architecture — capture-pane, display-message, and
+/// new-window all shell out to tmux — so no new dependency is introduced
+/// (`pick-links` already fails earlier in `capture_pane` if tmux isn't
+/// running).
 fn yank_to_clipboard(payload: &str) -> Result<()> {
     let args = yank_to_clipboard_args(payload);
     let status = Command::new("tmux")
@@ -175,10 +178,11 @@ fn resolve_pane_id() -> Result<String> {
 }
 
 /// History depth (lines above the visible pane top) that pick-links scans.
-/// Capped deliberately — a full 50k-line `history-limit` buffer produces
-/// stale context from days-old work and drowns real results in noise.
-/// 300 lines is roughly several screens of recent scrollback, enough to
-/// catch "that PR URL I pasted ten minutes ago" without going deeper.
+/// Capped deliberately — on typical dev machines the tmux `history-limit`
+/// is several thousand lines, which produces stale context from days-old
+/// work and drowns real results in noise. 300 is roughly several screens
+/// of recent scrollback, enough to catch "that PR URL I pasted ten minutes
+/// ago" without going deeper.
 pub(crate) const SCROLLBACK_HISTORY_LINES: u32 = 300;
 
 /// Build the argv for `tmux capture-pane`. Pulled out of `capture_pane` so a
@@ -210,11 +214,15 @@ fn capture_pane(pane_id: &str) -> Result<String> {
     let out = Command::new("tmux")
         .args(&args)
         .output()
-        .map_err(|e| anyhow!("tmux capture-pane failed: {e}"))?;
+        .map_err(|e| anyhow!("tmux capture-pane failed to spawn: {e}"))?;
     if !out.status.success() {
         let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        // Include the full argv so e.g. an ancient tmux rejecting `-S -300`
+        // surfaces the flag in the error rather than a cryptic
+        // "ambiguous option".
         return Err(anyhow!(
-            "tmux capture-pane -t {pane_id} returned nonzero: {err}"
+            "tmux {} returned nonzero: {err}",
+            args.join(" ")
         ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).to_string())

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -1,0 +1,23 @@
+//! Scrollback link picker — top-level orchestration.
+
+pub mod detect;
+pub mod enrich;
+pub mod tui;
+
+use anyhow::Result;
+
+/// Entry point for `rmux_helper pick-links`.
+pub fn pick_links(_json: bool, _enrich_deadline_ms: u64) -> Result<()> {
+    // Minimal smoke: print empty JSON array.
+    println!("[]");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn pick_links_json_mode_returns_empty_array_when_scrollback_is_empty() {
+        // Integration-level smoke; replaced in Task 13 with real pipeline.
+        assert!(true, "placeholder — replaced when pipeline lands");
+    }
+}

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -40,7 +40,7 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     match action {
         tui::Action::Quit => std::process::exit(130),
         tui::Action::Yank(row) => {
-            yank_osc52(&row.canonical)?;
+            yank_to_clipboard(&row.canonical)?;
             println!("{}", row.canonical);
         }
         tui::Action::Open(row) => open_url(&row.canonical)?,
@@ -56,26 +56,29 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     Ok(())
 }
 
-/// Build the raw OSC 52 "copy to clipboard" escape sequence for `payload`.
-/// Pure function split out of `yank_osc52` so it's unit-testable — the
-/// writing-to-/dev/tty side is inherently integration-tested via tmux
-/// (`tmux show-buffer` after a yank), but the byte format itself should be
-/// pinned against accidental base64 flavor or prefix/suffix drift.
+/// Push `payload` onto the clipboard via `tmux set-buffer -w`.
 ///
-/// Format: `ESC ] 52 ; c ; <standard-base64> ESC \` — the xterm OSC 52
-/// "set clipboard" sequence, `c` selector for the CLIPBOARD selection.
-pub(crate) fn format_osc52(payload: &str) -> String {
-    use base64::Engine;
-    let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
-    format!("\x1b]52;c;{b64}\x1b\\")
-}
-
-fn yank_osc52(payload: &str) -> Result<()> {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    let mut tty = OpenOptions::new().write(true).open("/dev/tty")?;
-    write!(tty, "{}", format_osc52(payload))?;
-    tty.flush()?;
+/// The `-w` flag tells tmux to also emit OSC 52 to each attached client's
+/// pty, which is the path verified end-to-end (devvm → tmux server →
+/// terminal emulator → OS clipboard). The earlier direct write to
+/// `/dev/tty` also worked but went through a different code path and was
+/// harder to diagnose when intermediate links broke; routing through tmux
+/// unifies yank with the rest of `rmux_helper`'s "everything goes through
+/// tmux" architecture (capture-pane, display-message, new-window).
+///
+/// Requires tmux to be running — but so does the whole picker (scrollback
+/// capture fails earlier without it), so this introduces no new dependency.
+fn yank_to_clipboard(payload: &str) -> Result<()> {
+    let status = Command::new("tmux")
+        .args(["set-buffer", "-w", payload])
+        .status()
+        .map_err(|e| anyhow!("tmux set-buffer failed to spawn: {e}"))?;
+    if !status.success() {
+        return Err(anyhow!(
+            "tmux set-buffer -w returned nonzero: {}",
+            status.code().unwrap_or(-1)
+        ));
+    }
     Ok(())
 }
 
@@ -213,47 +216,6 @@ mod orchestration_tests {
         let json = serde_json::to_string(&rows).unwrap();
         assert!(json.contains("\"category\":\"pull_request\""));
         assert!(json.contains("\"category\":\"server\""));
-    }
-
-    #[test]
-    fn osc52_format_matches_xterm_spec() {
-        // Spec: ESC ] 52 ; c ; <standard-base64(payload)> ESC \
-        let seq = format_osc52("https://github.com/a/b/pull/1");
-        assert!(seq.starts_with("\x1b]52;c;"), "missing OSC 52 prefix");
-        assert!(seq.ends_with("\x1b\\"), "missing ST suffix");
-
-        // Extract the base64 middle and confirm it decodes back to the payload.
-        let inner = seq
-            .strip_prefix("\x1b]52;c;")
-            .unwrap()
-            .strip_suffix("\x1b\\")
-            .unwrap();
-        use base64::Engine;
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(inner)
-            .expect("payload must be valid standard base64");
-        assert_eq!(decoded, b"https://github.com/a/b/pull/1");
-    }
-
-    #[test]
-    fn osc52_handles_unicode_and_special_chars() {
-        // UTF-8 payloads must survive the round-trip — rows can contain
-        // non-ASCII in context columns (though canonicals are ASCII URLs,
-        // we want the primitive to not silently corrupt anything).
-        let seq = format_osc52("c-5001 — ssh host");
-        let inner = seq
-            .strip_prefix("\x1b]52;c;")
-            .unwrap()
-            .strip_suffix("\x1b\\")
-            .unwrap();
-        use base64::Engine;
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(inner)
-            .unwrap();
-        assert_eq!(
-            String::from_utf8(decoded).unwrap(),
-            "c-5001 — ssh host"
-        );
     }
 
     #[test]

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -146,8 +146,12 @@ fn resolve_pane_id() -> Result<String> {
 
 /// Capture the full scrollback of `pane_id` via `tmux capture-pane`.
 fn capture_pane(pane_id: &str) -> Result<String> {
+    // NOTE: `-e` (include ANSI escapes) was removed because raw \x1b bytes
+    // in the context column leak through ratatui's cell rendering into the
+    // popup's pty and are interpreted as terminal control sequences,
+    // corrupting the display. Plain text is sufficient for v1.
     let out = Command::new("tmux")
-        .args(["capture-pane", "-p", "-J", "-e", "-S", "-", "-E", "-", "-t", pane_id])
+        .args(["capture-pane", "-p", "-J", "-S", "-", "-E", "-", "-t", pane_id])
         .output()
         .map_err(|e| anyhow!("tmux capture-pane failed: {e}"))?;
     if !out.status.success() {

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -144,14 +144,41 @@ fn resolve_pane_id() -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
-/// Capture the full scrollback of `pane_id` via `tmux capture-pane`.
+/// History depth (lines above the visible pane top) that pick-links scans.
+/// Capped deliberately — a full 50k-line `history-limit` buffer produces
+/// stale context from days-old work and drowns real results in noise.
+/// 300 lines is roughly several screens of recent scrollback, enough to
+/// catch "that PR URL I pasted ten minutes ago" without going deeper.
+pub(crate) const SCROLLBACK_HISTORY_LINES: u32 = 300;
+
+/// Build the argv for `tmux capture-pane`. Pulled out of `capture_pane` so a
+/// unit test can assert the history cap stays in place across refactors.
+///
+/// `-S -N` starts N lines above the top of the visible pane; `-E -` ends at
+/// the bottom of the visible pane. `-J` joins soft-wrapped lines so URLs
+/// that wrapped across terminal rows read back whole.
+pub(crate) fn capture_pane_args(pane_id: &str) -> Vec<String> {
+    // NOTE: `-e` (include ANSI escapes) was intentionally dropped earlier —
+    // raw \x1b bytes leaked through ratatui's cell rendering into the popup
+    // pty and corrupted the display. Plain text is sufficient.
+    vec![
+        "capture-pane".to_string(),
+        "-p".to_string(),
+        "-J".to_string(),
+        "-S".to_string(),
+        format!("-{SCROLLBACK_HISTORY_LINES}"),
+        "-E".to_string(),
+        "-".to_string(),
+        "-t".to_string(),
+        pane_id.to_string(),
+    ]
+}
+
+/// Capture the recent scrollback of `pane_id` via `tmux capture-pane`.
 fn capture_pane(pane_id: &str) -> Result<String> {
-    // NOTE: `-e` (include ANSI escapes) was removed because raw \x1b bytes
-    // in the context column leak through ratatui's cell rendering into the
-    // popup's pty and are interpreted as terminal control sequences,
-    // corrupting the display. Plain text is sufficient for v1.
+    let args = capture_pane_args(pane_id);
     let out = Command::new("tmux")
-        .args(["capture-pane", "-p", "-J", "-S", "-", "-E", "-", "-t", pane_id])
+        .args(&args)
         .output()
         .map_err(|e| anyhow!("tmux capture-pane failed: {e}"))?;
     if !out.status.success() {
@@ -174,5 +201,38 @@ mod orchestration_tests {
         let json = serde_json::to_string(&rows).unwrap();
         assert!(json.contains("\"category\":\"pull_request\""));
         assert!(json.contains("\"category\":\"server\""));
+    }
+
+    #[test]
+    fn capture_pane_caps_history_at_300_lines() {
+        // Regression guard: the deliberate 300-line history cap must not
+        // silently revert to `-S -` (full history) during refactors.
+        // Going deeper surfaced ancient stale context in earlier --json
+        // dumps and drowned recent work in noise.
+        let args = capture_pane_args("%42");
+        let s_idx = args
+            .iter()
+            .position(|a| a == "-S")
+            .expect("capture-pane must pass -S");
+        assert_eq!(
+            args[s_idx + 1],
+            "-300",
+            "history depth must stay capped at 300 lines above visible top"
+        );
+        let e_idx = args
+            .iter()
+            .position(|a| a == "-E")
+            .expect("capture-pane must pass -E");
+        assert_eq!(
+            args[e_idx + 1],
+            "-",
+            "end must be bottom of visible pane"
+        );
+        assert!(args.contains(&"-J".to_string()), "must join wrapped lines");
+        assert!(args.contains(&"%42".to_string()), "must target the pane");
+        assert!(
+            !args.iter().any(|a| a == "-e"),
+            "must NOT include ANSI escapes (they corrupt popup rendering)"
+        );
     }
 }

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -56,6 +56,20 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     Ok(())
 }
 
+/// Build the argv for `tmux set-buffer -w <payload>`. Pulled out of
+/// `yank_to_clipboard` so a unit test can pin the flags across refactors —
+/// specifically, that `-w` stays (without it tmux would set only its own
+/// internal buffer and skip OSC 52 emission to clients, silently breaking
+/// the Mac-clipboard hop), and that `payload` is passed as a single
+/// argument so whitespace-containing URLs don't get split.
+pub(crate) fn yank_to_clipboard_args(payload: &str) -> Vec<String> {
+    vec![
+        "set-buffer".to_string(),
+        "-w".to_string(),
+        payload.to_string(),
+    ]
+}
+
 /// Push `payload` onto the clipboard via `tmux set-buffer -w`.
 ///
 /// The `-w` flag tells tmux to also emit OSC 52 to each attached client's
@@ -69,8 +83,9 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
 /// Requires tmux to be running — but so does the whole picker (scrollback
 /// capture fails earlier without it), so this introduces no new dependency.
 fn yank_to_clipboard(payload: &str) -> Result<()> {
+    let args = yank_to_clipboard_args(payload);
     let status = Command::new("tmux")
-        .args(["set-buffer", "-w", payload])
+        .args(&args)
         .status()
         .map_err(|e| anyhow!("tmux set-buffer failed to spawn: {e}"))?;
     if !status.success() {
@@ -216,6 +231,31 @@ mod orchestration_tests {
         let json = serde_json::to_string(&rows).unwrap();
         assert!(json.contains("\"category\":\"pull_request\""));
         assert!(json.contains("\"category\":\"server\""));
+    }
+
+    #[test]
+    fn yank_argv_passes_dash_w_and_single_payload_arg() {
+        // Regression guard: if someone drops `-w` the OSC 52 hop to clients
+        // silently stops working — tmux would only set its own buffer, no
+        // client ever gets the escape, Mac clipboard stays stale. And if
+        // payload gets split across multiple args, tmux treats it as a
+        // command-line-join which corrupts URLs containing spaces or
+        // special chars.
+        let args = yank_to_clipboard_args("https://github.com/a/b/pull/1");
+        assert_eq!(args[0], "set-buffer");
+        assert_eq!(args[1], "-w", "must keep -w for client OSC 52 emission");
+        assert_eq!(args[2], "https://github.com/a/b/pull/1");
+        assert_eq!(args.len(), 3, "no extra args or stray flags");
+    }
+
+    #[test]
+    fn yank_argv_passes_payload_with_spaces_as_one_arg() {
+        // Payloads can include spaces (context strings, enriched titles).
+        // Each must arrive at tmux as ONE argv slot — not split on
+        // whitespace.
+        let args = yank_to_clipboard_args("hello world with spaces");
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[2], "hello world with spaces");
     }
 
     #[test]

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -1,23 +1,91 @@
 //! Scrollback link picker — top-level orchestration.
+//! See spec docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md §Execution Flow.
 
 pub mod detect;
 pub mod enrich;
 pub mod tui;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use std::env;
+use std::process::Command;
 
-/// Entry point for `rmux_helper pick-links`.
-pub fn pick_links(_json: bool, _enrich_deadline_ms: u64) -> Result<()> {
-    // Minimal smoke: print empty JSON array.
-    println!("[]");
+/// Entry point for `rmux_helper pick-links`. See spec §Execution Flow.
+pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
+    // 1. Resolve pane
+    let pane_id = resolve_pane_id()?;
+
+    // 2. Capture (sync, fallible)
+    let raw = capture_pane(&pane_id)?;
+
+    // 3. Detect
+    let rows = detect::parse(&raw);
+
+    if json {
+        // --json short-circuit: skip enrich + TUI entirely.
+        println!("{}", serde_json::to_string(&rows)?);
+        return Ok(());
+    }
+
+    // 4. Enrich (blocks inside tokio, then drops runtime before TUI)
+    let rows = enrich::enrich_rows(rows, enrich_deadline_ms);
+
+    // 5. TUI (stub in this task; real implementation in Task 14-15)
+    if rows.is_empty() {
+        eprintln!("pick-links: no links, servers, or IPs in scrollback");
+        return Ok(());
+    }
+    let _action = tui::run(rows)?;
+
+    // 6-7. Teardown + dispatch happen inside tui::run + action handler in Task 16.
     Ok(())
 }
 
+/// Resolve the tmux pane id to capture. See spec §Scrollback Capture.
+fn resolve_pane_id() -> Result<String> {
+    if let Ok(p) = env::var("TMUX_PANE") {
+        if !p.is_empty() {
+            return Ok(p);
+        }
+    }
+    if env::var("TMUX").is_err() {
+        return Err(anyhow!("pick-links: not inside tmux; nothing to capture"));
+    }
+    // Fallback: ask tmux directly.
+    let out = Command::new("tmux")
+        .args(["display-message", "-p", "-t", "#{client_active_pane}", "#{pane_id}"])
+        .output()
+        .map_err(|e| anyhow!("tmux display-message failed: {e}"))?;
+    if !out.status.success() {
+        return Err(anyhow!("tmux display-message returned nonzero"));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Capture the full scrollback of `pane_id` via `tmux capture-pane`.
+fn capture_pane(pane_id: &str) -> Result<String> {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-p", "-J", "-e", "-S", "-", "-E", "-", "-t", pane_id])
+        .output()
+        .map_err(|e| anyhow!("tmux capture-pane failed: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(anyhow!(
+            "tmux capture-pane -t {pane_id} returned nonzero: {err}"
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
 #[cfg(test)]
-mod tests {
+mod orchestration_tests {
+    use super::*;
+
     #[test]
-    fn pick_links_json_mode_returns_empty_array_when_scrollback_is_empty() {
-        // Integration-level smoke; replaced in Task 13 with real pipeline.
-        assert!(true, "placeholder — replaced when pipeline lands");
+    fn parses_json_output_from_fake_scrollback() {
+        let raw = "Merge https://github.com/a/b/pull/1\nssh c-5001\n";
+        let rows = detect::parse(raw);
+        let json = serde_json::to_string(&rows).unwrap();
+        assert!(json.contains("\"category\":\"pull_request\""));
+        assert!(json.contains("\"category\":\"server\""));
     }
 }

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -45,7 +45,7 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
         }
         tui::Action::Open(row) => open_url(&row.canonical)?,
         tui::Action::GhWeb(row) => gh_web(&row)?,
-        tui::Action::Ssh(row) => ssh_host(&row)?,
+        tui::Action::Ssh(row) => ssh_host(&row, &pane_id)?,
         tui::Action::SwapToPickTui => {
             use std::os::unix::process::CommandExt;
             // execvp: never returns on success
@@ -108,13 +108,18 @@ fn gh_web(row: &detect::Row) -> Result<()> {
     Ok(())
 }
 
-fn ssh_host(row: &detect::Row) -> Result<()> {
+fn ssh_host(row: &detect::Row, pane_id: &str) -> Result<()> {
     // Use tmux new-window in the originating pane's session.
-    let pane = env::var("TMUX_PANE").unwrap_or_default();
     let host_arg = format!("ssh {}", row.canonical);
-    Command::new("tmux")
-        .args(["new-window", "-t", &pane, &host_arg])
+    let status = Command::new("tmux")
+        .args(["new-window", "-t", pane_id, "-c", "#{pane_current_path}", &host_arg])
         .status()?;
+    if !status.success() {
+        return Err(anyhow!(
+            "tmux new-window failed with exit status {}",
+            status.code().unwrap_or(-1)
+        ));
+    }
     Ok(())
 }
 

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -29,14 +29,92 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     // 4. Enrich (blocks inside tokio, then drops runtime before TUI)
     let rows = enrich::enrich_rows(rows, enrich_deadline_ms);
 
-    // 5. TUI (stub in this task; real implementation in Task 14-15)
+    // 5. TUI
     if rows.is_empty() {
         eprintln!("pick-links: no links, servers, or IPs in scrollback");
         return Ok(());
     }
-    let _action = tui::run(rows)?;
+    let action = tui::run(rows)?;
 
-    // 6-7. Teardown + dispatch happen inside tui::run + action handler in Task 16.
+    // 6-7. Dispatch post-TUI (terminal already restored by tui::run).
+    match action {
+        tui::Action::Quit => std::process::exit(130),
+        tui::Action::Yank(row) => {
+            yank_osc52(&row.canonical)?;
+            println!("{}", row.canonical);
+        }
+        tui::Action::Open(row) => open_url(&row.canonical)?,
+        tui::Action::GhWeb(row) => gh_web(&row)?,
+        tui::Action::Ssh(row) => ssh_host(&row)?,
+        tui::Action::SwapToPickTui => {
+            use std::os::unix::process::CommandExt;
+            // execvp: never returns on success
+            let err = Command::new("rmux_helper").arg("pick-tui").exec();
+            return Err(anyhow!("exec pick-tui failed: {err}"));
+        }
+    }
+    Ok(())
+}
+
+fn yank_osc52(payload: &str) -> Result<()> {
+    use base64::Engine;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+    let mut tty = OpenOptions::new().write(true).open("/dev/tty")?;
+    write!(tty, "\x1b]52;c;{b64}\x1b\\")?;
+    tty.flush()?;
+    Ok(())
+}
+
+fn open_url(url: &str) -> Result<()> {
+    let cmd = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    Command::new(cmd).arg(url).status()?;
+    Ok(())
+}
+
+fn gh_web(row: &detect::Row) -> Result<()> {
+    use detect::Category as C;
+    let subcmd = match row.category {
+        C::PullRequest => "pr",
+        C::Issue => "issue",
+        C::Commit | C::File | C::Repo => {
+            // Fall through to plain open — gh doesn't have a generic "view" for these
+            return open_url(&row.canonical);
+        }
+        _ => return Ok(()),
+    };
+    // row.key is "#N" for PR/Issue — strip "#" for gh arg.
+    let id = row.key.trim_start_matches('#');
+    // repo_or_host carries only the repo name; owner must come from canonical.
+    // canonical is normalized: https://github.com/OWNER/REPO/...
+    let owner_repo = row
+        .canonical
+        .strip_prefix("https://github.com/")
+        .map(|s| {
+            let mut parts = s.splitn(3, '/');
+            let o = parts.next().unwrap_or("");
+            let r = parts.next().unwrap_or("");
+            format!("{o}/{r}")
+        })
+        .unwrap_or_else(|| row.repo_or_host.clone());
+    Command::new("gh")
+        .args([subcmd, "view", id, "-R", &owner_repo, "--web"])
+        .status()?;
+    Ok(())
+}
+
+fn ssh_host(row: &detect::Row) -> Result<()> {
+    // Use tmux new-window in the originating pane's session.
+    let pane = env::var("TMUX_PANE").unwrap_or_default();
+    let host_arg = format!("ssh {}", row.canonical);
+    Command::new("tmux")
+        .args(["new-window", "-t", &pane, &host_arg])
+        .status()?;
     Ok(())
 }
 

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -56,13 +56,25 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     Ok(())
 }
 
-fn yank_osc52(payload: &str) -> Result<()> {
+/// Build the raw OSC 52 "copy to clipboard" escape sequence for `payload`.
+/// Pure function split out of `yank_osc52` so it's unit-testable — the
+/// writing-to-/dev/tty side is inherently integration-tested via tmux
+/// (`tmux show-buffer` after a yank), but the byte format itself should be
+/// pinned against accidental base64 flavor or prefix/suffix drift.
+///
+/// Format: `ESC ] 52 ; c ; <standard-base64> ESC \` — the xterm OSC 52
+/// "set clipboard" sequence, `c` selector for the CLIPBOARD selection.
+pub(crate) fn format_osc52(payload: &str) -> String {
     use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+    format!("\x1b]52;c;{b64}\x1b\\")
+}
+
+fn yank_osc52(payload: &str) -> Result<()> {
     use std::fs::OpenOptions;
     use std::io::Write;
-    let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
     let mut tty = OpenOptions::new().write(true).open("/dev/tty")?;
-    write!(tty, "\x1b]52;c;{b64}\x1b\\")?;
+    write!(tty, "{}", format_osc52(payload))?;
     tty.flush()?;
     Ok(())
 }
@@ -201,6 +213,47 @@ mod orchestration_tests {
         let json = serde_json::to_string(&rows).unwrap();
         assert!(json.contains("\"category\":\"pull_request\""));
         assert!(json.contains("\"category\":\"server\""));
+    }
+
+    #[test]
+    fn osc52_format_matches_xterm_spec() {
+        // Spec: ESC ] 52 ; c ; <standard-base64(payload)> ESC \
+        let seq = format_osc52("https://github.com/a/b/pull/1");
+        assert!(seq.starts_with("\x1b]52;c;"), "missing OSC 52 prefix");
+        assert!(seq.ends_with("\x1b\\"), "missing ST suffix");
+
+        // Extract the base64 middle and confirm it decodes back to the payload.
+        let inner = seq
+            .strip_prefix("\x1b]52;c;")
+            .unwrap()
+            .strip_suffix("\x1b\\")
+            .unwrap();
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(inner)
+            .expect("payload must be valid standard base64");
+        assert_eq!(decoded, b"https://github.com/a/b/pull/1");
+    }
+
+    #[test]
+    fn osc52_handles_unicode_and_special_chars() {
+        // UTF-8 payloads must survive the round-trip — rows can contain
+        // non-ASCII in context columns (though canonicals are ASCII URLs,
+        // we want the primitive to not silently corrupt anything).
+        let seq = format_osc52("c-5001 — ssh host");
+        let inner = seq
+            .strip_prefix("\x1b]52;c;")
+            .unwrap()
+            .strip_suffix("\x1b\\")
+            .unwrap();
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(inner)
+            .unwrap();
+        assert_eq!(
+            String::from_utf8(decoded).unwrap(),
+            "c-5001 — ssh host"
+        );
     }
 
     #[test]

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -265,6 +265,14 @@ pub fn run(rows: Vec<Row>) -> Result<Action> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
+    // Drain any stale events queued before the popup opened (e.g. the
+    // `C-a L` keypress leaking into the new pty). Without this, the first
+    // event_loop iteration can consume a phantom event and act on it
+    // unexpectedly. Mirrors picker.rs:595-598.
+    while event::poll(std::time::Duration::from_millis(1))? {
+        let _ = event::read();
+    }
+
     let mut app = App::new(rows);
     let result = event_loop(&mut app, &mut terminal);
 

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -426,9 +426,125 @@ fn preview_for_selection(app: &App) -> Text<'static> {
         .unwrap_or_else(|_| Text::raw(body))
 }
 
-// Key handling is stubbed here for Task 14; wired in Task 15.
-fn handle_key(app: &mut App, _mods: KeyModifiers, code: KeyCode) {
+fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
+    // Esc: drill-out or quit
     if matches!(code, KeyCode::Esc) {
-        app.action = Some(Action::Quit);
+        if app.drilled_in.is_some() {
+            app.drilled_in = None;
+            app.rebuild_filter();
+        } else {
+            app.action = Some(Action::Quit);
+        }
+        return;
+    }
+
+    // Ctrl-C: clear query or quit
+    if matches!(code, KeyCode::Char('c')) && mods.contains(KeyModifiers::CONTROL) {
+        if !app.query.is_empty() {
+            app.query.clear();
+            app.rebuild_filter();
+        } else {
+            app.action = Some(Action::Quit);
+        }
+        return;
+    }
+
+    // Navigation
+    match code {
+        KeyCode::Down | KeyCode::Char('\x0e') => app.move_selection(1),
+        KeyCode::Up | KeyCode::Char('\x10') => app.move_selection(-1),
+        KeyCode::Right => app.drill_in(),
+        KeyCode::Left => {
+            if app.drilled_in.is_some() {
+                app.drilled_in = None;
+                app.rebuild_filter();
+            }
+        }
+        KeyCode::Enter => app.on_enter(),
+        KeyCode::F(2) => app.action = Some(Action::SwapToPickTui),
+        KeyCode::F(1) => { /* help overlay — TODO v1.1 */ }
+        KeyCode::Backspace => {
+            app.query.pop();
+            app.rebuild_filter();
+        }
+        KeyCode::Char('l') if mods.contains(KeyModifiers::CONTROL) => {
+            app.horizontal = !app.horizontal;
+        }
+        KeyCode::Char('n') if mods.contains(KeyModifiers::CONTROL) => app.move_selection(1),
+        KeyCode::Char('p') if mods.contains(KeyModifiers::CONTROL) => app.move_selection(-1),
+        // Digit 1-9: jump to Nth category drilled-in view
+        KeyCode::Char(c @ '1'..='9') if mods.is_empty() && app.query.is_empty() => {
+            let n = (c as u8 - b'0') as usize;
+            if let Some(cat) = app.categories_present.get(n - 1) {
+                app.drilled_in = Some(*cat);
+                app.rebuild_filter();
+            }
+        }
+        KeyCode::Char(c) if c.is_ascii_graphic() || c == ' ' => {
+            app.query.push(c);
+            app.rebuild_filter();
+        }
+        _ => {}
+    }
+}
+
+impl App {
+    /// Move selection by `delta`. Headers are selectable per spec — do NOT skip them.
+    /// (Plan deviation: the plan's version skipped headers, contradicting the spec.)
+    fn move_selection(&mut self, delta: i32) {
+        let Some(cur) = self.list_state.selected() else {
+            return;
+        };
+        let len = self.filtered.len() as i32;
+        if len == 0 {
+            return;
+        }
+        let next = (cur as i32 + delta).clamp(0, len - 1);
+        self.list_state.select(Some(next as usize));
+    }
+
+    fn drill_in(&mut self) {
+        if self.drilled_in.is_some() {
+            return;
+        }
+        let Some(cur) = self.list_state.selected() else {
+            return;
+        };
+        let Some(&idx) = self.filtered.get(cur) else {
+            return;
+        };
+        let cat = if let Some(c) = sentinel_to_category(idx) {
+            c
+        } else {
+            self.rows[idx].category
+        };
+        self.drilled_in = Some(cat);
+        self.rebuild_filter();
+    }
+
+    fn on_enter(&mut self) {
+        let Some(cur) = self.list_state.selected() else {
+            return;
+        };
+        let Some(&idx) = self.filtered.get(cur) else {
+            return;
+        };
+        if let Some(cat) = sentinel_to_category(idx) {
+            // Header: drill in
+            self.drilled_in = Some(cat);
+            self.rebuild_filter();
+            return;
+        }
+        // Leaf: default action
+        let row = self.rows[idx].clone();
+        self.action = Some(default_action(&row));
+    }
+}
+
+/// Default Enter action per category (see spec §Actions → Default).
+pub(crate) fn default_action(row: &Row) -> Action {
+    match row.category {
+        Category::Server | Category::Ip => Action::Ssh(row.clone()),
+        _ => Action::Yank(row.clone()),
     }
 }

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -1,15 +1,434 @@
-//! Ratatui TUI for the link picker. Replaced in Task 14.
+//! Ratatui TUI for the link picker. See spec §Layout & Display and §Navigation.
 
-use crate::link_picker::detect::Row;
+use crate::link_picker::detect::{Category, GhState, Row};
+use ansi_to_tui::IntoText;
 use anyhow::Result;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    prelude::*,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    Terminal,
+};
+use std::io;
 
-/// Placeholder action enum — extended in Task 16.
+/// Action returned from the TUI to the orchestrator. See spec §Actions.
+#[derive(Debug)]
 pub enum Action {
     Quit,
+    Yank(Row),
+    Open(Row),
+    GhWeb(Row),
+    Ssh(Row),
+    SwapToPickTui,
 }
 
-pub fn run(_rows: Vec<Row>) -> Result<Action> {
-    // Temporary: immediately return Quit so `pick-links` without `--json`
-    // is still callable from tests without a TTY.
-    Ok(Action::Quit)
+struct App {
+    rows: Vec<Row>,
+    filtered: Vec<usize>, // indices into rows in display order (including separators)
+    categories_present: Vec<Category>, // non-empty categories
+    list_state: ListState,
+    query: String,
+    drilled_in: Option<Category>,
+    horizontal: bool,
+    action: Option<Action>,
+    error_msg: Option<String>,
+}
+
+impl App {
+    fn new(rows: Vec<Row>) -> Self {
+        let mut app = Self {
+            rows,
+            filtered: Vec::new(),
+            categories_present: Vec::new(),
+            list_state: ListState::default(),
+            query: String::new(),
+            drilled_in: None,
+            horizontal: true,
+            action: None,
+            error_msg: None,
+        };
+        app.rebuild_filter();
+        app
+    }
+
+    /// Rebuild `filtered` + `categories_present` based on query + drill state.
+    fn rebuild_filter(&mut self) {
+        self.categories_present.clear();
+        self.filtered.clear();
+
+        let tokens = tokenize(&self.query);
+        let matches: Vec<usize> = self
+            .rows
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| match_row(r, &tokens))
+            .filter(|(_, r)| self.drilled_in.map_or(true, |c| r.category == c))
+            .map(|(i, _)| i)
+            .collect();
+
+        // Sentinel indexing: we insert separators as usize::MAX entries and category
+        // headers as (usize::MAX - 1 - category_idx). We disambiguate when rendering.
+        let mut last_cat: Option<Category> = None;
+        for idx in &matches {
+            let cat = self.rows[*idx].category;
+            if Some(cat) != last_cat {
+                if self.drilled_in.is_none() {
+                    self.filtered.push(header_sentinel(cat));
+                }
+                self.categories_present.push(cat);
+                last_cat = Some(cat);
+            }
+            self.filtered.push(*idx);
+        }
+
+        // Snap selection to the first leaf (if any).
+        if self.filtered.is_empty() {
+            self.list_state.select(None);
+        } else {
+            let first_leaf = self
+                .filtered
+                .iter()
+                .position(|&i| i < SENTINEL_BASE)
+                .unwrap_or(0);
+            self.list_state.select(Some(first_leaf));
+        }
+    }
+}
+
+/// Sentinel values above the real index space mean "not a leaf".
+const SENTINEL_BASE: usize = usize::MAX - 100;
+fn header_sentinel(cat: Category) -> usize {
+    SENTINEL_BASE + (cat as usize)
+}
+fn sentinel_to_category(s: usize) -> Option<Category> {
+    if s < SENTINEL_BASE {
+        return None;
+    }
+    match s - SENTINEL_BASE {
+        1 => Some(Category::PullRequest),
+        2 => Some(Category::Issue),
+        3 => Some(Category::Commit),
+        4 => Some(Category::File),
+        5 => Some(Category::Repo),
+        6 => Some(Category::Blog),
+        7 => Some(Category::OtherLink),
+        8 => Some(Category::Server),
+        9 => Some(Category::Ip),
+        _ => None,
+    }
+}
+
+// ----- Filter tokenization (see spec §Filtering semantics, Divergence 1 & 2) -----
+
+/// Divergence 1 from pick-tui: multi-digit tokens are NOT split per-digit,
+/// because splitting would cause PR-number matches to misfire.
+pub(crate) fn tokenize(query: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for word in query.split_whitespace() {
+        // Split letter/digit boundaries ONCE per transition (not per character).
+        let mut cur = String::new();
+        let mut cur_is_digit = None;
+        for ch in word.chars() {
+            let this_is_digit = ch.is_ascii_digit();
+            if cur_is_digit.map_or(false, |d: bool| d != this_is_digit) && !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+            cur.push(ch);
+            cur_is_digit = Some(this_is_digit);
+        }
+        if !cur.is_empty() {
+            out.push(cur);
+        }
+    }
+    out
+}
+
+/// Divergence 2: the category short-name tag is prepended to the row's
+/// search string with a `\x1f` unit separator so substring matches can't
+/// leak from the tag into the body.
+pub(crate) fn row_search_string(r: &Row) -> String {
+    // tag \x1f key repo-or-host context canonical
+    format!(
+        "{}\x1f{} {} {} {}",
+        r.category.tag(),
+        r.key,
+        r.repo_or_host,
+        r.context,
+        r.canonical
+    )
+}
+
+pub(crate) fn match_row(r: &Row, tokens: &[String]) -> bool {
+    if tokens.is_empty() {
+        return true;
+    }
+    let hay = row_search_string(r).to_lowercase();
+    // Key column alone for digit tokens:
+    let key_lc = r.key.to_lowercase();
+    for tok in tokens {
+        let t = tok.to_lowercase();
+        if tok.chars().all(|c| c.is_ascii_digit()) {
+            if !key_lc.contains(&t) {
+                return false;
+            }
+        } else if !hay.contains(&t) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::*;
+
+    fn mk(cat: Category, key: &str, context: &str) -> Row {
+        Row {
+            category: cat,
+            canonical: format!("https://github.com/a/b/pull/{key}"),
+            key: key.to_string(),
+            repo_or_host: "b".to_string(),
+            context: context.to_string(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 0,
+        }
+    }
+
+    #[test]
+    fn tokenize_splits_letter_digit_boundary_once() {
+        assert_eq!(tokenize("pr68"), vec!["pr", "68"]);
+        assert_eq!(tokenize("14 cl"), vec!["14", "cl"]);
+    }
+
+    #[test]
+    fn multi_digit_token_not_split_per_digit() {
+        assert_eq!(tokenize("1234"), vec!["1234"]);
+    }
+
+    #[test]
+    fn tag_leak_is_prevented_by_unit_separator() {
+        let r = mk(Category::PullRequest, "#68", "writing prose all day");
+        // "pr" tag should NOT leak into matching against "prose"
+        let s = row_search_string(&r);
+        assert!(s.starts_with("pr\x1f"));
+        assert!(!s[..3].contains("prose"));
+    }
+
+    #[test]
+    fn digit_token_matches_key_only() {
+        let r = mk(Category::PullRequest, "#68", "context 68 somewhere");
+        assert!(match_row(&r, &[String::from("68")])); // in key
+        let r2 = mk(Category::PullRequest, "#99", "context 68 somewhere");
+        assert!(!match_row(&r2, &[String::from("68")])); // not in key
+    }
+
+    #[test]
+    fn category_tag_matches_at_start() {
+        let r = mk(Category::PullRequest, "#1", "");
+        assert!(match_row(&r, &[String::from("pr")]));
+        let r2 = mk(Category::Issue, "#1", "");
+        assert!(!match_row(&r2, &[String::from("pr")]));
+    }
+}
+
+// ----- Run loop + rendering -----
+
+pub fn run(rows: Vec<Row>) -> Result<Action> {
+    if rows.is_empty() {
+        return Ok(Action::Quit);
+    }
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(rows);
+    let result = event_loop(&mut app, &mut terminal);
+
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    drop(terminal);
+
+    result
+}
+
+fn event_loop<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> Result<Action> {
+    loop {
+        terminal.draw(|f| draw(f, app))?;
+        if let Event::Key(k) = event::read()? {
+            if k.kind != KeyEventKind::Press {
+                continue;
+            }
+            handle_key(app, k.modifiers, k.code);
+            if let Some(action) = app.action.take() {
+                return Ok(action);
+            }
+        }
+    }
+}
+
+fn draw(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let main = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(5)])
+        .split(area);
+
+    // Top bar with breadcrumb or flat hints.
+    let top = if let Some(cat) = app.drilled_in {
+        format!(
+            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back F2:sess ?:help",
+            app.query,
+            cat.display()
+        )
+    } else {
+        format!(
+            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh F2:sess ?:help",
+            app.query
+        )
+    };
+    f.render_widget(
+        Paragraph::new(top).style(Style::default().fg(Color::Yellow)),
+        main[0],
+    );
+
+    // Split content horizontally or vertically
+    let content_chunks = if app.horizontal {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(main[1])
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(65), Constraint::Percentage(35)])
+            .split(main[1])
+    };
+
+    // List
+    let items: Vec<ListItem> = app
+        .filtered
+        .iter()
+        .map(|&idx| render_item(app, idx))
+        .collect();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title("Links"))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+    f.render_stateful_widget(list, content_chunks[0], &mut app.list_state);
+
+    // Preview
+    let preview_text = preview_for_selection(app);
+    let preview = Paragraph::new(preview_text)
+        .block(Block::default().borders(Borders::ALL).title("Preview"))
+        .wrap(Wrap { trim: false });
+    f.render_widget(preview, content_chunks[1]);
+}
+
+fn render_item(app: &App, idx: usize) -> ListItem<'static> {
+    if let Some(cat) = sentinel_to_category(idx) {
+        let count = app
+            .filtered
+            .iter()
+            .filter(|i| **i < SENTINEL_BASE && app.rows[**i].category == cat)
+            .count();
+        return ListItem::new(format!("⊟ {} ({count})", cat.display()))
+            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+    }
+    let r = &app.rows[idx];
+    let tree = "├─ ";
+    let glyph = r
+        .enriched
+        .as_ref()
+        .map(|e| state_glyph(e.state))
+        .unwrap_or("");
+    let title = r
+        .enriched
+        .as_ref()
+        .map(|e| e.title.clone())
+        .unwrap_or_else(|| r.context.clone());
+    let count = if r.count > 1 {
+        format!("  ×{}", r.count)
+    } else {
+        String::new()
+    };
+    let spans = vec![
+        Span::styled(tree, Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("{:<8} ", r.key),
+            Style::default().fg(Color::LightYellow),
+        ),
+        Span::styled(
+            format!("{:<16} ", r.repo_or_host),
+            Style::default().fg(Color::LightGreen),
+        ),
+        Span::styled(
+            format!("{glyph} "),
+            Style::default().fg(glyph_color(r.enriched.as_ref().map(|e| e.state))),
+        ),
+        Span::styled(title, Style::default().fg(Color::LightMagenta)),
+        Span::styled(count, Style::default().fg(Color::LightCyan)),
+    ];
+    ListItem::new(Line::from(spans))
+}
+
+fn state_glyph(s: GhState) -> &'static str {
+    match s {
+        GhState::Open => "◉",
+        GhState::MergedPr => "●",
+        GhState::Closed => "✕",
+        GhState::Draft => "◐",
+        GhState::Commit => "⎇",
+    }
+}
+
+fn glyph_color(s: Option<GhState>) -> Color {
+    match s {
+        Some(GhState::Open) => Color::LightGreen,
+        Some(GhState::MergedPr) => Color::LightMagenta,
+        Some(GhState::Closed) => Color::DarkGray,
+        Some(GhState::Draft) => Color::LightYellow,
+        Some(GhState::Commit) => Color::LightBlue,
+        None => Color::Reset,
+    }
+}
+
+fn preview_for_selection(app: &App) -> Text<'static> {
+    let Some(pos) = app.list_state.selected() else {
+        return Text::raw("");
+    };
+    let Some(&idx) = app.filtered.get(pos) else {
+        return Text::raw("");
+    };
+    if let Some(cat) = sentinel_to_category(idx) {
+        return Text::raw(format!("Category: {} (header)", cat.display()));
+    }
+    let r = &app.rows[idx];
+    let body = format!(
+        "{}\n\ncanonical: {}\nkey: {}\nrepo/host: {}\ncount: {}",
+        r.context, r.canonical, r.key, r.repo_or_host, r.count
+    );
+    body.clone()
+        .into_text()
+        .unwrap_or_else(|_| Text::raw(body))
+}
+
+// Key handling is stubbed here for Task 14; wired in Task 15.
+fn handle_key(app: &mut App, _mods: KeyModifiers, code: KeyCode) {
+    if matches!(code, KeyCode::Esc) {
+        app.action = Some(Action::Quit);
+    }
 }

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -9,11 +9,11 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     prelude::*,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Terminal,
 };
 use std::io;
@@ -37,6 +37,7 @@ struct App {
     query: String,
     drilled_in: Option<Category>,
     horizontal: bool,
+    show_help: bool,
     action: Option<Action>,
 }
 
@@ -50,6 +51,7 @@ impl App {
             query: String::new(),
             drilled_in: None,
             horizontal: true,
+            show_help: false,
             action: None,
         };
         app.rebuild_filter();
@@ -253,6 +255,119 @@ mod filter_tests {
     }
 }
 
+#[cfg(test)]
+mod help_overlay_tests {
+    use super::*;
+
+    fn app_with_one_row() -> App {
+        let row = Row {
+            category: Category::Server,
+            canonical: "c-5001".into(),
+            key: "c-5001".into(),
+            repo_or_host: "—".into(),
+            context: "ssh c-5001".into(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 0,
+        };
+        App::new(vec![row])
+    }
+
+    #[test]
+    fn question_mark_opens_help_overlay() {
+        let mut app = app_with_one_row();
+        assert!(!app.show_help, "help starts hidden");
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('?'));
+        assert!(app.show_help, "? opens help");
+        assert!(app.action.is_none(), "? must not trigger an action");
+    }
+
+    #[test]
+    fn f1_opens_help_overlay() {
+        let mut app = app_with_one_row();
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::F(1));
+        assert!(app.show_help, "F1 opens help");
+        assert!(app.action.is_none());
+    }
+
+    #[test]
+    fn any_key_dismisses_help_without_side_effects() {
+        let mut app = app_with_one_row();
+        app.show_help = true;
+        // Arrow key should dismiss help, NOT move selection, NOT trigger action.
+        let selection_before = app.list_state.selected();
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Down);
+        assert!(!app.show_help, "Down dismisses help");
+        assert_eq!(
+            app.list_state.selected(),
+            selection_before,
+            "selection untouched"
+        );
+        assert!(app.action.is_none(), "dismiss must not trigger action");
+    }
+
+    #[test]
+    fn esc_dismisses_help_without_quitting() {
+        let mut app = app_with_one_row();
+        app.show_help = true;
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Esc);
+        assert!(!app.show_help, "Esc dismisses help");
+        assert!(app.action.is_none(), "Esc on help overlay must not quit");
+    }
+
+    #[test]
+    fn enter_dismisses_help_without_firing_default_action() {
+        let mut app = app_with_one_row();
+        app.show_help = true;
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Enter);
+        assert!(!app.show_help);
+        assert!(
+            app.action.is_none(),
+            "Enter on help overlay must not fire default action"
+        );
+    }
+
+    #[test]
+    fn question_mark_does_not_leak_into_query() {
+        // Regression guard: `?` must be intercepted before the generic
+        // ascii_graphic char handler that types into the query field.
+        let mut app = app_with_one_row();
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('?'));
+        assert_eq!(app.query, "", "? must not type into query");
+    }
+
+    #[test]
+    fn help_text_documents_every_actionable_key() {
+        // If someone adds a new handler in handle_key but forgets to update
+        // the help panel, this test fires — keep them in lockstep.
+        let body: String = help_lines()
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join(" ");
+        for needle in [
+            "Enter",
+            "Esc",
+            "F2",
+            "C-c",
+            "C-l",
+            "y",
+            "o",
+            "g",
+            "s",
+            "Backspace",
+            "drill",
+            "yank",
+            "ssh",
+        ] {
+            assert!(
+                body.contains(needle),
+                "help panel must document `{needle}` — got:\n{body}"
+            );
+        }
+    }
+}
+
 // ----- Run loop + rendering -----
 
 pub fn run(rows: Vec<Row>) -> Result<Action> {
@@ -313,13 +428,13 @@ fn draw(f: &mut Frame, app: &mut App) {
     // Top bar with breadcrumb or flat hints.
     let top = if let Some(cat) = app.drilled_in {
         format!(
-            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back F2:sess",
+            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back ?:help F2:sess",
             app.query,
             cat.display()
         )
     } else {
         format!(
-            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh F2:sess",
+            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh ?:help F2:sess",
             app.query
         )
     };
@@ -363,6 +478,92 @@ fn draw(f: &mut Frame, app: &mut App) {
         .block(Block::default().borders(Borders::ALL).title("Preview"))
         .wrap(Wrap { trim: false });
     f.render_widget(preview, content_chunks[1]);
+
+    // Help overlay (modal): render last so it paints on top of the list/preview.
+    if app.show_help {
+        draw_help_overlay(f, area);
+    }
+}
+
+/// Build the help overlay content. Pulled out so the exact key list is easy
+/// to eyeball and keep in sync with `handle_key`.
+fn help_lines() -> Vec<Line<'static>> {
+    let hdr = Style::default()
+        .fg(Color::LightCyan)
+        .add_modifier(Modifier::BOLD);
+    let key = Style::default()
+        .fg(Color::LightYellow)
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(Color::Gray);
+
+    let kv = |k: &'static str, v: &'static str| -> Line<'static> {
+        Line::from(vec![
+            Span::styled(format!("  {k:<14}"), key),
+            Span::styled(v.to_string(), dim),
+        ])
+    };
+
+    vec![
+        Line::from(Span::styled("Navigation", hdr)),
+        kv("↑ ↓ / C-p C-n", "move selection (headers selectable)"),
+        kv("→ / Enter", "drill into category header"),
+        kv("← / Esc", "drill out (first press), then quit"),
+        kv("1 – 9", "jump into Nth non-empty category (empty query)"),
+        Line::from(""),
+        Line::from(Span::styled("Actions (empty query)", hdr)),
+        kv("Enter", "default: yank URL / ssh server or IP"),
+        kv("y", "yank canonical via OSC 52"),
+        kv("o", "open / xdg-open in browser"),
+        kv("g", "gh view --web (GitHub rows only)"),
+        kv("s", "force ssh in new tmux window"),
+        Line::from(""),
+        Line::from(Span::styled("Filter", hdr)),
+        kv("a – z 0 – 9", "type into filter query"),
+        kv("Backspace", "delete last character"),
+        kv("C-c", "clear query (or quit if empty)"),
+        Line::from(""),
+        Line::from(Span::styled("Display & picker swap", hdr)),
+        kv("C-l", "toggle horizontal/vertical split"),
+        kv("F2", "swap to rmux_helper pick-tui (session picker)"),
+        kv("? / F1", "toggle this help overlay"),
+        Line::from(""),
+        Line::from(Span::styled("  Press any key to dismiss.", dim)),
+    ]
+}
+
+fn draw_help_overlay(f: &mut Frame, area: Rect) {
+    let popup = centered_rect(70, 80, area);
+    // Clear under the popup so the list/preview don't bleed through.
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Help — pick-links ")
+        .style(Style::default().fg(Color::LightYellow));
+    let para = Paragraph::new(help_lines())
+        .block(block)
+        .wrap(Wrap { trim: false });
+    f.render_widget(para, popup);
+}
+
+/// Centered rect: `percent_x`/`percent_y` of the parent `r`, clamped so the
+/// popup is never wider or taller than the parent. Standard ratatui idiom.
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
 }
 
 fn render_item(app: &App, idx: usize) -> ListItem<'static> {
@@ -372,8 +573,11 @@ fn render_item(app: &App, idx: usize) -> ListItem<'static> {
             .iter()
             .filter(|i| **i < SENTINEL_BASE && app.rows[**i].category == cat)
             .count();
-        return ListItem::new(format!("⊟ {} ({count})", cat.display()))
-            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+        return ListItem::new(format!("⊟ {} ({count})", cat.display())).style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
     }
     let r = &app.rows[idx];
     let tree = "├─ ";
@@ -454,6 +658,21 @@ fn preview_for_selection(app: &App) -> Text<'static> {
 }
 
 fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
+    // Help overlay is modal: any key dismisses it, consuming that key so it
+    // can't double as navigation, action, or query input. Must be the first
+    // branch in handle_key for this to be airtight.
+    if app.show_help {
+        app.show_help = false;
+        return;
+    }
+
+    // `?` and F1 open the help overlay. `?` is matched here (before the
+    // generic ascii_graphic handler) so it doesn't type into the query.
+    if matches!(code, KeyCode::Char('?') | KeyCode::F(1)) && !mods.contains(KeyModifiers::CONTROL) {
+        app.show_help = true;
+        return;
+    }
+
     // Esc: drill-out or quit
     if matches!(code, KeyCode::Esc) {
         if app.drilled_in.is_some() {
@@ -489,7 +708,6 @@ fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
         }
         KeyCode::Enter => app.on_enter(),
         KeyCode::F(2) => app.action = Some(Action::SwapToPickTui),
-        KeyCode::F(1) => { /* help overlay — TODO v1.1 */ }
         KeyCode::Backspace => {
             app.query.pop();
             app.rebuild_filter();

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -1,1 +1,15 @@
-//! Ratatui TUI for the link picker.
+//! Ratatui TUI for the link picker. Replaced in Task 14.
+
+use crate::link_picker::detect::Row;
+use anyhow::Result;
+
+/// Placeholder action enum — extended in Task 16.
+pub enum Action {
+    Quit,
+}
+
+pub fn run(_rows: Vec<Row>) -> Result<Action> {
+    // Temporary: immediately return Quit so `pick-links` without `--json`
+    // is still callable from tests without a TTY.
+    Ok(Action::Quit)
+}

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -331,15 +331,58 @@ mod help_overlay_tests {
     fn question_mark_does_not_leak_into_query() {
         // Regression guard: `?` must be intercepted before the generic
         // ascii_graphic char handler that types into the query field.
+        // Pre-populate the query so the assertion fails loudly if the
+        // `?` handler starts appending (rather than passing vacuously
+        // when the query is already empty).
         let mut app = app_with_one_row();
+        app.query = "abc".to_string();
         handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('?'));
-        assert_eq!(app.query, "", "? must not type into query");
+        assert_eq!(app.query, "abc", "? must not type into query");
+    }
+
+    #[test]
+    fn ctrl_c_while_help_shown_dismisses_help_not_quits() {
+        // Pins the airtightness-order claim in handle_key: the
+        // `if app.show_help { … return; }` branch MUST run before the
+        // Ctrl+C → Quit branch. Otherwise a future refactor that moves
+        // the Ctrl+C handler above the dismiss check would silently
+        // change Ctrl+C-while-help from "dismiss modal" to "quit picker"
+        // — a surprising behavior change reviewers would miss.
+        //
+        // Current decision: first Ctrl+C dismisses help; user can press
+        // Ctrl+C again from the flat view to quit. If we ever want
+        // "Ctrl+C always quits", flip this assertion and update
+        // handle_key.
+        let mut app = app_with_one_row();
+        app.show_help = true;
+        handle_key(&mut app, KeyModifiers::CONTROL, KeyCode::Char('c'));
+        assert!(!app.show_help, "Ctrl+C dismisses help modal");
+        assert!(app.action.is_none(), "Ctrl+C on help overlay does NOT quit");
+    }
+
+    #[test]
+    fn f2_while_help_shown_dismisses_help_not_swaps() {
+        // Same airtightness contract for F2: must dismiss help first,
+        // not punch through to the pick-tui swap. Otherwise pressing F2
+        // while help is shown would leak the swap action and tear down
+        // the TUI mid-help-display.
+        let mut app = app_with_one_row();
+        app.show_help = true;
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::F(2));
+        assert!(!app.show_help, "F2 dismisses help modal");
+        assert!(
+            app.action.is_none(),
+            "F2 on help overlay does NOT fire SwapToPickTui"
+        );
     }
 
     #[test]
     fn help_text_documents_every_actionable_key() {
-        // If someone adds a new handler in handle_key but forgets to update
-        // the help panel, this test fires — keep them in lockstep.
+        // If someone removes a documented key's mention from help_lines,
+        // this test fires. It does NOT enforce the inverse direction
+        // (adding a brand-new handler still requires updating the needle
+        // list below) — that's a harder coupling to automate without
+        // parsing handle_key's source.
         let body: String = help_lines()
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
@@ -365,6 +408,56 @@ mod help_overlay_tests {
                 "help panel must document `{needle}` — got:\n{body}"
             );
         }
+    }
+
+    #[test]
+    fn help_overlay_actually_renders_title_when_show_help_is_true() {
+        // Guards against a refactor that removes the
+        // `if app.show_help { draw_help_overlay(...) }` branch in draw():
+        // state-machine tests would still pass (show_help toggles
+        // correctly) but the user would see an invisible modal. Drive
+        // draw() via TestBackend and assert the help title is painted.
+        use ratatui::backend::TestBackend;
+        let mut app = app_with_one_row();
+        app.show_help = true;
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            rendered.contains("Help") && rendered.contains("pick-links"),
+            "help overlay title must be visible when show_help=true; got buffer:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn help_overlay_does_not_render_when_show_help_is_false() {
+        // Inverse of the above: the title must NOT appear in the rendered
+        // buffer when show_help=false. Otherwise the if-branch could be
+        // deleted and the overlay would always show.
+        use ratatui::backend::TestBackend;
+        let mut app = app_with_one_row();
+        assert!(!app.show_help, "help starts hidden");
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            !rendered.contains("Help — pick-links"),
+            "help overlay title must NOT be visible when show_help=false"
+        );
     }
 }
 

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -215,11 +215,27 @@ mod filter_tests {
 
     #[test]
     fn tag_leak_is_prevented_by_unit_separator() {
-        let r = mk(Category::PullRequest, "#68", "writing prose all day");
-        // "pr" tag should NOT leak into matching against "prose"
+        // A Server row whose key (hostname) starts with "ose-..." must NOT match
+        // the query "serverose" — the `\x1f` separator between the `server` tag
+        // and the key prevents the two from being seen as a single substring.
+        // Without the separator the search string would be `serverose-host ...`
+        // and the substring `serverose` would match; with the separator we get
+        // `server\x1fose-host ...` and the boundary breaks the match.
+        let r = mk(Category::Server, "ose-host", "context unrelated");
         let s = row_search_string(&r);
-        assert!(s.starts_with("pr\x1f"));
-        assert!(!s[..3].contains("prose"));
+        assert!(s.starts_with("server\x1f"), "tag should be at the start");
+        assert!(
+            s.contains("server\x1fose"),
+            "separator must sit between tag and key"
+        );
+        // The whole concatenated string lowercased must NOT contain "serverose"
+        // because the `\x1f` byte breaks the substring.
+        assert!(
+            !s.to_lowercase().contains("serverose"),
+            "unit separator must prevent `server` + `ose` from forming `serverose`"
+        );
+        // End-to-end: match_row for the `serverose` token should return false.
+        assert!(!match_row(&r, &[String::from("serverose")]));
     }
 
     #[test]
@@ -421,7 +437,7 @@ fn preview_for_selection(app: &App) -> Text<'static> {
         "{}\n\ncanonical: {}\nkey: {}\nrepo/host: {}\ncount: {}",
         r.context, r.canonical, r.key, r.repo_or_host, r.count
     );
-    body.clone()
+    body.as_str()
         .into_text()
         .unwrap_or_else(|_| Text::raw(body))
 }

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -480,6 +480,39 @@ fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
                 app.rebuild_filter();
             }
         }
+        // Override keys (on selected leaf only). Gated on empty query so they
+        // don't collide with typing search queries containing these letters.
+        KeyCode::Char('y') if mods.is_empty() && app.query.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Yank(row));
+            }
+        }
+        KeyCode::Char('o') if mods.is_empty() && app.query.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Open(row));
+            }
+        }
+        KeyCode::Char('g') if mods.is_empty() && app.query.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                if matches!(
+                    row.category,
+                    Category::PullRequest
+                        | Category::Issue
+                        | Category::Commit
+                        | Category::File
+                        | Category::Repo
+                ) {
+                    app.action = Some(Action::GhWeb(row));
+                } else {
+                    app.error_msg = Some("g: not a GitHub row".into());
+                }
+            }
+        }
+        KeyCode::Char('s') if mods.is_empty() && app.query.is_empty() => {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Ssh(row));
+            }
+        }
         KeyCode::Char(c) if c.is_ascii_graphic() || c == ' ' => {
             app.query.push(c);
             app.rebuild_filter();
@@ -520,6 +553,15 @@ impl App {
         };
         self.drilled_in = Some(cat);
         self.rebuild_filter();
+    }
+
+    fn selected_leaf(&self) -> Option<Row> {
+        let cur = self.list_state.selected()?;
+        let &idx = self.filtered.get(cur)?;
+        if idx >= SENTINEL_BASE {
+            return None;
+        }
+        Some(self.rows[idx].clone())
     }
 
     fn on_enter(&mut self) {

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -1,0 +1,1 @@
+//! Ratatui TUI for the link picker.

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -38,7 +38,6 @@ struct App {
     drilled_in: Option<Category>,
     horizontal: bool,
     action: Option<Action>,
-    error_msg: Option<String>,
 }
 
 impl App {
@@ -52,7 +51,6 @@ impl App {
             drilled_in: None,
             horizontal: true,
             action: None,
-            error_msg: None,
         };
         app.rebuild_filter();
         app
@@ -302,13 +300,13 @@ fn draw(f: &mut Frame, app: &mut App) {
     // Top bar with breadcrumb or flat hints.
     let top = if let Some(cat) = app.drilled_in {
         format!(
-            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back F2:sess ?:help",
+            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back F2:sess",
             app.query,
             cat.display()
         )
     } else {
         format!(
-            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh F2:sess ?:help",
+            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh F2:sess",
             app.query
         )
     };
@@ -519,8 +517,6 @@ fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
                         | Category::Repo
                 ) {
                     app.action = Some(Action::GhWeb(row));
-                } else {
-                    app.error_msg = Some("g: not a GitHub row".into());
                 }
             }
         }

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -265,19 +265,24 @@ pub fn run(rows: Vec<Row>) -> Result<Action> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // Drain any stale events queued before the popup opened (e.g. the
-    // `C-a L` keypress leaking into the new pty). Without this, the first
-    // event_loop iteration can consume a phantom event and act on it
-    // unexpectedly. Mirrors picker.rs:595-598.
-    while event::poll(std::time::Duration::from_millis(1))? {
-        let _ = event::read();
+    let mut app = App::new(rows);
+
+    // First draw so the terminal is in its intended state, then drain any
+    // queued events. Tmux popups inject terminal-state responses (cursor
+    // position, device attributes, focus events) shortly after the pty comes
+    // up, and crossterm's parser can treat some of these as key events. Poll
+    // with a longer window than picker.rs's 1ms to catch late arrivals.
+    terminal.draw(|f| draw(f, &mut app))?;
+    for _ in 0..16 {
+        while event::poll(std::time::Duration::from_millis(5))? {
+            let _ = event::read();
+        }
     }
 
-    let mut app = App::new(rows);
     let result = event_loop(&mut app, &mut terminal);
 
-    disable_raw_mode()?;
-    execute!(io::stdout(), LeaveAlternateScreen)?;
+    let _ = disable_raw_mode();
+    let _ = execute!(io::stdout(), LeaveAlternateScreen);
     drop(terminal);
 
     result

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -1,4 +1,5 @@
 mod picker;
+mod link_picker;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -70,6 +71,15 @@ enum Commands {
     },
     /// Debug: show raw key events (press q to quit)
     DebugKeys,
+    /// TUI picker for GitHub links, servers, and IPs in the current tmux pane's scrollback
+    PickLinks {
+        /// Emit JSON of detected items to stdout and exit (no TUI)
+        #[arg(long)]
+        json: bool,
+        /// Enrichment deadline in milliseconds (0 disables gh enrichment)
+        #[arg(long, default_value_t = 3000)]
+        enrich_deadline_ms: u64,
+    },
 }
 
 // Layout state constants
@@ -1820,6 +1830,9 @@ fn main() -> Result<()> {
         Some(Commands::SideEdit { file }) => side_edit(file.as_deref()),
         Some(Commands::SideRun { command, force }) => side_run(command.as_deref(), force),
         Some(Commands::DebugKeys) => debug_keys(),
+        Some(Commands::PickLinks { json, enrich_deadline_ms }) => {
+            link_picker::pick_links(json, enrich_deadline_ms)
+        }
         None => {
             // Show help when no command given
             use clap::CommandFactory;

--- a/rust/tmux_helper/src/picker.rs
+++ b/rust/tmux_helper/src/picker.rs
@@ -647,6 +647,12 @@ fn run_picker_tui(mut app: PickerApp<'_>) -> Result<Option<String>> {
                     }
                 }
                 (_, KeyCode::Enter) => app.select_current(),
+                (_, KeyCode::F(2)) => {
+                    // Cross-picker swap: exit pick-tui and exec pick-links.
+                    // See LINK_PICKER_SPEC.md §Cross-picker shortcut.
+                    app.should_quit = true;
+                    app.selected_target = Some("__swap_to_pick_links__".into());
+                }
                 (_, KeyCode::F(1)) | (KeyModifiers::CONTROL, KeyCode::Char('/')) => {
                     app.show_help = true
                 }
@@ -685,6 +691,17 @@ fn run_picker_tui(mut app: PickerApp<'_>) -> Result<Option<String>> {
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    drop(terminal);
+
+    // Cross-picker swap: if F2 was pressed, exec pick-links after teardown.
+    // Short-circuits BEFORE the caller can dispatch `tmux switch-client` on the sentinel.
+    if matches!(app.selected_target.as_deref(), Some("__swap_to_pick_links__")) {
+        use std::os::unix::process::CommandExt;
+        let err = std::process::Command::new("rmux_helper")
+            .arg("pick-links")
+            .exec();
+        return Err(anyhow::anyhow!("exec pick-links failed: {err}"));
+    }
 
     Ok(app.selected_target)
 }

--- a/shared/.tmux.conf
+++ b/shared/.tmux.conf
@@ -122,8 +122,7 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 bind-key w display-popup -E -w 100% -h 100% "rmux_helper pick-tui"
 bind-key C-w choose-tree -Zw
 # Scrollback link picker: C-a L extracts URLs/PRs/hosts/IPs from current pane scrollback
-bind-key L display-popup -E -w 95% -h 95% \
-  "TMUX_PANE=#{pane_id} rmux_helper pick-links"
+bind-key L display-popup -E -w 95% -h 95% "rmux_helper pick-links"
 # set -g @plugin 'Morantron/tmux-fingers'
 # Cool idea, but doesn't work for me, I wonder if it's not compatible with power theme
 set -g @tmux-nerd-font-window-name-shell-icon ''

--- a/shared/.tmux.conf
+++ b/shared/.tmux.conf
@@ -13,6 +13,7 @@
 #   C-a /                - Toggle 1/3-2/3 layout (works with 2 panes)
 #   C-a {                - Swap current pane with previous pane
 #   C-a }                - Swap current pane with next pane
+#   C-a L                - Launch scrollback link picker popup (rmux_helper pick-links)
 #
 # Command Aliases (use via C-a : then type command):
 #   :info                - Update window title based on running process
@@ -27,6 +28,7 @@
 #   :side-edit <file>    - Open/reuse right-side nvim pane with file (supports file:line)
 #   :side-run <cmd>      - Run shell command in side pane (--force to kill nvim)
 #   :launch-servers      - Start dev servers session (btm, caffeinate, jekyll, agent)
+#   :pick-links          - Launch scrollback link picker (PRs, issues, links, hosts, IPs)
 # ============================================================================
 
 # cheat sheet:
@@ -119,6 +121,9 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 # Session/window/pane picker: C-a w for native skim picker, C-a C-w for built-in tree
 bind-key w display-popup -E -w 100% -h 100% "rmux_helper pick-tui"
 bind-key C-w choose-tree -Zw
+# Scrollback link picker: C-a L extracts URLs/PRs/hosts/IPs from current pane scrollback
+bind-key L display-popup -E -w 95% -h 95% \
+  "TMUX_PANE=#{pane_id} rmux_helper pick-links"
 # set -g @plugin 'Morantron/tmux-fingers'
 # Cool idea, but doesn't work for me, I wonder if it's not compatible with power theme
 set -g @tmux-nerd-font-window-name-shell-icon ''
@@ -330,9 +335,11 @@ set -s command-alias[112] launch-servers='run-shell "rmux_helper launch-servers"
 set -s command-alias[113] side-edit='run-shell "rmux_helper side-edit"'
 # side-run: Run a shell command in the side pane (--force to kill nvim first)
 set -s command-alias[114] side-run='run-shell "rmux_helper side-run"'
+# pick-links: Launch scrollback link picker (PRs, issues, links, hosts, IPs)
+set -s command-alias[115] pick-links='run-shell "rmux_helper pick-links"'
 #
 # To add more commands like this:
-#   set -s command-alias[115] foo='run-shell "rmux_helper third \"your command\""'
+#   set -s command-alias[116] foo='run-shell "rmux_helper third \"your command\""'
 
 # ============================================================================
 # Auto-rename windows every 10 seconds


### PR DESCRIPTION
## Summary

New `rmux_helper pick-links` subcommand: a ratatui TUI popup that scans the current tmux pane's scrollback for actionable items across 9 categories, parallel-enriches GitHub rows via `gh`, and supports contextual actions (OSC 52 yank, `gh … --web`, `tmux new-window ssh`, cross-picker swap).

- **Detection (sync, pure):** Pull Requests, Issues, Commits, Files, Repos, Blog posts, Other URLs, ssh Servers, IPv4 addresses. Dedupe by canonical URL/host, order most-recent-first, strip ANSI from context column.
- **Enrichment (parallel):** `gh pr/issue/commit view` fanned out via `tokio::task::JoinSet` under a semaphore (cap 8) with a 3-second shared wall-clock deadline. On-disk cache at `~/.cache/rmux_helper/gh-links.json` (1h TTL, atomic write, silent degradation on `gh` missing / unauthenticated / parse failure).
- **TUI:** Tree view with selectable category headers, drill-down (`→` / `1`–`9`), filter tokenizer with `\x1f` tag separator (Divergence 2 from `pick-tui`), state glyphs (`◉ ● ✕ ◐ ⎇`), horizontal/vertical auto-layout (`C-l` toggle), ANSI-preserved preview pane.
- **Actions:** Default `Enter` yanks URLs via OSC 52 or opens ssh in a new tmux window for Server/IP rows. Override keys `y`/`o`/`g`/`s` (yank / open / gh web / ssh) gated on empty query.
- **Cross-picker:** `F2` bidirectional swap between `pick-tui` and `pick-links` via exec-based handoff. `PICKER_SPEC.md` updated.
- **Binding:** `C-a L` in `shared/.tmux.conf` launches the popup (95% × 95%).

## Design / planning artifacts

- **Design spec** (3-pass architect reviewed, convergence 11 → 5 → 0): `docs/superpowers/specs/2026-04-12-scrollback-link-picker-design.md`
- **Implementation plan** (17 tasks, TDD): `docs/superpowers/plans/2026-04-12-scrollback-link-picker.md`
- **Behavior contract:** `rust/tmux_helper/LINK_PICKER_SPEC.md`

## Commit structure

- `91c1183` plan
- `a98390f`–`4a68e6f` T1–T13 (scaffolding → detection → enrichment → orchestration, `--json` works end-to-end here)
- `60b5d3b`–`ee07aa4` T14–T16 (TUI, navigation, OSC 52, override keys)
- `59fc6a3` fix(T14-16 review): dead field, vacuous test, pane_id threading
- `517be86` T17 (F2 cross-picker, tmux binding, specs)
- `5b7ee5f` holistic review cleanup (`App::error_msg`, `?:help` trap, `Category::all` lint)
- `0424944` fix: drop `tmux capture-pane -e` — raw `\x1b` bytes were corrupting ratatui rendering in popups
- `4bbf22a` fix: bind-key `#{pane_id}` not format-expanded by `display-popup` command arg — resolve via `tmux display-message` inside the binary; also longer stale-event drain
- `2e5e59b` docs(claude-md): tmux popup/bind-key gotchas + pgrep truncation note

## Test plan

- [x] `cargo test -p rmux_helper` — 125 passing (54 new `link_picker::` tests; 71 pre-existing)
- [x] `cargo build` clean, zero warnings
- [x] `rmux_helper pick-links --json` emits valid JSON from live tmux scrollback
- [x] `tmux display-popup -E rmux_helper pick-links` (backgrounded, from CLI) reaches event loop and blocks on input — popup stays alive end-to-end
- [ ] **Interactive smoke (reviewer):** `C-a L` in any pane — popup renders tree view, navigation works, `Enter` on a PR row yanks to clipboard, `F2` swaps to `pick-tui` and back, `Esc` quits
- [ ] **OSC 52 clipboard bridge from devvm → Mac iTerm:** yank a URL, verify it lands in Mac pasteboard

## Known v1.1 polish items (non-blocking, flagged by holistic review)

- `F2` exec failure path returns `Err` instead of staying open with a bottom-bar error (rare: PATH issues mid-session)
- No integration tests for `enrich::enrich_rows` against a stubbed `gh` binary — parser is unit-tested, argv + JSON round-trip is not
- TUI `disable_raw_mode` teardown has no panic-safety guard (matches existing `picker.rs` pattern — would be a cross-cutting cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scrollback Link Picker — interactive TUI to detect links in tmux scrollback (GitHub PRs/issues/commits, repos, blogs, servers, IPs). Filtering, drill-down, preview, F2 cross-picker swap, JSON output, clipboard yank (OSC 52), open/gh-web/ssh actions, enrichment with timeout and on-disk caching, and tmux keybinding (C‑a L).

* **Documentation**
  * Added detailed picker specs/design/changelog and expanded tmux/popup guidance, collaboration preferences, and tmux/pgrep gotchas for reliable reproduction and bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->