### PR TITLE
feat(y): add ou command to open clipboard URL in browser

### DIFF
--- a/py/y.py
+++ b/py/y.py
@@ -2108,6 +2108,34 @@ def ai_rhyme():
     _call_ai_clip("seuss", "🎭 Transforming clipboard text to Dr. Seuss style...")
 
 
+@app.command()
+def ou():
+    """Open URL from clipboard in default browser; alert if clipboard has no URL"""
+    import webbrowser
+    from urllib.parse import urlparse
+
+    clip = (pyperclip.paste() or "").strip()
+    parsed = urlparse(clip)
+    is_url = parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+    if is_url:
+        webbrowser.open(clip)
+        print(f"[green]Opened: {clip}[/green]")
+        return
+
+    # No URL — show alert via ux center popup
+    try:
+        ux_path = PY_TOOLS_PATH / "ux"
+        subprocess.run(
+            [str(ux_path), "center", "No URL in clipboard", "--seconds", "2"],
+            capture_output=True,
+            check=False,
+        )
+    except Exception as e:
+        print(f"[dim]Note: Could not show popup: {e}[/dim]")
+    print("[yellow]No URL in clipboard[/yellow]")
+
+
 def _find_highest_numbered_file(directory: Path, prefix: str) -> int:
     """Find the highest number in files matching prefix<N>.png pattern.
 


### PR DESCRIPTION
## Summary
- New `ou` command in `py/y.py` that reads the clipboard, and if it holds an `http(s)` URL with a netloc, opens it in the default browser via `webbrowser.open`.
- When the clipboard does not contain a URL, shows a 2s `ux center` popup ("No URL in clipboard") matching the pattern used by `ai_fix`.

## Test plan
- [ ] `./py/y.py ou --help` shows the new command
- [ ] Copy `https://example.com` to clipboard → `./py/y.py ou` opens it in the default browser
- [ ] Copy plain text (e.g. `hello world`) → `./py/y.py ou` shows the "No URL in clipboard" popup and prints the yellow warning
- [ ] Copy a bare string like `foo.py` → treated as non-URL (no scheme), popup shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)