### PR TITLE
rmux_helper: add parent-pid-tree subcommand for tmux pane resolution

### DIFF
--- a/rust/tmux_helper/CLAUDE.md
+++ b/rust/tmux_helper/CLAUDE.md
@@ -14,6 +14,7 @@ The spec documents the *what* (behavior rules), not the *how* (implementation). 
 - `rename-all` - Rename all windows based on running processes
 - `rotate` - Toggle between horizontal/vertical layouts
 - `third` - Toggle between even and 1/3-2/3 split
+- `parent-pid-tree` - Resolve caller's owning tmux pane by walking the parent-PID chain (see below)
 
 ## Building
 
@@ -31,6 +32,28 @@ cargo test
 ## Smoke testing against tmux
 
 `cargo build` updates `target/`, but tmux keybindings and `$PATH` resolve to `~/.cargo/bin/rmux_helper`. After any change you want to exercise live, run `cargo install --path . --force` before invoking `rmux_helper` from a tmux session.
+
+## `parent-pid-tree`
+
+Resolves the calling process's owning tmux pane by walking the parent-PID chain from `/proc/<pid>/stat` against `tmux list-panes -a -F '#{pane_id} #{pane_pid}'`. Use this whenever a script needs to answer "which tmux pane am I running inside?" — **never** use `tmux display-message -p '#{pane_id}'` for this, which returns the tmux-*active* pane (the one focused in the attached client), not the caller's pane.
+
+Typical invocations:
+
+- `rmux_helper parent-pid-tree` — prints the owning pane id (e.g. `%35`) on stdout, exits 0. Scriptable: `pane=$(rmux_helper parent-pid-tree)`.
+- `rmux_helper parent-pid-tree --json` — structured output with `pane_id`, `pane_pid`, `walked_from_pid`, and `ancestors_walked`. Useful for debugging.
+- `rmux_helper parent-pid-tree --pid <N>` — resolve a different pid's owning pane instead of the caller's. Walk starts directly from `N` (no parent-of-ppid hop).
+- `rmux_helper parent-pid-tree --verbose` — log the walk chain to stderr for debugging, e.g. `walked 474064 -> 4114505 -> 4114434 -> 2594534 (pane_pid) -> pane %35`.
+
+**Exit codes**:
+
+- `0` — pane found, id printed on stdout
+- `1` — no match (caller/pid not in any tmux pane); nothing on stdout, `no tmux pane found for pid <N>` on stderr
+- `2` — tmux not running or no panes
+- `3` — `/proc/<self>/stat` unreadable (cannot determine caller pid)
+
+**Why this exists**: `tmux display-message -p '#{pane_id}'` returns the focused pane, which is wrong when multiple Claude sessions run in different panes concurrently. Observed 2026-04-14: `harden-telegram`'s watchdog.py reloaded the wrong pane for ~45 minutes before diagnosis. Encapsulating the correct walk here means future tmux-integration code can call `rmux_helper parent-pid-tree` and trust the answer instead of hand-rolling the walk.
+
+**Implementation**: see `fn resolve_pane_by_parent_chain` in `src/main.rs`. The walker is dependency-injected over `read_ppid: FnMut(u32) -> Option<u32>` so unit tests can verify the multi-session, no-match, vanished-parent, and cycle cases without touching `/proc`.
 
 ## side-edit / side-run stdout contract
 

--- a/rust/tmux_helper/CLAUDE.md
+++ b/rust/tmux_helper/CLAUDE.md
@@ -63,6 +63,43 @@ Typical invocations:
 
 When adding new tmux-integration code, prefer this pattern: put shell-outs behind `TmuxProvider` (extend the trait as needed), keep all logic in a pure function that takes the trait object, and make the command wrapper thin. The other tmux call sites in this binary (`side_edit`, `side_run`, `rename_all`, `rotate`, `third`, etc.) still shell out directly — see the TODO above `run_tmux_command` in `src/main.rs`. They should be migrated once characterization tests exist for their current behavior.
 
+## Shell completions
+
+### Install
+
+```bash
+rmux_helper install-completions              # auto-detects from $SHELL
+rmux_helper install-completions --shell zsh  # explicit
+rmux_helper install-completions --print-only # dump to stdout for custom install
+rmux_helper install-completions --dry-run    # report target path, skip the write
+```
+
+`--print-only` and `--dry-run` are mutually exclusive (enforced by clap).
+Re-running `install-completions` overwrites the existing file — idempotent.
+
+Installation paths (default):
+
+| Shell | Path |
+|---|---|
+| zsh | `$ZDOTDIR/.zfunc/_rmux_helper` or `$HOME/.zfunc/_rmux_helper` |
+| bash | `$XDG_DATA_HOME/bash-completion/completions/rmux_helper` or `$HOME/.local/share/bash-completion/completions/rmux_helper` |
+| fish | `$XDG_CONFIG_HOME/fish/completions/rmux_helper.fish` or `$HOME/.config/fish/completions/rmux_helper.fish` |
+| powershell / elvish | no default — use `--print-only` and pipe to your profile |
+
+On first zsh install, make sure `~/.zfunc` is in `$fpath` and `autoload -Uz compinit && compinit` has run.
+
+### Dynamic completion
+
+- `parent-pid-tree --pid <TAB>` — completes to running pids with `comm` as the help text. Read live from `/proc` at tab-time, sorted newest-first, capped at 500.
+- Subcommand names, flag names, and static enum values (e.g. `--shell <TAB>`) complete via clap's built-in generation — free.
+- File-accepting args (`side-edit <file>`) complete via the shell's default file completion (`ValueHint::FilePath`).
+
+The tab-time hook is `clap_complete::CompleteEnv::with_factory(Cli::command).complete()` at the top of `main()`. When the binary is invoked with `COMPLETE=<shell>` in its environment, clap_complete intercepts, writes the shell-specific completion output to stdout, and exits before regular arg parsing. The installed shell script re-invokes the binary with `COMPLETE` set on every tab press, so completion values are always live — no static snapshot to regenerate on upgrade.
+
+### Dep footprint
+
+Adds `clap_complete = { version = "4", features = ["unstable-dynamic"] }`. Feature flag is required for `CompleteEnv`, `ArgValueCompleter`, and `CompletionCandidate`. The API is marked unstable — if it churns, expect a compile error that points directly at `pid_completer` / the `#[arg(add = ...)]` attribute.
+
 ## side-edit / side-run stdout contract
 
 `side-edit` and `side-run` (with no args, status-only) print three lines that shell scripts consume:

--- a/rust/tmux_helper/CLAUDE.md
+++ b/rust/tmux_helper/CLAUDE.md
@@ -55,6 +55,14 @@ Typical invocations:
 
 **Implementation**: see `fn resolve_pane_by_parent_chain` in `src/main.rs`. The walker is dependency-injected over `read_ppid: FnMut(u32) -> Option<u32>` so unit tests can verify the multi-session, no-match, vanished-parent, and cycle cases without touching `/proc`.
 
+**Humble Object layout**: the command is split into a thin shell and a testable core.
+
+- **Humble shell** — the `TmuxProvider` and `ProcReader` traits in `src/main.rs`. Production uses `RealTmuxProvider` (shells out to `tmux list-panes`) and `RealProcReader` (reads `/proc/<pid>/stat`). These are the only places that touch external state for the command.
+- **Testable core** — `fn run_parent_pid_tree(args, self_pid, tmux, proc) -> ParentPidTreeOutcome`. Accepts the traits as `&dyn`, returns `{ stdout, stderr_lines, exit_code }`. Every flag combination and exit code is reachable through in-memory `MockTmuxProvider` / `MockProcReader` without tmux or `/proc` being present.
+- **Command wrapper** — `fn parent_pid_tree_cmd` is the only place that constructs `Real*` impls and writes to real stdout/stderr. `main()` calls it and forwards the exit code.
+
+When adding new tmux-integration code, prefer this pattern: put shell-outs behind `TmuxProvider` (extend the trait as needed), keep all logic in a pure function that takes the trait object, and make the command wrapper thin. The other tmux call sites in this binary (`side_edit`, `side_run`, `rename_all`, `rotate`, `third`, etc.) still shell out directly — see the TODO above `run_tmux_command` in `src/main.rs`. They should be migrated once characterization tests exist for their current behavior.
+
 ## side-edit / side-run stdout contract
 
 `side-edit` and `side-run` (with no args, status-only) print three lines that shell scripts consume:

--- a/rust/tmux_helper/Cargo.lock
+++ b/rust/tmux_helper/Cargo.lock
@@ -137,8 +137,20 @@ checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.6",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+ "clap_lex 1.1.0",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -158,6 +170,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -417,6 +435,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -701,6 +728,7 @@ dependencies = [
  "ansi-to-tui",
  "anyhow",
  "clap",
+ "clap_complete",
  "crossterm 0.29.0",
  "dirs",
  "hostname",
@@ -814,6 +842,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1159,6 +1193,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1190,11 +1233,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1219,6 +1279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1295,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1243,10 +1315,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1261,6 +1345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1361,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1285,6 +1381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1397,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zmij"

--- a/rust/tmux_helper/Cargo.toml
+++ b/rust/tmux_helper/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = { version = "4", features = ["unstable-dynamic"] }
 sysinfo = "0.37"
 anyhow = "1"
 ratatui = "0.29"

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -1,5 +1,5 @@
-mod picker;
 mod link_picker;
+mod picker;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -10,12 +10,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use sysinfo::{Pid, ProcessRefreshKind, System};
 
-pub const VERSION: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
-    " (",
-    env!("GIT_HASH"),
-    ")"
-);
+pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")");
 
 #[derive(Parser)]
 #[command(name = "rmux_helper")]
@@ -95,6 +90,10 @@ enum Commands {
         /// Log the walk (ancestor chain, pane match) to stderr for debugging
         #[arg(long)]
         verbose: bool,
+        /// Print the full ancestor chain as a visual tree with cmdline / exe
+        /// metadata per PID. Combine with --json for structured output.
+        #[arg(long)]
+        tree: bool,
     },
 }
 
@@ -157,13 +156,12 @@ fn get_original_pane_title(
         .unwrap_or_default();
 
     // Normalize: treat hostname and empty as "no title"
-    let normalized_current = if current_title.eq_ignore_ascii_case(&hostname)
-        || current_title.is_empty()
-    {
-        String::new()
-    } else {
-        current_title.to_string()
-    };
+    let normalized_current =
+        if current_title.eq_ignore_ascii_case(&hostname) || current_title.is_empty() {
+            String::new()
+        } else {
+            current_title.to_string()
+        };
 
     // Check if we have a cached value
     if let Some(cached) = cache.get(pane_id) {
@@ -489,10 +487,9 @@ pub fn get_git_repo_name(cwd: &str, cache: &mut HashMap<String, Option<String>>)
 }
 
 pub fn get_short_path(cwd: &str, git_repo: Option<&str>) -> String {
-    let path_mappings: HashMap<&str, &str> =
-        [("idvorkin.github.io", "blog"), ("idvorkin", "me")]
-            .into_iter()
-            .collect();
+    let path_mappings: HashMap<&str, &str> = [("idvorkin.github.io", "blog"), ("idvorkin", "me")]
+        .into_iter()
+        .collect();
 
     if let Some(repo) = git_repo {
         let base_name = path_mappings.get(repo).copied().unwrap_or(repo);
@@ -586,7 +583,7 @@ fn compact_path(path: &str) -> String {
     }
 
     let first: String = chars[..2].iter().collect();
-    let last: String = chars[chars.len()-2..].iter().collect();
+    let last: String = chars[chars.len() - 2..].iter().collect();
     format!("{}..{}", first, last)
 }
 
@@ -786,8 +783,9 @@ fn rename_all() -> Result<()> {
                 window_width: pane.window_width,
             };
 
-            generate_title_with_context(&process_info, &ctx)
-                .unwrap_or_else(|| generate_title_from_tmux(&pane.pane_current_command, &short_path))
+            generate_title_with_context(&process_info, &ctx).unwrap_or_else(|| {
+                generate_title_from_tmux(&pane.pane_current_command, &short_path)
+            })
         } else {
             // Fallback: use tmux's pane info (works for remote/container processes)
             let cwd = &pane.pane_current_path;
@@ -1063,13 +1061,25 @@ fn third(command: &str) -> Result<()> {
         if is_horizontal {
             let target_width = (window_width as f32 * 0.33) as i32;
             let _ = Command::new("tmux")
-                .args(["resize-pane", "-t", &panes[0], "-x", &target_width.to_string()])
+                .args([
+                    "resize-pane",
+                    "-t",
+                    &panes[0],
+                    "-x",
+                    &target_width.to_string(),
+                ])
                 .output();
             set_tmux_option(THIRD_STATE_OPTION, STATE_THIRD_HORIZONTAL);
         } else {
             let target_height = (window_height as f32 * 0.33) as i32;
             let _ = Command::new("tmux")
-                .args(["resize-pane", "-t", &panes[0], "-y", &target_height.to_string()])
+                .args([
+                    "resize-pane",
+                    "-t",
+                    &panes[0],
+                    "-y",
+                    &target_height.to_string(),
+                ])
                 .output();
             set_tmux_option(THIRD_STATE_OPTION, STATE_THIRD_VERTICAL);
         }
@@ -1132,8 +1142,8 @@ fn get_pane_cwd(pane_id: &str) -> String {
 /// Uses the same broad matching as `process_tree_has_pattern` (name + cmdline + exe substring),
 /// so it catches wrappers like `nvim.appimage`, `nvim-qt`, embedded under shells, etc.
 fn inspect_pane_for_vim(pane_id: &str, system: &System) -> Option<bool> {
-    let pid_str = run_tmux_command(&["display-message", "-t", pane_id, "-p", "#{pane_pid}"])
-        .ok()?;
+    let pid_str =
+        run_tmux_command(&["display-message", "-t", pane_id, "-p", "#{pane_pid}"]).ok()?;
     let pid: u32 = pid_str.trim().parse().ok().filter(|p| *p > 0)?;
     let info = get_process_info(system, pid)?;
     Some(process_tree_has_pattern(&info, &["vim", "nvim"]))
@@ -1335,9 +1345,8 @@ where
     F: FnMut(&str) -> Option<bool>,
 {
     // Step 1: stored option, if still valid for this window.
-    let stored_valid = !stored.is_empty()
-        && window_panes.iter().any(|p| p == stored)
-        && stored != caller_pane_id;
+    let stored_valid =
+        !stored.is_empty() && window_panes.iter().any(|p| p == stored) && stored != caller_pane_id;
     if stored_valid {
         let nvim_running = inspect(stored);
         return ResolvedStatus {
@@ -1412,7 +1421,11 @@ where
 fn get_side_pane_status(caller_pane_id: &str) -> SidePaneStatus {
     // Query the window-local option scoped to the caller's window (not tmux's "current" window)
     let stored = run_tmux_command(&[
-        "show-option", "-wqv", "-t", caller_pane_id, SIDE_EDIT_PANE_OPTION,
+        "show-option",
+        "-wqv",
+        "-t",
+        caller_pane_id,
+        SIDE_EDIT_PANE_OPTION,
     ])
     .unwrap_or_default();
     let window_panes = get_panes_in_window(caller_pane_id);
@@ -1482,7 +1495,6 @@ fn shell_quote(path: &str) -> String {
     format!("'{}'", path.replace('\'', "'\\''"))
 }
 
-
 /// Open a file in an existing pane, reusing nvim if running.
 fn open_file_in_pane(
     pane_id: &str,
@@ -1534,7 +1546,11 @@ fn resolve_side_pane(caller_pane_id: &str) -> Result<String> {
 
     // Query window-local option scoped to caller's window
     let stored_pane_id = run_tmux_command(&[
-        "show-option", "-wqv", "-t", caller_pane_id, SIDE_EDIT_PANE_OPTION,
+        "show-option",
+        "-wqv",
+        "-t",
+        caller_pane_id,
+        SIDE_EDIT_PANE_OPTION,
     ])
     .unwrap_or_default();
 
@@ -1553,10 +1569,17 @@ fn resolve_side_pane(caller_pane_id: &str) -> Result<String> {
     match other_panes.len() {
         0 => {
             // Only caller pane — create a shell split
-            let new_id = create_side_pane_shell(caller_pane_id)
-                .context("Failed to create side pane.")?;
+            let new_id =
+                create_side_pane_shell(caller_pane_id).context("Failed to create side pane.")?;
             let _ = Command::new("tmux")
-                .args(["set-option", "-w", "-t", caller_pane_id, SIDE_EDIT_PANE_OPTION, &new_id])
+                .args([
+                    "set-option",
+                    "-w",
+                    "-t",
+                    caller_pane_id,
+                    SIDE_EDIT_PANE_OPTION,
+                    &new_id,
+                ])
                 .output();
             Ok(new_id)
         }
@@ -1576,7 +1599,14 @@ fn resolve_side_pane(caller_pane_id: &str) -> Result<String> {
             }
             let adopted = candidate.clone();
             let _ = Command::new("tmux")
-                .args(["set-option", "-w", "-t", caller_pane_id, SIDE_EDIT_PANE_OPTION, &adopted])
+                .args([
+                    "set-option",
+                    "-w",
+                    "-t",
+                    caller_pane_id,
+                    SIDE_EDIT_PANE_OPTION,
+                    &adopted,
+                ])
                 .output();
             Ok(adopted)
         }
@@ -1630,7 +1660,13 @@ fn create_side_pane_shell(caller_pane_id: &str) -> Option<String> {
             if let Ok(width) = width_str.trim().parse::<i32>() {
                 let target = (width as f32 * 0.33) as i32;
                 let _ = Command::new("tmux")
-                    .args(["resize-pane", "-t", caller_pane_id, "-x", &target.to_string()])
+                    .args([
+                        "resize-pane",
+                        "-t",
+                        caller_pane_id,
+                        "-x",
+                        &target.to_string(),
+                    ])
                     .output();
             }
         }
@@ -1639,9 +1675,15 @@ fn create_side_pane_shell(caller_pane_id: &str) -> Option<String> {
     // Poll up to 500ms for the new pane's shell to be ready
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
     loop {
-        let pid_str = run_tmux_command(&["display-message", "-t", &new_pane_id, "-p", "#{pane_pid}"])
-            .unwrap_or_default();
-        if pid_str.trim().parse::<u32>().map(|p| p > 0).unwrap_or(false) {
+        let pid_str =
+            run_tmux_command(&["display-message", "-t", &new_pane_id, "-p", "#{pane_pid}"])
+                .unwrap_or_default();
+        if pid_str
+            .trim()
+            .parse::<u32>()
+            .map(|p| p > 0)
+            .unwrap_or(false)
+        {
             break;
         }
         if std::time::Instant::now() >= deadline {
@@ -1926,6 +1968,22 @@ trait ProcReader {
     /// `None` for pid 0, a vanished process, or an unreadable/unparseable stat
     /// file. `None` is non-fatal to the walker — it just means "stop here".
     fn read_ppid(&self, pid: u32) -> Option<u32>;
+
+    /// Return the full command line (argv joined by spaces) from
+    /// `/proc/<pid>/cmdline`. Null bytes in the file are argv separators and
+    /// are replaced with spaces; a trailing null is stripped. Returns `None`
+    /// when the file is missing, unreadable, or empty (kernel threads).
+    fn read_cmdline(&self, pid: u32) -> Option<String>;
+
+    /// Return the short process name from `/proc/<pid>/comm`, trimmed of the
+    /// trailing newline. Useful fallback for kernel threads whose
+    /// `/proc/<pid>/cmdline` is empty. Returns `None` on read/parse failure.
+    fn read_comm(&self, pid: u32) -> Option<String>;
+
+    /// Return the executable path via `readlink /proc/<pid>/exe`. Returns
+    /// `None` when the symlink can't be read (process gone, permission denied,
+    /// kernel thread).
+    fn read_exe(&self, pid: u32) -> Option<PathBuf>;
 }
 
 /// Production implementation of `TmuxProvider` — shells out to the `tmux`
@@ -1958,7 +2016,11 @@ impl TmuxProvider for RealTmuxProvider {
             return Err(TmuxError::NotRunning);
         }
         let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if s.is_empty() { Ok(None) } else { Ok(Some(s)) }
+        if s.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(s))
+        }
     }
 }
 
@@ -1971,6 +2033,72 @@ impl ProcReader for RealProcReader {
     fn read_ppid(&self, pid: u32) -> Option<u32> {
         read_ppid_from_proc(pid)
     }
+
+    fn read_cmdline(&self, pid: u32) -> Option<String> {
+        read_cmdline_from_proc(pid)
+    }
+
+    fn read_comm(&self, pid: u32) -> Option<String> {
+        read_comm_from_proc(pid)
+    }
+
+    fn read_exe(&self, pid: u32) -> Option<PathBuf> {
+        read_exe_from_proc(pid)
+    }
+}
+
+/// Read `/proc/<pid>/cmdline` — argv joined by null bytes, with a possible
+/// trailing null. Convert null separators to spaces. Returns `None` when the
+/// file is absent, unreadable, or entirely empty (kernel threads).
+fn read_cmdline_from_proc(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    let path = format!("/proc/{}/cmdline", pid);
+    let bytes = fs::read(&path).ok()?;
+    if bytes.is_empty() {
+        return None;
+    }
+    // Strip trailing NUL if present.
+    let trimmed = if bytes.last() == Some(&0) {
+        &bytes[..bytes.len() - 1]
+    } else {
+        &bytes[..]
+    };
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Replace remaining NULs with spaces, lossy UTF-8.
+    let with_spaces: Vec<u8> = trimmed
+        .iter()
+        .map(|b| if *b == 0 { b' ' } else { *b })
+        .collect();
+    Some(String::from_utf8_lossy(&with_spaces).into_owned())
+}
+
+/// Read `/proc/<pid>/comm` — short process name, trailing newline trimmed.
+fn read_comm_from_proc(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    let path = format!("/proc/{}/comm", pid);
+    let content = fs::read_to_string(&path).ok()?;
+    let trimmed = content.trim_end_matches('\n').trim_end_matches('\r');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Read the executable path via `readlink /proc/<pid>/exe`. Returns `None` for
+/// kernel threads, vanished processes, or permission-denied symlinks.
+fn read_exe_from_proc(pid: u32) -> Option<PathBuf> {
+    if pid == 0 {
+        return None;
+    }
+    let path = format!("/proc/{}/exe", pid);
+    fs::read_link(&path).ok()
 }
 
 /// Result of a successful parent-pid walk.
@@ -2103,6 +2231,19 @@ struct ParentPidTreeArgs {
     json: bool,
     pid: Option<u32>,
     verbose: bool,
+    tree: bool,
+}
+
+/// One row of the `--tree` output: a PID in the ancestor chain plus any
+/// cheap `/proc/<pid>/` metadata we could harvest. All metadata fields are
+/// `Option` because any `/proc` read can fail for kernel threads, vanished
+/// processes, or permission-gated targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TreeEntry {
+    pid: u32,
+    comm: Option<String>,
+    cmdline: Option<String>,
+    exe: Option<PathBuf>,
 }
 
 /// Structured result of running `parent-pid-tree`.
@@ -2121,6 +2262,21 @@ struct ParentPidTreeOutcome {
     stderr_lines: Vec<String>,
     /// Concrete exit code. See `run_parent_pid_tree` for the contract.
     exit_code: i32,
+    /// Populated only when `--tree` is set. Ordered from the start pid at
+    /// index 0 down to the pane-matching pid (or the last pid walked if no
+    /// match). `None` when `--tree` was not requested.
+    tree: Option<Vec<TreeEntry>>,
+    /// When `--tree` is set and the walk matched a pane, this is the matched
+    /// pane id. Lets the formatter annotate the leaf without re-walking.
+    /// `None` when tree was not requested or no pane was matched.
+    tree_pane_id: Option<String>,
+    /// When `--tree` is set and the walk matched a pane, this is the matched
+    /// pane_pid. `None` when tree was not requested or no match.
+    tree_pane_pid: Option<u32>,
+    /// The start pid of the walk, captured so the JSON tree payload can
+    /// report it. `None` when tree was not requested or the walk never
+    /// started (e.g. exit 2/3 paths).
+    tree_start_pid: Option<u32>,
 }
 
 /// Testable core of `parent-pid-tree`. Takes humble-shell dependencies so
@@ -2155,6 +2311,10 @@ fn run_parent_pid_tree(
                 stdout: String::new(),
                 stderr_lines,
                 exit_code: 2,
+                tree: None,
+                tree_pane_id: None,
+                tree_pane_pid: None,
+                tree_start_pid: None,
             };
         }
         Err(e) => {
@@ -2163,6 +2323,10 @@ fn run_parent_pid_tree(
                 stdout: String::new(),
                 stderr_lines,
                 exit_code: 2,
+                tree: None,
+                tree_pane_id: None,
+                tree_pane_pid: None,
+                tree_start_pid: None,
             };
         }
     };
@@ -2183,34 +2347,60 @@ fn run_parent_pid_tree(
                     stdout: String::new(),
                     stderr_lines,
                     exit_code: 3,
+                    tree: None,
+                    tree_pane_id: None,
+                    tree_pane_pid: None,
+                    tree_start_pid: None,
                 };
             }
         },
     };
 
     if args.verbose {
-        stderr_lines.push(format!("parent-pid-tree: starting walk at pid {}", start_pid));
+        stderr_lines.push(format!(
+            "parent-pid-tree: starting walk at pid {}",
+            start_pid
+        ));
     }
 
     // 3. Walk the chain. The walker takes its own read_ppid closure, which we
-    //    adapt from the injected `ProcReader`.
-    let result = resolve_pane_by_parent_chain(start_pid, &pane_pids, |p| proc.read_ppid(p));
+    //    adapt from the injected `ProcReader`. When --tree is set we also
+    //    capture the full walked chain even on no-match, so the tree view can
+    //    help the user debug why resolution failed.
+    let mut walked_chain: Vec<u32> = Vec::new();
+    let result = resolve_pane_by_parent_chain(start_pid, &pane_pids, |p| {
+        let next = proc.read_ppid(p);
+        if args.tree {
+            if let Some(n) = next {
+                walked_chain.push(n);
+            }
+        }
+        next
+    });
 
     match result {
         Some(m) => {
             if args.verbose {
-                let chain: Vec<String> = m
-                    .ancestors_walked
-                    .iter()
-                    .map(|p| p.to_string())
-                    .collect();
+                let chain: Vec<String> = m.ancestors_walked.iter().map(|p| p.to_string()).collect();
                 stderr_lines.push(format!(
                     "parent-pid-tree: walked {} (pane_pid) -> pane {}",
                     chain.join(" -> "),
                     m.pane_id
                 ));
             }
-            let stdout = if args.json {
+            let tree_data = if args.tree {
+                Some(collect_tree_entries(&m.ancestors_walked, proc))
+            } else {
+                None
+            };
+            let stdout = if args.tree {
+                let entries = tree_data.as_deref().unwrap_or(&[]);
+                if args.json {
+                    format_tree_json(start_pid, Some(&m.pane_id), Some(m.pane_pid), entries)
+                } else {
+                    format_tree_text(entries, Some(&m.pane_id))
+                }
+            } else if args.json {
                 let payload = serde_json::json!({
                     "pane_id": m.pane_id,
                     "pane_pid": m.pane_pid,
@@ -2225,6 +2415,14 @@ fn run_parent_pid_tree(
                 stdout,
                 stderr_lines,
                 exit_code: 0,
+                tree: tree_data,
+                tree_pane_id: if args.tree {
+                    Some(m.pane_id.clone())
+                } else {
+                    None
+                },
+                tree_pane_pid: if args.tree { Some(m.pane_pid) } else { None },
+                tree_start_pid: if args.tree { Some(start_pid) } else { None },
             }
         }
         None => {
@@ -2235,20 +2433,172 @@ fn run_parent_pid_tree(
                 ));
             }
             stderr_lines.push(format!("no tmux pane found for pid {}", start_pid));
+            // On no-match, rebuild the chain walked: start_pid plus whatever
+            // ancestors the walker consumed before stopping. We didn't have a
+            // `PaneMatch` to harvest from, so synthesize from `walked_chain`.
+            let tree_data = if args.tree {
+                let mut chain: Vec<u32> = Vec::with_capacity(walked_chain.len() + 1);
+                chain.push(start_pid);
+                for p in &walked_chain {
+                    if !chain.contains(p) {
+                        chain.push(*p);
+                    }
+                }
+                Some(collect_tree_entries(&chain, proc))
+            } else {
+                None
+            };
+            let stdout = if args.tree {
+                let entries = tree_data.as_deref().unwrap_or(&[]);
+                if args.json {
+                    format_tree_json(start_pid, None, None, entries)
+                } else {
+                    format_tree_text(entries, None)
+                }
+            } else {
+                String::new()
+            };
             ParentPidTreeOutcome {
-                stdout: String::new(),
+                stdout,
                 stderr_lines,
                 exit_code: 1,
+                tree: tree_data,
+                tree_pane_id: None,
+                tree_pane_pid: None,
+                tree_start_pid: if args.tree { Some(start_pid) } else { None },
             }
         }
     }
 }
 
+/// Harvest `/proc/<pid>/` metadata for each pid in the chain. Pure data
+/// transform — all external reads go through the injected `ProcReader`.
+fn collect_tree_entries(chain: &[u32], proc: &dyn ProcReader) -> Vec<TreeEntry> {
+    chain
+        .iter()
+        .map(|&pid| TreeEntry {
+            pid,
+            comm: proc.read_comm(pid),
+            cmdline: proc.read_cmdline(pid),
+            exe: proc.read_exe(pid),
+        })
+        .collect()
+}
+
+/// Max width (chars) we truncate cmdline output to in the text tree view.
+/// Users who need the full cmdline should use `--tree --json`.
+const TREE_CMDLINE_MAX_WIDTH: usize = 120;
+
+/// Render an ASCII tree for the chain. `pane_id` is `Some` when the walk
+/// matched a tmux pane — the leaf entry is annotated with `(pane shell)` and
+/// a `tmux pane:` line. When `None`, no annotations are added.
+fn format_tree_text(entries: &[TreeEntry], pane_id: Option<&str>) -> String {
+    let mut out = String::from("parent-pid-tree\n");
+    let n = entries.len();
+    if n == 0 {
+        return out;
+    }
+    // Compute the longest comm for column alignment (bounded to a reasonable
+    // width so absurd comms don't blow out the layout).
+    let comm_col = entries
+        .iter()
+        .map(|e| e.comm.as_deref().unwrap_or("?").len())
+        .max()
+        .unwrap_or(1)
+        .min(16);
+    for (i, entry) in entries.iter().enumerate() {
+        let is_leaf = i == n - 1;
+        let branch = if is_leaf { "└─" } else { "├─" };
+        let cont = if is_leaf { "  " } else { "│ " };
+        let comm = entry.comm.as_deref().unwrap_or("?");
+        let cmd_display = match entry.cmdline.as_deref() {
+            Some(c) if !c.is_empty() => truncate_display(c, TREE_CMDLINE_MAX_WIDTH),
+            // No cmdline — convention for kernel threads is [comm].
+            _ => format!("[{}]", comm),
+        };
+        let pane_suffix = if is_leaf && pane_id.is_some() {
+            "  (pane shell)"
+        } else {
+            ""
+        };
+        out.push_str(&format!(
+            "{} [pid {:<7}] {:<width$}  {}{}\n",
+            branch,
+            entry.pid,
+            comm,
+            cmd_display,
+            pane_suffix,
+            width = comm_col,
+        ));
+        match entry.exe.as_ref() {
+            Some(path) => {
+                out.push_str(&format!("{}    exe: {}\n", cont, path.display()));
+            }
+            None => {
+                out.push_str(&format!("{}    exe: (unreadable)\n", cont));
+            }
+        }
+        if is_leaf {
+            if let Some(pid) = pane_id {
+                out.push_str(&format!("{}    tmux pane: {}\n", cont, pid));
+            }
+        }
+    }
+    out
+}
+
+/// Render the tree as JSON. `pane_id` / `pane_pid` are None when the walk
+/// didn't match a pane (useful for debugging why resolution failed).
+fn format_tree_json(
+    start_pid: u32,
+    pane_id: Option<&str>,
+    pane_pid: Option<u32>,
+    entries: &[TreeEntry],
+) -> String {
+    let chain: Vec<serde_json::Value> = entries
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "pid": e.pid,
+                "comm": e.comm,
+                "cmdline": e.cmdline,
+                "exe": e.exe.as_ref().map(|p| p.display().to_string()),
+            })
+        })
+        .collect();
+    let payload = serde_json::json!({
+        "start_pid": start_pid,
+        "pane_id": pane_id,
+        "pane_pid": pane_pid,
+        "chain": chain,
+    });
+    payload.to_string()
+}
+
+/// Truncate `s` to at most `max` display chars, appending `…` if cut. Uses
+/// char count, not byte count — this is `/proc/<pid>/cmdline` so worst-case
+/// we have multi-byte UTF-8 (rare in practice for binary paths/argv).
+fn truncate_display(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    // Reserve one char for the ellipsis marker.
+    let keep = max.saturating_sub(1);
+    let mut out: String = s.chars().take(keep).collect();
+    out.push('…');
+    out
+}
+
 /// Thin wrapper that wires the real humble-shell impls into the testable core
 /// and performs the actual stdout/stderr writes. `main()` calls this; tests
 /// call `run_parent_pid_tree` directly with mocks.
-fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool) -> i32 {
-    let args = ParentPidTreeArgs { json, pid, verbose };
+fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool, tree: bool) -> i32 {
+    let args = ParentPidTreeArgs {
+        json,
+        pid,
+        verbose,
+        tree,
+    };
     let tmux = RealTmuxProvider;
     let proc = RealProcReader;
     let outcome = run_parent_pid_tree(args, std::process::id(), &tmux, &proc);
@@ -2256,7 +2606,15 @@ fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool) -> i32 {
         eprintln!("{}", line);
     }
     if !outcome.stdout.is_empty() {
-        println!("{}", outcome.stdout);
+        // Tree text output already contains trailing newlines per row; avoid
+        // adding an extra blank line for the multi-line tree view. For the
+        // single-line (non-tree) output path we keep the historical newline
+        // behavior.
+        if outcome.stdout.ends_with('\n') {
+            print!("{}", outcome.stdout);
+        } else {
+            println!("{}", outcome.stdout);
+        }
     }
     outcome.exit_code
 }
@@ -2273,11 +2631,17 @@ fn main() -> Result<()> {
         Some(Commands::SideEdit { file }) => side_edit(file.as_deref()),
         Some(Commands::SideRun { command, force }) => side_run(command.as_deref(), force),
         Some(Commands::DebugKeys) => debug_keys(),
-        Some(Commands::PickLinks { json, enrich_deadline_ms }) => {
-            link_picker::pick_links(json, enrich_deadline_ms)
-        }
-        Some(Commands::ParentPidTree { json, pid, verbose }) => {
-            let code = parent_pid_tree_cmd(json, pid, verbose);
+        Some(Commands::PickLinks {
+            json,
+            enrich_deadline_ms,
+        }) => link_picker::pick_links(json, enrich_deadline_ms),
+        Some(Commands::ParentPidTree {
+            json,
+            pid,
+            verbose,
+            tree,
+        }) => {
+            let code = parent_pid_tree_cmd(json, pid, verbose, tree);
             std::process::exit(code);
         }
         None => {
@@ -2354,20 +2718,29 @@ mod tests {
     fn test_generate_title_vim() {
         let child = make_process_info("nvim", "nvim file.rs", vec![]);
         let info = make_process_info("zsh", "/bin/zsh", vec![child]);
-        assert_eq!(generate_title(&info, "myproject"), Some("vi myproject".to_string()));
+        assert_eq!(
+            generate_title(&info, "myproject"),
+            Some("vi myproject".to_string())
+        );
     }
 
     #[test]
     fn test_generate_title_plain_shell() {
         let info = make_process_info("zsh", "/bin/zsh", vec![]);
-        assert_eq!(generate_title(&info, "myproject"), Some("z myproject".to_string()));
+        assert_eq!(
+            generate_title(&info, "myproject"),
+            Some("z myproject".to_string())
+        );
     }
 
     #[test]
     fn test_generate_title_docker() {
         let child = make_process_info("docker", "docker run nginx", vec![]);
         let info = make_process_info("zsh", "/bin/zsh", vec![child]);
-        assert_eq!(generate_title(&info, "myproject"), Some("docker myproject".to_string()));
+        assert_eq!(
+            generate_title(&info, "myproject"),
+            Some("docker myproject".to_string())
+        );
     }
 
     #[test]
@@ -2383,7 +2756,10 @@ mod tests {
         // just with subcommand should show "j <subcommand> <path>"
         let child = make_process_info("just", "just dev", vec![]);
         let info = make_process_info("zsh", "/bin/zsh", vec![child]);
-        assert_eq!(generate_title(&info, "blog"), Some("j dev blog".to_string()));
+        assert_eq!(
+            generate_title(&info, "blog"),
+            Some("j dev blog".to_string())
+        );
     }
 
     #[test]
@@ -2399,7 +2775,10 @@ mod tests {
         // jekyll should show "jekyll <path>"
         let child = make_process_info("jekyll", "jekyll serve", vec![]);
         let info = make_process_info("zsh", "/bin/zsh", vec![child]);
-        assert_eq!(generate_title(&info, "blog"), Some("jekyll blog".to_string()));
+        assert_eq!(
+            generate_title(&info, "blog"),
+            Some("jekyll blog".to_string())
+        );
     }
 
     #[test]
@@ -2407,7 +2786,10 @@ mod tests {
         // "just jekyll-serve" should shorten to "j jekyll <path>"
         let child = make_process_info("just", "just jekyll-serve", vec![]);
         let info = make_process_info("zsh", "/bin/zsh", vec![child]);
-        assert_eq!(generate_title(&info, "blog"), Some("j jekyll blog".to_string()));
+        assert_eq!(
+            generate_title(&info, "blog"),
+            Some("j jekyll blog".to_string())
+        );
     }
 
     #[test]
@@ -2495,15 +2877,15 @@ mod tests {
             shorten_path_middle("repo/subdir/leaf", 30),
             "repo/subdir/leaf"
         );
-        assert_eq!(
-            shorten_path_middle("repo/subdir/leaf", 12),
-            "repo/…/leaf"
-        );
+        assert_eq!(shorten_path_middle("repo/subdir/leaf", 12), "repo/…/leaf");
     }
 
     #[test]
     fn test_shorten_path_middle_home_path() {
-        assert_eq!(shorten_path_middle("~/deep/path/leaf", 20), "~/deep/path/leaf");
+        assert_eq!(
+            shorten_path_middle("~/deep/path/leaf", 20),
+            "~/deep/path/leaf"
+        );
         assert_eq!(shorten_path_middle("~/deep/path/leaf", 10), "~/…/leaf");
     }
 
@@ -2564,10 +2946,7 @@ mod tests {
     #[test]
     fn test_parse_file_line_zero() {
         // Line 0 is invalid, treat as no line
-        assert_eq!(
-            parse_file_line("foo.py:0"),
-            ("foo.py:0".to_string(), None)
-        );
+        assert_eq!(parse_file_line("foo.py:0"), ("foo.py:0".to_string(), None));
     }
 
     #[test]
@@ -2640,13 +3019,7 @@ mod tests {
     fn test_find_nvim_in_tree_no_match_does_not_pick_shell() {
         // A shell whose cmdline accidentally contains "vim" must NOT be picked
         // as the nvim pid — that would yield a wrong /proc/<pid>/cmdline.
-        let parent = make_process_info_full(
-            10,
-            "zsh",
-            "/bin/zsh -c 'edit vimrc'",
-            None,
-            vec![],
-        );
+        let parent = make_process_info_full(10, "zsh", "/bin/zsh -c 'edit vimrc'", None, vec![]);
         assert_eq!(find_nvim_in_tree(&parent), None);
     }
 
@@ -2883,10 +3256,7 @@ mod tests {
             nvim_running: Some(false),
             file: None,
         };
-        assert_eq!(
-            format_pane_status(&s),
-            "pane_id: none\nnvim: false\nfile: "
-        );
+        assert_eq!(format_pane_status(&s), "pane_id: none\nnvim: false\nfile: ");
     }
 
     #[test]
@@ -2925,7 +3295,11 @@ mod tests {
 
     /// Build a fake ppid reader from (child -> parent) pairs.
     fn fake_ppid(chain: &[(u32, u32)]) -> impl FnMut(u32) -> Option<u32> + '_ {
-        move |pid: u32| chain.iter().find_map(|(c, p)| if *c == pid { Some(*p) } else { None })
+        move |pid: u32| {
+            chain
+                .iter()
+                .find_map(|(c, p)| if *c == pid { Some(*p) } else { None })
+        }
     }
 
     #[test]
@@ -3134,9 +3508,10 @@ mod tests {
             match &self.result {
                 MockTmuxResult::Ok(pairs) => Ok(pairs.clone()),
                 MockTmuxResult::NotRunning => Err(TmuxError::NotRunning),
-                MockTmuxResult::ListFailed => Err(TmuxError::ListFailed(
-                    std::io::Error::new(std::io::ErrorKind::NotFound, "no such binary"),
-                )),
+                MockTmuxResult::ListFailed => Err(TmuxError::ListFailed(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "no such binary",
+                ))),
             }
         }
 
@@ -3153,6 +3528,9 @@ mod tests {
     struct MockProcReader {
         chain: Vec<(u32, u32)>,
         fail_on: HashSet<u32>,
+        cmdlines: HashMap<u32, String>,
+        comms: HashMap<u32, String>,
+        exes: HashMap<u32, PathBuf>,
     }
 
     impl MockProcReader {
@@ -3160,11 +3538,29 @@ mod tests {
             Self {
                 chain: chain.to_vec(),
                 fail_on: HashSet::new(),
+                cmdlines: HashMap::new(),
+                comms: HashMap::new(),
+                exes: HashMap::new(),
             }
         }
 
         fn failing_on(mut self, pid: u32) -> Self {
             self.fail_on.insert(pid);
+            self
+        }
+
+        fn with_cmdline(mut self, pid: u32, cmdline: &str) -> Self {
+            self.cmdlines.insert(pid, cmdline.to_string());
+            self
+        }
+
+        fn with_comm(mut self, pid: u32, comm: &str) -> Self {
+            self.comms.insert(pid, comm.to_string());
+            self
+        }
+
+        fn with_exe(mut self, pid: u32, exe: &str) -> Self {
+            self.exes.insert(pid, PathBuf::from(exe));
             self
         }
     }
@@ -3178,10 +3574,36 @@ mod tests {
                 .iter()
                 .find_map(|(c, p)| if *c == pid { Some(*p) } else { None })
         }
+
+        fn read_cmdline(&self, pid: u32) -> Option<String> {
+            self.cmdlines.get(&pid).cloned()
+        }
+
+        fn read_comm(&self, pid: u32) -> Option<String> {
+            self.comms.get(&pid).cloned()
+        }
+
+        fn read_exe(&self, pid: u32) -> Option<PathBuf> {
+            self.exes.get(&pid).cloned()
+        }
     }
 
     fn args(json: bool, pid: Option<u32>, verbose: bool) -> ParentPidTreeArgs {
-        ParentPidTreeArgs { json, pid, verbose }
+        ParentPidTreeArgs {
+            json,
+            pid,
+            verbose,
+            tree: false,
+        }
+    }
+
+    fn tree_args(json: bool, pid: Option<u32>, verbose: bool) -> ParentPidTreeArgs {
+        ParentPidTreeArgs {
+            json,
+            pid,
+            verbose,
+            tree: true,
+        }
     }
 
     #[test]
@@ -3210,8 +3632,7 @@ mod tests {
         let tmux = MockTmuxProvider::with_panes(&[("%42", 12345)]);
         // Chain: 999 -> 12345, which matches %42.
         let proc = MockProcReader::from_chain(&[(999, 12345)]);
-        let outcome =
-            run_parent_pid_tree(args(true, Some(999), false), 9_999_999, &tmux, &proc);
+        let outcome = run_parent_pid_tree(args(true, Some(999), false), 9_999_999, &tmux, &proc);
         assert_eq!(outcome.exit_code, 0);
         let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
         assert_eq!(payload["pane_id"], "%42");
@@ -3256,7 +3677,10 @@ mod tests {
         assert_eq!(outcome.stdout, "%35");
         // First verbose line is the start announcement, second is the chain.
         assert!(
-            outcome.stderr_lines.iter().any(|l| l.contains("starting walk at pid 999")),
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("starting walk at pid 999")),
             "stderr missing start line: {:?}",
             outcome.stderr_lines
         );
@@ -3363,12 +3787,10 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
         assert_eq!(payload["pane_id"], "%9");
         // stderr has the walk chain — JSON must not leak into stderr lines.
-        assert!(
-            outcome
-                .stderr_lines
-                .iter()
-                .any(|l| l.contains("800 -> 900") && l.contains("pane %9"))
-        );
+        assert!(outcome
+            .stderr_lines
+            .iter()
+            .any(|l| l.contains("800 -> 900") && l.contains("pane %9")));
         for line in &outcome.stderr_lines {
             assert!(
                 !line.contains("\"pane_id\""),
@@ -3376,5 +3798,264 @@ mod tests {
                 line
             );
         }
+    }
+
+    // ---- --tree flag tests -----------------------------------------------
+    //
+    // These exercise the humble-object core with populated cmdline/comm/exe
+    // data and verify both the TreeEntry collection and the pure formatters.
+
+    #[test]
+    fn test_run_parent_pid_tree_tree_mode_collects_chain_metadata() {
+        // Three-pid chain: 999 -> 4000 -> 2500 (pane_pid of %35). Each pid
+        // has distinct cmdline/comm/exe, so we can verify the entries come
+        // back in walk order with the per-pid metadata attached.
+        let tmux = MockTmuxProvider::with_panes(&[("%35", 2500)]);
+        let proc = MockProcReader::from_chain(&[(999, 4000), (4000, 2500)])
+            .with_comm(999, "bash")
+            .with_cmdline(999, "/usr/bin/bash -c rmux_helper parent-pid-tree --tree")
+            .with_exe(999, "/usr/bin/bash")
+            .with_comm(4000, "claude")
+            .with_cmdline(4000, "claude /startup-larry")
+            .with_exe(4000, "/home/developer/.local/bin/claude")
+            .with_comm(2500, "zsh")
+            .with_cmdline(2500, "/home/linuxbrew/.linuxbrew/bin/zsh")
+            .with_exe(2500, "/home/linuxbrew/.linuxbrew/bin/zsh");
+        let outcome = run_parent_pid_tree(tree_args(false, Some(999), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let tree = outcome.tree.as_ref().expect("tree should be populated");
+        assert_eq!(tree.len(), 3, "expected 3 entries, got {}", tree.len());
+        assert_eq!(tree[0].pid, 999);
+        assert_eq!(tree[0].comm.as_deref(), Some("bash"));
+        assert_eq!(
+            tree[0].cmdline.as_deref(),
+            Some("/usr/bin/bash -c rmux_helper parent-pid-tree --tree")
+        );
+        assert_eq!(
+            tree[0].exe.as_deref(),
+            Some(std::path::Path::new("/usr/bin/bash"))
+        );
+        assert_eq!(tree[1].pid, 4000);
+        assert_eq!(tree[1].comm.as_deref(), Some("claude"));
+        assert_eq!(tree[2].pid, 2500);
+        assert_eq!(tree[2].comm.as_deref(), Some("zsh"));
+        assert_eq!(outcome.tree_pane_id.as_deref(), Some("%35"));
+        assert_eq!(outcome.tree_pane_pid, Some(2500));
+        assert_eq!(outcome.tree_start_pid, Some(999));
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_tree_mode_handles_missing_cmdline() {
+        // A kernel-thread-like entry in the chain: comm populated, cmdline
+        // empty. The TreeEntry must capture comm = Some("kthreadd") and
+        // cmdline = None. The formatter will render this as [kthreadd].
+        let tmux = MockTmuxProvider::with_panes(&[("%1", 100)]);
+        let proc = MockProcReader::from_chain(&[(50, 100)])
+            .with_comm(50, "kthreadd")
+            // Intentionally NO cmdline for pid 50.
+            .with_exe(50, "/usr/sbin/init")
+            .with_comm(100, "zsh")
+            .with_cmdline(100, "/bin/zsh")
+            .with_exe(100, "/bin/zsh");
+        let outcome = run_parent_pid_tree(tree_args(false, Some(50), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let tree = outcome.tree.as_ref().unwrap();
+        assert_eq!(tree[0].pid, 50);
+        assert_eq!(tree[0].comm.as_deref(), Some("kthreadd"));
+        assert_eq!(tree[0].cmdline, None);
+        // Text formatter should fall back to [kthreadd].
+        assert!(
+            outcome.stdout.contains("[kthreadd]"),
+            "stdout missing kthreadd fallback: {}",
+            outcome.stdout
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_tree_mode_handles_missing_exe() {
+        // Middle pid has no exe readlink (permission denied / race). We must
+        // not panic — TreeEntry.exe stays None and the text formatter prints
+        // "exe: (unreadable)".
+        let tmux = MockTmuxProvider::with_panes(&[("%2", 200)]);
+        let proc = MockProcReader::from_chain(&[(100, 150), (150, 200)])
+            .with_comm(100, "bash")
+            .with_cmdline(100, "bash -l")
+            .with_exe(100, "/bin/bash")
+            .with_comm(150, "mystery")
+            .with_cmdline(150, "/opt/mystery --flag")
+            // Intentionally NO exe for pid 150.
+            .with_comm(200, "zsh")
+            .with_cmdline(200, "/bin/zsh")
+            .with_exe(200, "/bin/zsh");
+        let outcome = run_parent_pid_tree(tree_args(false, Some(100), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let tree = outcome.tree.as_ref().unwrap();
+        assert_eq!(tree[1].pid, 150);
+        assert_eq!(tree[1].exe, None);
+        assert!(
+            outcome.stdout.contains("exe: (unreadable)"),
+            "stdout missing (unreadable) marker: {}",
+            outcome.stdout
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_tree_and_json_combined() {
+        // --tree + --json: stdout is structured JSON with start_pid, pane_id,
+        // pane_pid, and a chain array where each entry has pid/comm/cmdline/exe.
+        let tmux = MockTmuxProvider::with_panes(&[("%42", 420)]);
+        let proc = MockProcReader::from_chain(&[(100, 420)])
+            .with_comm(100, "bash")
+            .with_cmdline(100, "/bin/bash -c foo")
+            .with_exe(100, "/bin/bash")
+            .with_comm(420, "zsh")
+            .with_cmdline(420, "/bin/zsh")
+            .with_exe(420, "/bin/zsh");
+        let outcome = run_parent_pid_tree(tree_args(true, Some(100), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let payload: serde_json::Value =
+            serde_json::from_str(&outcome.stdout).expect("stdout must be valid JSON");
+        assert_eq!(payload["start_pid"], 100);
+        assert_eq!(payload["pane_id"], "%42");
+        assert_eq!(payload["pane_pid"], 420);
+        let chain = payload["chain"].as_array().expect("chain must be an array");
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0]["pid"], 100);
+        assert_eq!(chain[0]["comm"], "bash");
+        assert_eq!(chain[0]["cmdline"], "/bin/bash -c foo");
+        assert_eq!(chain[0]["exe"], "/bin/bash");
+        assert_eq!(chain[1]["pid"], 420);
+        assert_eq!(chain[1]["exe"], "/bin/zsh");
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_tree_on_no_match() {
+        // Walker never hits a pane_pid (walks from 999 -> 500 -> 1). Exit 1,
+        // but tree data is still populated so the user can see the chain they
+        // walked (useful when debugging why resolution failed).
+        let tmux = MockTmuxProvider::with_panes(&[("%99", 9999)]);
+        let proc = MockProcReader::from_chain(&[(999, 500), (500, 1)])
+            .with_comm(999, "bash")
+            .with_cmdline(999, "bash")
+            .with_comm(500, "sshd")
+            .with_cmdline(500, "sshd");
+        let outcome = run_parent_pid_tree(tree_args(false, Some(999), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 1);
+        let tree = outcome
+            .tree
+            .as_ref()
+            .expect("tree populated even on no-match");
+        // Chain includes start_pid plus whatever ancestors the walker reached
+        // before the walker gave up at init (pid 1).
+        let pids: Vec<u32> = tree.iter().map(|e| e.pid).collect();
+        assert!(pids.contains(&999));
+        assert!(pids.contains(&500));
+        assert_eq!(outcome.tree_pane_id, None);
+        assert_eq!(outcome.tree_pane_pid, None);
+    }
+
+    #[test]
+    fn test_tree_formatter_truncates_long_cmdline() {
+        // Cmdline >120 chars should be truncated with a `…` suffix in the
+        // text view. The full value is still available via --json.
+        let long_arg = "a".repeat(300);
+        let entry = TreeEntry {
+            pid: 42,
+            comm: Some("bash".to_string()),
+            cmdline: Some(format!("/bin/bash -c '{}'", long_arg)),
+            exe: Some(PathBuf::from("/bin/bash")),
+        };
+        let out = format_tree_text(&[entry], None);
+        assert!(out.contains("…"), "missing ellipsis: {}", out);
+        // No line in the tree body should exceed ~200 chars (a generous
+        // upper bound allowing for prefix + truncated cmdline).
+        for line in out.lines() {
+            assert!(
+                line.chars().count() < 200,
+                "line too long ({} chars): {}",
+                line.chars().count(),
+                line,
+            );
+        }
+    }
+
+    #[test]
+    fn test_tree_formatter_ascii_box_drawing() {
+        // Two-entry tree: first row uses `├─`, last row uses `└─`. The
+        // continuation prefix on the non-leaf entry's exe line uses `│`.
+        let entries = vec![
+            TreeEntry {
+                pid: 1,
+                comm: Some("a".to_string()),
+                cmdline: Some("a".to_string()),
+                exe: Some(PathBuf::from("/a")),
+            },
+            TreeEntry {
+                pid: 2,
+                comm: Some("b".to_string()),
+                cmdline: Some("b".to_string()),
+                exe: Some(PathBuf::from("/b")),
+            },
+        ];
+        let out = format_tree_text(&entries, None);
+        assert!(out.contains("├─"), "missing ├─ branch marker: {}", out);
+        assert!(out.contains("└─"), "missing └─ leaf marker: {}", out);
+        assert!(out.contains("│"), "missing │ continuation marker: {}", out);
+        // Ordering sanity: the ├─ line appears before the └─ line.
+        let branch_idx = out.find("├─").unwrap();
+        let leaf_idx = out.find("└─").unwrap();
+        assert!(branch_idx < leaf_idx);
+    }
+
+    #[test]
+    fn test_tree_formatter_shows_pane_id_at_leaf() {
+        // When pane_id is Some, the final entry gets a "(pane shell)"
+        // annotation AND a "tmux pane: %35" line.
+        let entries = vec![TreeEntry {
+            pid: 1,
+            comm: Some("zsh".to_string()),
+            cmdline: Some("/bin/zsh".to_string()),
+            exe: Some(PathBuf::from("/bin/zsh")),
+        }];
+        let out = format_tree_text(&entries, Some("%35"));
+        assert!(
+            out.contains("(pane shell)"),
+            "missing (pane shell): {}",
+            out
+        );
+        assert!(
+            out.contains("tmux pane: %35"),
+            "missing tmux pane line: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_tree_formatter_omits_pane_id_when_none() {
+        // When pane_id is None (no-match case), neither annotation appears.
+        let entries = vec![TreeEntry {
+            pid: 1,
+            comm: Some("zsh".to_string()),
+            cmdline: Some("/bin/zsh".to_string()),
+            exe: Some(PathBuf::from("/bin/zsh")),
+        }];
+        let out = format_tree_text(&entries, None);
+        assert!(!out.contains("(pane shell)"));
+        assert!(!out.contains("tmux pane:"));
+    }
+
+    #[test]
+    fn test_real_proc_reader_cmdline_for_self() {
+        // Real-proc read for our own pid: cmdline should be non-empty and
+        // include something binary-ish. Loosely asserted — this is just a
+        // smoke test to make sure the RealProcReader wiring works.
+        let reader = RealProcReader;
+        let pid = std::process::id();
+        let cmdline = reader.read_cmdline(pid);
+        assert!(cmdline.is_some(), "own cmdline must be readable");
+        let comm = reader.read_comm(pid);
+        assert!(comm.is_some(), "own comm must be readable");
+        let exe = reader.read_exe(pid);
+        assert!(exe.is_some(), "own exe must be readable");
     }
 }

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -2805,4 +2805,77 @@ mod tests {
         let result = resolve_pane_by_parent_chain(500, &pane_pids, fake_ppid(&chain));
         assert!(result.is_none());
     }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_start_from_pid_zero() {
+        // Sentinel guard: starting at pid 0 must return None immediately without
+        // consulting the reader. Protects against bogus input blowing up the walk.
+        let pane_pids = HashMap::new();
+        let mut calls = 0u32;
+        let reader = |_pid: u32| {
+            calls += 1;
+            Some(42u32)
+        };
+        let result = resolve_pane_by_parent_chain(0, &pane_pids, reader);
+        assert!(result.is_none());
+        assert_eq!(calls, 0, "reader must not be called when start_pid is 0");
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_start_from_pid_one() {
+        // Same sentinel guard for init (pid 1). Walker must stop, not query reader.
+        let pane_pids = HashMap::new();
+        let mut calls = 0u32;
+        let reader = |_pid: u32| {
+            calls += 1;
+            Some(42u32)
+        };
+        let result = resolve_pane_by_parent_chain(1, &pane_pids, reader);
+        assert!(result.is_none());
+        assert_eq!(calls, 0, "reader must not be called when start_pid is 1");
+    }
+
+    #[test]
+    fn test_read_ppid_from_proc_pid_zero_guard() {
+        // pid 0 is a sentinel — must return None without touching /proc.
+        assert_eq!(read_ppid_from_proc(0), None);
+    }
+
+    #[test]
+    fn test_read_ppid_from_proc_nonexistent_pid() {
+        // A pid that (almost) certainly does not exist on any real system must
+        // return None gracefully (fs::read fails → .ok()? short-circuits). Any
+        // panic here would indicate the error path is broken.
+        assert_eq!(read_ppid_from_proc(u32::MAX), None);
+    }
+
+    // --- Integration-ish tests against real /proc -------------------------------
+    //
+    // These exercise the live /proc stat parser (rfind(')')-based comm handling)
+    // against real kernel data so the `comm` field with spaces or close-parens
+    // doesn't silently break parsing. They're Linux-only; guarded with cfg.
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_read_ppid_from_proc_init_is_zero() {
+        // init (pid 1) always exists on Linux and its ppid is 0 by kernel
+        // convention. Verifies the parser works end-to-end on a real stat line.
+        let ppid = read_ppid_from_proc(1).expect("/proc/1/stat must be readable on Linux");
+        assert_eq!(ppid, 0, "init's ppid should be 0");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_read_ppid_from_proc_self_matches_process_parent() {
+        // The current process's ppid from /proc must be Some(non-zero). This
+        // catches regressions in field-offset math after the comm section — the
+        // very bug the rfind(')') logic exists to prevent.
+        let my_pid = std::process::id();
+        let ppid =
+            read_ppid_from_proc(my_pid).expect("/proc/<self>/stat must be readable and parseable");
+        assert!(
+            ppid > 0,
+            "own ppid must be > 0 (actual pid tree should have a real parent)"
+        );
+    }
 }

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -27,6 +27,7 @@ Features:
   - Fuzzy session/window/pane picker with tree view (pick-tui)
   - Auto-rename windows based on running processes (rename-all)
   - Layout rotation and 1/3-2/3 split management (rotate, third)
+  - Resolve caller's owning tmux pane via parent-PID walk (parent-pid-tree)
 
 Keybindings (configured in .tmux.conf):
   C-a w     Launch picker popup
@@ -79,6 +80,21 @@ enum Commands {
         /// Enrichment deadline in milliseconds (0 disables gh enrichment)
         #[arg(long, default_value_t = 3000)]
         enrich_deadline_ms: u64,
+    },
+    /// Resolve the calling process's owning tmux pane by walking the parent-PID chain.
+    /// Use this instead of `tmux display-message -p '#{pane_id}'`, which returns the
+    /// tmux-active pane (focused pane) rather than the caller's pane.
+    ParentPidTree {
+        /// Emit structured JSON with pane_id, pane_pid, walked_from_pid, and ancestors_walked
+        #[arg(long)]
+        json: bool,
+        /// Start the walk from this pid instead of the caller's pid.
+        /// When omitted, starts from the parent of rmux_helper (i.e. the caller).
+        #[arg(long)]
+        pid: Option<u32>,
+        /// Log the walk (ancestor chain, pane match) to stderr for debugging
+        #[arg(long)]
+        verbose: bool,
     },
 }
 
@@ -1818,6 +1834,230 @@ fn debug_keys() -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// parent-pid-tree: resolve the caller's owning tmux pane by walking ppid chain
+// ============================================================================
+//
+// Why this exists: `tmux display-message -p '#{pane_id}'` returns the tmux-active
+// pane (the one focused in the attached client), not the pane the caller is
+// running inside. With multiple Claude sessions in different panes, that primitive
+// silently targets the wrong session. The correct primitive is to walk from the
+// caller's pid up through ppid (via /proc/<pid>/stat field 4) until we hit a pid
+// that matches a `pane_pid` reported by `tmux list-panes`. The first ancestor
+// match is deterministically the caller's pane, regardless of focus state.
+
+/// Result of a successful parent-pid walk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PaneMatch {
+    pane_id: String,
+    pane_pid: u32,
+    ancestors_walked: Vec<u32>,
+}
+
+/// Read field 4 (ppid) of /proc/<pid>/stat.
+///
+/// The stat file is space-separated, but field 2 (`comm`) is wrapped in parens
+/// and CAN contain spaces or closing-parens inside. Find the LAST `)` to locate
+/// the end of comm, then split the rest — field 4 becomes index 1 after the
+/// state char.
+fn read_ppid_from_proc(pid: u32) -> Option<u32> {
+    if pid == 0 {
+        return None;
+    }
+    let path = format!("/proc/{}/stat", pid);
+    let bytes = fs::read(&path).ok()?;
+    let content = String::from_utf8_lossy(&bytes);
+    let last_paren = content.rfind(')')?;
+    let after = content.get(last_paren + 1..)?.trim_start();
+    // after = "<state> <ppid> <pgrp> ..."
+    let mut fields = after.split_ascii_whitespace();
+    let _state = fields.next()?;
+    let ppid_str = fields.next()?;
+    ppid_str.parse().ok()
+}
+
+/// Parse `tmux list-panes -a -F '#{pane_id} #{pane_pid}'` output into a map
+/// from pane_pid -> pane_id.
+fn parse_pane_pids(output: &str) -> HashMap<u32, String> {
+    let mut map = HashMap::new();
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split_ascii_whitespace();
+        let Some(pane_id) = parts.next() else {
+            continue;
+        };
+        let Some(pid_str) = parts.next() else {
+            continue;
+        };
+        if let Ok(pid) = pid_str.parse::<u32>() {
+            map.insert(pid, pane_id.to_string());
+        }
+    }
+    map
+}
+
+/// Fetch `tmux list-panes -a -F '#{pane_id} #{pane_pid}'` and parse it.
+/// Returns an error if tmux is not running or the command fails.
+fn list_tmux_pane_pids() -> Result<HashMap<u32, String>> {
+    let output = Command::new("tmux")
+        .args(["list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"])
+        .output()
+        .context("failed to spawn tmux")?;
+    if !output.status.success() {
+        anyhow::bail!("tmux list-panes failed (is tmux running?)");
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let map = parse_pane_pids(&stdout);
+    Ok(map)
+}
+
+/// Safety cap on walk depth — normal process trees on Linux are well under this.
+const PPID_WALK_MAX_DEPTH: usize = 64;
+
+/// Walk from `start_pid` up through parent PIDs until we find one whose pid
+/// appears in `pane_pids`. Returns the first match, or None if we reach pid 1/0,
+/// hit max depth, fail to read a ppid before matching, or detect a cycle.
+///
+/// `read_ppid` is injected so tests can provide a fake ancestor chain without
+/// touching /proc. The first entry in `ancestors_walked` is always `start_pid`.
+///
+/// Behavior notes:
+/// - If `start_pid` itself is in `pane_pids`, it matches immediately.
+/// - If `read_ppid` returns None for a specific pid (vanished process, unreadable
+///   stat file), we stop walking — this is graceful, not a panic.
+fn resolve_pane_by_parent_chain<F>(
+    start_pid: u32,
+    pane_pids: &HashMap<u32, String>,
+    mut read_ppid: F,
+) -> Option<PaneMatch>
+where
+    F: FnMut(u32) -> Option<u32>,
+{
+    let mut current = start_pid;
+    let mut ancestors: Vec<u32> = Vec::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+
+    for _ in 0..PPID_WALK_MAX_DEPTH {
+        if current == 0 || current == 1 {
+            // Reached init / sentinel — no pane match.
+            if !ancestors.contains(&current) {
+                ancestors.push(current);
+            }
+            return None;
+        }
+        if !seen.insert(current) {
+            // Cycle detection — shouldn't happen with real ppid but be safe.
+            return None;
+        }
+        ancestors.push(current);
+        if let Some(pane_id) = pane_pids.get(&current) {
+            return Some(PaneMatch {
+                pane_id: pane_id.clone(),
+                pane_pid: current,
+                ancestors_walked: ancestors,
+            });
+        }
+        // Read the next ancestor. If the read fails we stop walking — the
+        // process probably exited mid-walk. We don't treat that as a hard error;
+        // first-match-wins semantics have already been applied above.
+        match read_ppid(current) {
+            Some(next) => current = next,
+            None => return None,
+        }
+    }
+    None
+}
+
+/// Run the parent-pid-tree command end to end: default start-pid resolution,
+/// tmux list-panes, walk, output formatting, exit code.
+///
+/// Returns a concrete exit code (0/1/2/3) rather than anyhow::Error so that the
+/// error contract documented in CLAUDE.md is preserved — we want deterministic
+/// codes regardless of what fails underneath.
+fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool) -> i32 {
+    // 1. Fetch pane_pid map from tmux.
+    let pane_pids = match list_tmux_pane_pids() {
+        Ok(map) if map.is_empty() => {
+            eprintln!("tmux not running or no panes");
+            return 2;
+        }
+        Ok(map) => map,
+        Err(e) => {
+            eprintln!("tmux not running or no panes: {}", e);
+            return 2;
+        }
+    };
+
+    // 2. Determine start pid. When the user passed --pid we trust it verbatim.
+    // Otherwise we walk from the PARENT of rmux_helper itself: rmux_helper is
+    // a child of whoever invoked it, and that caller is what we want to resolve.
+    let start_pid = match pid {
+        Some(p) => p,
+        None => {
+            let self_pid = std::process::id();
+            match read_ppid_from_proc(self_pid) {
+                Some(p) => p,
+                None => {
+                    eprintln!(
+                        "could not read /proc/{}/stat to find caller pid",
+                        self_pid
+                    );
+                    return 3;
+                }
+            }
+        }
+    };
+
+    if verbose {
+        eprintln!("parent-pid-tree: starting walk at pid {}", start_pid);
+    }
+
+    // 3. Walk the chain.
+    let result = resolve_pane_by_parent_chain(start_pid, &pane_pids, read_ppid_from_proc);
+
+    match result {
+        Some(m) => {
+            if verbose {
+                let chain: Vec<String> = m
+                    .ancestors_walked
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect();
+                eprintln!(
+                    "parent-pid-tree: walked {} (pane_pid) -> pane {}",
+                    chain.join(" -> "),
+                    m.pane_id
+                );
+            }
+            if json {
+                let payload = serde_json::json!({
+                    "pane_id": m.pane_id,
+                    "pane_pid": m.pane_pid,
+                    "walked_from_pid": start_pid,
+                    "ancestors_walked": m.ancestors_walked,
+                });
+                println!("{}", payload);
+            } else {
+                println!("{}", m.pane_id);
+            }
+            0
+        }
+        None => {
+            if verbose {
+                eprintln!(
+                    "parent-pid-tree: no pane match for pid {} (walked until init/unreadable/max-depth)",
+                    start_pid
+                );
+            }
+            eprintln!("no tmux pane found for pid {}", start_pid);
+            1
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -1832,6 +2072,10 @@ fn main() -> Result<()> {
         Some(Commands::DebugKeys) => debug_keys(),
         Some(Commands::PickLinks { json, enrich_deadline_ms }) => {
             link_picker::pick_links(json, enrich_deadline_ms)
+        }
+        Some(Commands::ParentPidTree { json, pid, verbose }) => {
+            let code = parent_pid_tree_cmd(json, pid, verbose);
+            std::process::exit(code);
         }
         None => {
             // Show help when no command given
@@ -2453,5 +2697,112 @@ mod tests {
             format_pane_status(&s),
             "pane_id: ambiguous\nnvim: true\nfile: "
         );
+    }
+
+    // ---- parent-pid-tree ----
+
+    #[test]
+    fn test_parse_pane_pids_basic() {
+        let input = "%35 2594534\n%65 331460\n";
+        let map = parse_pane_pids(input);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&2594534).map(String::as_str), Some("%35"));
+        assert_eq!(map.get(&331460).map(String::as_str), Some("%65"));
+    }
+
+    #[test]
+    fn test_parse_pane_pids_handles_blank_and_malformed_lines() {
+        let input = "\n%1 100\n   \ngarbage\n%2 notapid\n%3 300\n";
+        let map = parse_pane_pids(input);
+        // Only well-formed lines survive; malformed ones are skipped, not errored.
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&100).map(String::as_str), Some("%1"));
+        assert_eq!(map.get(&300).map(String::as_str), Some("%3"));
+    }
+
+    /// Build a fake ppid reader from (child -> parent) pairs.
+    fn fake_ppid(chain: &[(u32, u32)]) -> impl FnMut(u32) -> Option<u32> + '_ {
+        move |pid: u32| chain.iter().find_map(|(c, p)| if *c == pid { Some(*p) } else { None })
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_larry_scenario() {
+        // Larry scenario: caller pid is 400284. Its ancestor chain is
+        // 400284 -> 398200 -> 2594534. The pane_pid map has %35 -> 2594534
+        // and %65 -> 331460. We expect %35.
+        let mut pane_pids = HashMap::new();
+        pane_pids.insert(2594534, "%35".to_string());
+        pane_pids.insert(331460, "%65".to_string());
+        let chain = [(400284u32, 398200u32), (398200, 2594534)];
+        let result = resolve_pane_by_parent_chain(400284, &pane_pids, fake_ppid(&chain))
+            .expect("expected a match");
+        assert_eq!(result.pane_id, "%35");
+        assert_eq!(result.pane_pid, 2594534);
+        assert_eq!(result.ancestors_walked, vec![400284, 398200, 2594534]);
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_start_pid_already_matches() {
+        // Edge case: start_pid itself is a pane_pid.
+        let mut pane_pids = HashMap::new();
+        pane_pids.insert(2594534, "%35".to_string());
+        let chain: [(u32, u32); 0] = [];
+        let result = resolve_pane_by_parent_chain(2594534, &pane_pids, fake_ppid(&chain))
+            .expect("expected a match");
+        assert_eq!(result.pane_id, "%35");
+        assert_eq!(result.pane_pid, 2594534);
+        assert_eq!(result.ancestors_walked, vec![2594534]);
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_no_match() {
+        // Walker whose chain never hits any pane_pid — walk terminates at init.
+        let mut pane_pids = HashMap::new();
+        pane_pids.insert(9999, "%99".to_string());
+        let chain = [(500u32, 400u32), (400, 300), (300, 1)];
+        let result = resolve_pane_by_parent_chain(500, &pane_pids, fake_ppid(&chain));
+        assert!(result.is_none(), "expected None, got {:?}", result);
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_vanished_parent_graceful() {
+        // Walker whose parent disappears mid-walk (read_ppid returns None).
+        // Should return None gracefully, not panic.
+        let pane_pids = HashMap::new();
+        let chain = [(500u32, 400u32)]; // 400 has no entry, so read_ppid(400) = None
+        let result = resolve_pane_by_parent_chain(500, &pane_pids, fake_ppid(&chain));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_vanished_parent_but_prior_match() {
+        // Walker's first ancestor matches, so the match wins even though the
+        // next read would fail. Verifies "first match wins" semantics.
+        let mut pane_pids = HashMap::new();
+        pane_pids.insert(400, "%7".to_string());
+        let chain = [(500u32, 400u32)]; // read_ppid(400) would be None, but we match first
+        let result = resolve_pane_by_parent_chain(500, &pane_pids, fake_ppid(&chain))
+            .expect("expected a match");
+        assert_eq!(result.pane_id, "%7");
+        assert_eq!(result.pane_pid, 400);
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_depth_cap() {
+        // Ensure a degenerate chain doesn't loop forever — capped at 64.
+        let pane_pids = HashMap::new();
+        // Every pid's parent is pid+1000, so we never hit 1. Walker must stop.
+        let reader = |pid: u32| Some(pid + 1000);
+        let result = resolve_pane_by_parent_chain(100, &pane_pids, reader);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_resolve_pane_by_parent_chain_cycle_safe() {
+        // Pathological cycle: 500 -> 400 -> 500. Walker must not infinite-loop.
+        let pane_pids = HashMap::new();
+        let chain = [(500u32, 400u32), (400, 500)];
+        let result = resolve_pane_by_parent_chain(500, &pane_pids, fake_ppid(&chain));
+        assert!(result.is_none());
     }
 }

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -2254,6 +2254,17 @@ struct ParentPidTreeArgs {
     tree: bool,
 }
 
+impl ParentPidTreeArgs {
+    /// True when the caller wants the rich per-pid chain details collected.
+    /// Both `--tree` (human text or structured JSON) and `--verbose` (JSON
+    /// payload inspection) trigger this; either flag makes `--json` emit the
+    /// full `chain[]` array. Without either, `--json` stays on the minimal
+    /// payload path for scriptability.
+    fn wants_rich_chain(&self) -> bool {
+        self.tree || self.verbose
+    }
+}
+
 /// One row of the `--tree` output: a PID in the ancestor chain plus any
 /// cheap `/proc/<pid>/` metadata we could harvest. All metadata fields are
 /// `Option` because any `/proc` read can fail for kernel threads, vanished
@@ -2384,13 +2395,14 @@ fn run_parent_pid_tree(
     }
 
     // 3. Walk the chain. The walker takes its own read_ppid closure, which we
-    //    adapt from the injected `ProcReader`. When --tree is set we also
-    //    capture the full walked chain even on no-match, so the tree view can
-    //    help the user debug why resolution failed.
+    //    adapt from the injected `ProcReader`. When --tree or --verbose is set
+    //    we also capture the full walked chain even on no-match, so the tree
+    //    view (and rich JSON) can help the user debug why resolution failed.
+    let wants_rich = args.wants_rich_chain();
     let mut walked_chain: Vec<u32> = Vec::new();
     let result = resolve_pane_by_parent_chain(start_pid, &pane_pids, |p| {
         let next = proc.read_ppid(p);
-        if args.tree {
+        if wants_rich {
             if let Some(n) = next {
                 walked_chain.push(n);
             }
@@ -2408,19 +2420,26 @@ fn run_parent_pid_tree(
                     m.pane_id
                 ));
             }
-            let tree_data = if args.tree {
+            // Collect rich chain metadata whenever the caller asked for it —
+            // either via --tree (text or JSON) or --verbose (JSON payload).
+            let tree_data = if wants_rich {
                 Some(collect_tree_entries(&m.ancestors_walked, proc))
             } else {
                 None
             };
-            let stdout = if args.tree {
+            let stdout = if args.tree && !args.json {
+                // Human-readable tree text only when --tree is explicit.
                 let entries = tree_data.as_deref().unwrap_or(&[]);
-                if args.json {
-                    format_tree_json(start_pid, Some(&m.pane_id), Some(m.pane_pid), entries)
-                } else {
-                    format_tree_text(entries, Some(&m.pane_id))
-                }
+                format_tree_text(entries, Some(&m.pane_id))
+            } else if args.json && wants_rich {
+                // Rich JSON: --tree --json OR --verbose --json produces the
+                // same payload shape. --verbose also leaves walk lines on
+                // stderr (above) for human inspection.
+                let entries = tree_data.as_deref().unwrap_or(&[]);
+                format_tree_json(start_pid, Some(&m.pane_id), Some(m.pane_pid), entries)
             } else if args.json {
+                // Minimal JSON — scriptable contract preserved when neither
+                // --tree nor --verbose is set.
                 let payload = serde_json::json!({
                     "pane_id": m.pane_id,
                     "pane_pid": m.pane_pid,
@@ -2429,6 +2448,8 @@ fn run_parent_pid_tree(
                 });
                 payload.to_string()
             } else {
+                // Plain text: just the pane id. --verbose alone does not
+                // change stdout; its effect lives entirely on stderr.
                 m.pane_id.clone()
             };
             ParentPidTreeOutcome {
@@ -2456,7 +2477,7 @@ fn run_parent_pid_tree(
             // On no-match, rebuild the chain walked: start_pid plus whatever
             // ancestors the walker consumed before stopping. We didn't have a
             // `PaneMatch` to harvest from, so synthesize from `walked_chain`.
-            let tree_data = if args.tree {
+            let tree_data = if wants_rich {
                 let mut chain: Vec<u32> = Vec::with_capacity(walked_chain.len() + 1);
                 chain.push(start_pid);
                 for p in &walked_chain {
@@ -2468,14 +2489,15 @@ fn run_parent_pid_tree(
             } else {
                 None
             };
-            let stdout = if args.tree {
+            let stdout = if args.tree && !args.json {
                 let entries = tree_data.as_deref().unwrap_or(&[]);
-                if args.json {
-                    format_tree_json(start_pid, None, None, entries)
-                } else {
-                    format_tree_text(entries, None)
-                }
+                format_tree_text(entries, None)
+            } else if args.json && wants_rich {
+                let entries = tree_data.as_deref().unwrap_or(&[]);
+                format_tree_json(start_pid, None, None, entries)
             } else {
+                // Minimal --json on no-match keeps the historical empty-stdout
+                // contract (exit 1 signals failure). Plain text is also empty.
                 String::new()
             };
             ParentPidTreeOutcome {
@@ -2528,6 +2550,7 @@ fn format_tree_text(entries: &[TreeEntry], pane_id: Option<&str>) -> String {
         .min(16);
     for (i, entry) in entries.iter().enumerate() {
         let is_leaf = i == n - 1;
+        let is_start = i == 0;
         let branch = if is_leaf { "└─" } else { "├─" };
         let cont = if is_leaf { "  " } else { "│ " };
         let comm = entry.comm.as_deref().unwrap_or("?");
@@ -2536,10 +2559,18 @@ fn format_tree_text(entries: &[TreeEntry], pane_id: Option<&str>) -> String {
             // No cmdline — convention for kernel threads is [comm].
             _ => format!("[{}]", comm),
         };
-        let pane_suffix = if is_leaf && pane_id.is_some() {
-            "  (pane shell)"
-        } else {
-            ""
+        // Annotate the start/leaf positions so users can see at a glance
+        // where the walk started and where it stopped. Single-entry chains
+        // collapse into a combined annotation. On no-match (`pane_id` is
+        // None) the leaf is labeled `(no pane found)` instead of
+        // `(pane shell)`.
+        let annotation = match (is_start, is_leaf, pane_id.is_some()) {
+            (true, true, true) => "  (start, pane shell)",
+            (true, true, false) => "  (start, no pane found)",
+            (true, false, _) => "  (start)",
+            (false, true, true) => "  (pane shell)",
+            (false, true, false) => "  (no pane found)",
+            _ => "",
         };
         out.push_str(&format!(
             "{} [pid {:<7}] {:<width$}  {}{}\n",
@@ -2547,7 +2578,7 @@ fn format_tree_text(entries: &[TreeEntry], pane_id: Option<&str>) -> String {
             entry.pid,
             comm,
             cmd_display,
-            pane_suffix,
+            annotation,
             width = comm_col,
         ));
         match entry.exe.as_ref() {
@@ -2569,20 +2600,32 @@ fn format_tree_text(entries: &[TreeEntry], pane_id: Option<&str>) -> String {
 
 /// Render the tree as JSON. `pane_id` / `pane_pid` are None when the walk
 /// didn't match a pane (useful for debugging why resolution failed).
+///
+/// Each chain entry carries a `role` string derived from its position and
+/// whether its pid matches `pane_pid`:
+///   - `"start"` — first entry of a multi-entry chain
+///   - `"ancestor"` — interior entries
+///   - `"pane_shell"` — leaf whose pid matches `pane_pid`
+///   - `"start_and_pane_shell"` — single-entry chain where start IS the pane
+///   - `"walked_past_root"` — leaf of a no-match chain (`pane_pid` is None)
 fn format_tree_json(
     start_pid: u32,
     pane_id: Option<&str>,
     pane_pid: Option<u32>,
     entries: &[TreeEntry],
 ) -> String {
+    let n = entries.len();
     let chain: Vec<serde_json::Value> = entries
         .iter()
-        .map(|e| {
+        .enumerate()
+        .map(|(i, e)| {
+            let role = chain_entry_role(i, n, e.pid, pane_pid);
             serde_json::json!({
                 "pid": e.pid,
                 "comm": e.comm,
                 "cmdline": e.cmdline,
                 "exe": e.exe.as_ref().map(|p| p.display().to_string()),
+                "role": role,
             })
         })
         .collect();
@@ -2593,6 +2636,27 @@ fn format_tree_json(
         "chain": chain,
     });
     payload.to_string()
+}
+
+/// Pure helper: derive the `role` string for chain entry at `index` given
+/// the chain length, the entry's pid, and the resolved `pane_pid` (if any).
+/// Extracted so tests can assert the role-assignment policy directly.
+fn chain_entry_role(index: usize, len: usize, pid: u32, pane_pid: Option<u32>) -> &'static str {
+    let is_first = index == 0;
+    let is_last = index + 1 == len;
+    let matches_pane = pane_pid.is_some_and(|pp| pp == pid);
+    match (is_first, is_last, matches_pane, pane_pid.is_some()) {
+        // Single-entry chain where start IS the pane shell.
+        (true, true, true, _) => "start_and_pane_shell",
+        // Any leaf without a pane match — walker stopped here empty-handed.
+        (_, true, false, false) => "walked_past_root",
+        // Multi-entry leaf that matches pane_pid is the pane shell.
+        (false, true, true, _) => "pane_shell",
+        // First entry of a multi-entry chain.
+        (true, false, _, _) => "start",
+        // Everything else — interior entries.
+        _ => "ancestor",
+    }
 }
 
 /// Truncate `s` to at most `max` display chars, appending `…` if cut. Uses
@@ -2741,7 +2805,11 @@ fn completion_install_path(shell: CompletionShell, env: &EnvSnapshot) -> Option<
                 let home = env.home.as_deref()?;
                 PathBuf::from(home).join(".config")
             };
-            Some(base.join("fish").join("completions").join("rmux_helper.fish"))
+            Some(
+                base.join("fish")
+                    .join("completions")
+                    .join("rmux_helper.fish"),
+            )
         }
         CompletionShell::Powershell | CompletionShell::Elvish => None,
     }
@@ -2776,7 +2844,12 @@ fn generate_completion_script(shell: CompletionShell) -> Result<String> {
     let output = Command::new(&exe)
         .env("COMPLETE", shell.as_str())
         .output()
-        .with_context(|| format!("failed to spawn {} for completion generation", exe.display()))?;
+        .with_context(|| {
+            format!(
+                "failed to spawn {} for completion generation",
+                exe.display()
+            )
+        })?;
     if !output.status.success() {
         anyhow::bail!(
             "rmux_helper exited {} while generating {} completions: {}",
@@ -2822,17 +2895,19 @@ fn install_completions_cmd(
     })?;
 
     if dry_run {
-        println!("would install {} completions to {}", resolved.as_str(), target.display());
+        println!(
+            "would install {} completions to {}",
+            resolved.as_str(),
+            target.display()
+        );
         return Ok(());
     }
 
     if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!("failed to create completion dir {}", parent.display())
-        })?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create completion dir {}", parent.display()))?;
     }
-    fs::write(&target, &script)
-        .with_context(|| format!("failed to write {}", target.display()))?;
+    fs::write(&target, &script).with_context(|| format!("failed to write {}", target.display()))?;
     println!(
         "installed {} completions to {}",
         resolved.as_str(),
@@ -4300,13 +4375,24 @@ mod tests {
     #[test]
     fn test_tree_formatter_shows_pane_id_at_leaf() {
         // When pane_id is Some, the final entry gets a "(pane shell)"
-        // annotation AND a "tmux pane: %35" line.
-        let entries = vec![TreeEntry {
-            pid: 1,
-            comm: Some("zsh".to_string()),
-            cmdline: Some("/bin/zsh".to_string()),
-            exe: Some(PathBuf::from("/bin/zsh")),
-        }];
+        // annotation AND a "tmux pane: %35" line. Use a 2-entry chain so the
+        // leaf's annotation is the plain "(pane shell)" — a single-entry
+        // chain collapses into "(start, pane shell)" which is covered
+        // separately in test_format_tree_text_single_entry_chain.
+        let entries = vec![
+            TreeEntry {
+                pid: 2,
+                comm: Some("bash".to_string()),
+                cmdline: Some("/bin/bash".to_string()),
+                exe: Some(PathBuf::from("/bin/bash")),
+            },
+            TreeEntry {
+                pid: 1,
+                comm: Some("zsh".to_string()),
+                cmdline: Some("/bin/zsh".to_string()),
+                exe: Some(PathBuf::from("/bin/zsh")),
+            },
+        ];
         let out = format_tree_text(&entries, Some("%35"));
         assert!(
             out.contains("(pane shell)"),
@@ -4353,11 +4439,26 @@ mod tests {
 
     #[test]
     fn test_detect_shell_from_env_basenames() {
-        assert_eq!(detect_shell_from_env(Some("/bin/zsh")), Some(CompletionShell::Zsh));
-        assert_eq!(detect_shell_from_env(Some("/usr/bin/bash")), Some(CompletionShell::Bash));
-        assert_eq!(detect_shell_from_env(Some("fish")), Some(CompletionShell::Fish));
-        assert_eq!(detect_shell_from_env(Some("/opt/homebrew/bin/pwsh")), Some(CompletionShell::Powershell));
-        assert_eq!(detect_shell_from_env(Some("elvish")), Some(CompletionShell::Elvish));
+        assert_eq!(
+            detect_shell_from_env(Some("/bin/zsh")),
+            Some(CompletionShell::Zsh)
+        );
+        assert_eq!(
+            detect_shell_from_env(Some("/usr/bin/bash")),
+            Some(CompletionShell::Bash)
+        );
+        assert_eq!(
+            detect_shell_from_env(Some("fish")),
+            Some(CompletionShell::Fish)
+        );
+        assert_eq!(
+            detect_shell_from_env(Some("/opt/homebrew/bin/pwsh")),
+            Some(CompletionShell::Powershell)
+        );
+        assert_eq!(
+            detect_shell_from_env(Some("elvish")),
+            Some(CompletionShell::Elvish)
+        );
     }
 
     #[test]
@@ -4375,7 +4476,10 @@ mod tests {
             ..Default::default()
         };
         let p = completion_install_path(CompletionShell::Zsh, &env).unwrap();
-        assert_eq!(p, PathBuf::from("/home/user/dotfiles/zsh/.zfunc/_rmux_helper"));
+        assert_eq!(
+            p,
+            PathBuf::from("/home/user/dotfiles/zsh/.zfunc/_rmux_helper")
+        );
     }
 
     #[test]
@@ -4448,7 +4552,10 @@ mod tests {
             home: Some("/home/user".into()),
             ..Default::default()
         };
-        assert_eq!(completion_install_path(CompletionShell::Powershell, &env), None);
+        assert_eq!(
+            completion_install_path(CompletionShell::Powershell, &env),
+            None
+        );
         assert_eq!(completion_install_path(CompletionShell::Elvish, &env), None);
     }
 
@@ -4464,10 +4571,8 @@ mod tests {
     #[test]
     fn test_enumerate_pid_candidates_sorted_desc_and_truncated() {
         // Build a tempdir `/proc`-like layout with numeric-named subdirs.
-        let tmp = std::env::temp_dir().join(format!(
-            "rmux_helper_pid_enum_test_{}",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("rmux_helper_pid_enum_test_{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).unwrap();
         for pid in [1u32, 5, 42, 100, 500, 9999] {
@@ -4533,5 +4638,354 @@ mod tests {
             "nosuchshell",
         ]);
         assert!(result.is_err(), "unknown shell should be rejected by clap");
+    }
+
+    // ---- --verbose + --json rich chain output ---------------------------
+    //
+    // Exercises the rule that either --tree OR --verbose triggers the full
+    // chain[] array in JSON, while --json alone keeps the minimal payload.
+    // Plain text mode with --verbose stays on the single-line pane-id output.
+
+    #[test]
+    fn test_run_parent_pid_tree_verbose_and_json_includes_rich_chain() {
+        // --verbose --json (no --tree): JSON stdout gets the full chain[]
+        // array AND stderr keeps its walk lines for human inspection.
+        let tmux = MockTmuxProvider::with_panes(&[("%35", 2500)]);
+        let proc = MockProcReader::from_chain(&[(999, 4000), (4000, 2500)])
+            .with_comm(999, "bash")
+            .with_cmdline(
+                999,
+                "/bin/bash -c rmux_helper parent-pid-tree --verbose --json",
+            )
+            .with_exe(999, "/usr/bin/bash")
+            .with_comm(4000, "claude")
+            .with_cmdline(4000, "claude /startup-larry")
+            .with_exe(4000, "/home/developer/.local/bin/claude")
+            .with_comm(2500, "zsh")
+            .with_cmdline(2500, "/bin/zsh")
+            .with_exe(2500, "/bin/zsh");
+        let mut a = args(true, Some(999), true);
+        a.tree = false;
+        let outcome = run_parent_pid_tree(a, 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        // stdout is valid JSON with chain[].
+        let payload: serde_json::Value =
+            serde_json::from_str(&outcome.stdout).expect("stdout must be valid JSON");
+        let chain = payload["chain"]
+            .as_array()
+            .expect("chain[] must be present on --verbose --json");
+        assert_eq!(chain.len(), 3);
+        assert_eq!(chain[0]["pid"], 999);
+        assert_eq!(chain[0]["comm"], "bash");
+        assert_eq!(chain[0]["role"], "start");
+        assert_eq!(chain[2]["pid"], 2500);
+        assert_eq!(chain[2]["role"], "pane_shell");
+        assert_eq!(payload["pane_id"], "%35");
+        assert_eq!(payload["pane_pid"], 2500);
+        assert_eq!(payload["start_pid"], 999);
+        // --verbose stderr walk lines still present — verbose's signature
+        // human-inspection stream is preserved even with rich JSON stdout.
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("starting walk at pid 999")),
+            "stderr missing verbose start line: {:?}",
+            outcome.stderr_lines
+        );
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("999 -> 4000 -> 2500")),
+            "stderr missing walk chain: {:?}",
+            outcome.stderr_lines
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_json_alone_stays_minimal() {
+        // --json alone (no --verbose, no --tree): minimal payload, NO
+        // chain[] field — preserves the scriptable contract.
+        let tmux = MockTmuxProvider::with_panes(&[("%35", 2500)]);
+        let proc = MockProcReader::from_chain(&[(999, 2500)])
+            .with_comm(999, "bash")
+            .with_cmdline(999, "/bin/bash")
+            .with_exe(999, "/usr/bin/bash")
+            .with_comm(2500, "zsh");
+        let outcome = run_parent_pid_tree(args(true, Some(999), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
+        assert!(
+            payload.get("chain").is_none(),
+            "minimal --json must NOT include chain[]: {}",
+            outcome.stdout
+        );
+        // Historical keys still present.
+        assert_eq!(payload["pane_id"], "%35");
+        assert_eq!(payload["pane_pid"], 2500);
+        assert_eq!(payload["walked_from_pid"], 999);
+        assert_eq!(payload["ancestors_walked"], serde_json::json!([999, 2500]));
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_verbose_text_mode_unchanged() {
+        // --verbose in plain text mode (no --json, no --tree) must still
+        // emit just the pane id on stdout. The stderr walk lines are the
+        // only visible effect of --verbose in text mode.
+        let tmux = MockTmuxProvider::with_panes(&[("%7", 400)]);
+        let proc = MockProcReader::from_chain(&[(500, 400)]);
+        let outcome = run_parent_pid_tree(args(false, Some(500), true), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.stdout, "%7");
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("starting walk at pid 500")),
+            "stderr missing verbose start line: {:?}",
+            outcome.stderr_lines
+        );
+    }
+
+    #[test]
+    fn test_format_tree_text_marks_root_with_start() {
+        // 3-entry chain — first entry's line must include "(start)".
+        let entries = vec![
+            TreeEntry {
+                pid: 10,
+                comm: Some("bash".to_string()),
+                cmdline: Some("bash".to_string()),
+                exe: Some(PathBuf::from("/bin/bash")),
+            },
+            TreeEntry {
+                pid: 20,
+                comm: Some("claude".to_string()),
+                cmdline: Some("claude".to_string()),
+                exe: Some(PathBuf::from("/bin/claude")),
+            },
+            TreeEntry {
+                pid: 30,
+                comm: Some("zsh".to_string()),
+                cmdline: Some("/bin/zsh".to_string()),
+                exe: Some(PathBuf::from("/bin/zsh")),
+            },
+        ];
+        let out = format_tree_text(&entries, Some("%35"));
+        // Find the line for pid 10 and assert it has (start).
+        let start_line = out
+            .lines()
+            .find(|l| l.contains("[pid 10 "))
+            .unwrap_or_else(|| panic!("no line for pid 10 in:\n{}", out));
+        assert!(
+            start_line.contains("(start)"),
+            "start line missing (start): {}",
+            start_line,
+        );
+        // Intermediate entry (pid 20) must NOT be annotated.
+        let mid_line = out
+            .lines()
+            .find(|l| l.contains("[pid 20 "))
+            .unwrap_or_else(|| panic!("no line for pid 20 in:\n{}", out));
+        assert!(
+            !mid_line.contains("(start)") && !mid_line.contains("(pane shell)"),
+            "intermediate line should be unannotated: {}",
+            mid_line,
+        );
+    }
+
+    #[test]
+    fn test_format_tree_text_single_entry_chain() {
+        // Single-entry chain where start IS the pane shell: the one
+        // annotation combines both roles into "(start, pane shell)".
+        let entries = vec![TreeEntry {
+            pid: 7,
+            comm: Some("zsh".to_string()),
+            cmdline: Some("/bin/zsh".to_string()),
+            exe: Some(PathBuf::from("/bin/zsh")),
+        }];
+        let out = format_tree_text(&entries, Some("%9"));
+        assert!(
+            out.contains("(start, pane shell)"),
+            "single-entry chain missing combined annotation: {}",
+            out,
+        );
+    }
+
+    #[test]
+    fn test_format_tree_text_no_match_marks_leaf() {
+        // 2-entry chain with pane_id=None: last line has "(no pane found)",
+        // first line has "(start)".
+        let entries = vec![
+            TreeEntry {
+                pid: 1,
+                comm: Some("bash".to_string()),
+                cmdline: Some("bash".to_string()),
+                exe: Some(PathBuf::from("/bin/bash")),
+            },
+            TreeEntry {
+                pid: 2,
+                comm: Some("init".to_string()),
+                cmdline: Some("init".to_string()),
+                exe: Some(PathBuf::from("/sbin/init")),
+            },
+        ];
+        let out = format_tree_text(&entries, None);
+        assert!(out.contains("(start)"), "missing (start): {}", out);
+        assert!(
+            out.contains("(no pane found)"),
+            "missing (no pane found): {}",
+            out,
+        );
+        // Single-entry variant collapses into "(start, no pane found)".
+        let solo = vec![TreeEntry {
+            pid: 1,
+            comm: Some("bash".to_string()),
+            cmdline: Some("bash".to_string()),
+            exe: Some(PathBuf::from("/bin/bash")),
+        }];
+        let solo_out = format_tree_text(&solo, None);
+        assert!(
+            solo_out.contains("(start, no pane found)"),
+            "single-entry no-match missing combined annotation: {}",
+            solo_out,
+        );
+    }
+
+    #[test]
+    fn test_format_tree_json_roles() {
+        // 4-entry chain where last pid matches pane_pid: roles are
+        // start / ancestor / ancestor / pane_shell.
+        let entries = vec![
+            TreeEntry {
+                pid: 10,
+                comm: Some("bash".to_string()),
+                cmdline: Some("bash".to_string()),
+                exe: Some(PathBuf::from("/bin/bash")),
+            },
+            TreeEntry {
+                pid: 20,
+                comm: Some("claude".to_string()),
+                cmdline: Some("claude".to_string()),
+                exe: Some(PathBuf::from("/bin/claude")),
+            },
+            TreeEntry {
+                pid: 30,
+                comm: Some("larry".to_string()),
+                cmdline: Some("larry".to_string()),
+                exe: Some(PathBuf::from("/bin/larry")),
+            },
+            TreeEntry {
+                pid: 40,
+                comm: Some("zsh".to_string()),
+                cmdline: Some("/bin/zsh".to_string()),
+                exe: Some(PathBuf::from("/bin/zsh")),
+            },
+        ];
+        let json = format_tree_json(10, Some("%35"), Some(40), &entries);
+        let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let chain = payload["chain"].as_array().unwrap();
+        assert_eq!(chain[0]["role"], "start");
+        assert_eq!(chain[1]["role"], "ancestor");
+        assert_eq!(chain[2]["role"], "ancestor");
+        assert_eq!(chain[3]["role"], "pane_shell");
+    }
+
+    #[test]
+    fn test_format_tree_json_no_match_case() {
+        // pane_id/pane_pid both None: last entry gets "walked_past_root".
+        let entries = vec![
+            TreeEntry {
+                pid: 10,
+                comm: Some("bash".to_string()),
+                cmdline: Some("bash".to_string()),
+                exe: Some(PathBuf::from("/bin/bash")),
+            },
+            TreeEntry {
+                pid: 1,
+                comm: Some("init".to_string()),
+                cmdline: Some("init".to_string()),
+                exe: Some(PathBuf::from("/sbin/init")),
+            },
+        ];
+        let json = format_tree_json(10, None, None, &entries);
+        let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(payload["pane_id"].is_null());
+        assert!(payload["pane_pid"].is_null());
+        let chain = payload["chain"].as_array().unwrap();
+        assert_eq!(chain[0]["role"], "start");
+        assert_eq!(chain[1]["role"], "walked_past_root");
+    }
+
+    #[test]
+    fn test_format_tree_json_single_entry_start_is_pane() {
+        // 1-entry chain where start pid IS the pane_pid.
+        let entries = vec![TreeEntry {
+            pid: 42,
+            comm: Some("zsh".to_string()),
+            cmdline: Some("/bin/zsh".to_string()),
+            exe: Some(PathBuf::from("/bin/zsh")),
+        }];
+        let json = format_tree_json(42, Some("%9"), Some(42), &entries);
+        let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let chain = payload["chain"].as_array().unwrap();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0]["role"], "start_and_pane_shell");
+    }
+
+    #[test]
+    fn test_format_tree_json_single_entry_no_match() {
+        // 1-entry no-match: role collapses into "walked_past_root".
+        let entries = vec![TreeEntry {
+            pid: 42,
+            comm: Some("init".to_string()),
+            cmdline: Some("init".to_string()),
+            exe: Some(PathBuf::from("/sbin/init")),
+        }];
+        let json = format_tree_json(42, None, None, &entries);
+        let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let chain = payload["chain"].as_array().unwrap();
+        assert_eq!(chain[0]["role"], "walked_past_root");
+    }
+
+    #[test]
+    fn test_chain_entry_role_pure_helper() {
+        // Direct coverage of the pure role-assignment policy.
+        // Multi-entry, leaf matches pane_pid.
+        assert_eq!(chain_entry_role(0, 3, 10, Some(30)), "start");
+        assert_eq!(chain_entry_role(1, 3, 20, Some(30)), "ancestor");
+        assert_eq!(chain_entry_role(2, 3, 30, Some(30)), "pane_shell");
+        // Single-entry, start is pane.
+        assert_eq!(chain_entry_role(0, 1, 5, Some(5)), "start_and_pane_shell");
+        // Single-entry, no match.
+        assert_eq!(chain_entry_role(0, 1, 5, None), "walked_past_root");
+        // Multi-entry, no match: first is start, middle is ancestor, last is
+        // walked_past_root.
+        assert_eq!(chain_entry_role(0, 3, 10, None), "start");
+        assert_eq!(chain_entry_role(1, 3, 20, None), "ancestor");
+        assert_eq!(chain_entry_role(2, 3, 30, None), "walked_past_root");
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_tree_and_json_adds_roles() {
+        // --tree --json end-to-end: chain[0].role == "start",
+        // chain[-1].role == "pane_shell".
+        let tmux = MockTmuxProvider::with_panes(&[("%42", 420)]);
+        let proc = MockProcReader::from_chain(&[(100, 200), (200, 420)])
+            .with_comm(100, "bash")
+            .with_cmdline(100, "/bin/bash")
+            .with_exe(100, "/bin/bash")
+            .with_comm(200, "claude")
+            .with_cmdline(200, "claude /startup")
+            .with_exe(200, "/bin/claude")
+            .with_comm(420, "zsh")
+            .with_cmdline(420, "/bin/zsh")
+            .with_exe(420, "/bin/zsh");
+        let outcome = run_parent_pid_tree(tree_args(true, Some(100), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
+        let chain = payload["chain"].as_array().unwrap();
+        assert_eq!(chain[0]["role"], "start");
+        assert_eq!(chain[2]["role"], "pane_shell");
     }
 }

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -359,6 +359,16 @@ struct ProcessInfo {
     children: Vec<ProcessInfo>,
 }
 
+// TODO: migrate callers of `run_tmux_command` (and the scattered
+// `Command::new("tmux")` fire-and-forget sites in `side_edit`, `side_run`,
+// `rename_all`, `rotate`, `third`, `info`, `resolve_side_pane`,
+// `ensure_two_panes`, `create_side_pane_shell`, `open_file_in_pane`, etc.)
+// to the `TmuxProvider` trait introduced for `parent-pid-tree`. None of
+// those functions have characterization tests today, so migrating them
+// blind would lose the "tests pass" safety net and could silently break
+// live tmux behavior. The pure helpers (`pick_side_pane`, `format_pane_status`,
+// `parse_file_line`, `resolve_pane_by_parent_chain`) are already DI-friendly
+// and tested; the shelling helpers need tests first, then trait migration.
 pub fn run_tmux_command(args: &[&str]) -> Result<String> {
     let output = Command::new("tmux")
         .args(args)

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -3071,4 +3071,300 @@ mod tests {
             "own ppid must be > 0 (actual pid tree should have a real parent)"
         );
     }
+
+    // ---- CLI-level tests for parent-pid-tree via DI ---------------------------
+    //
+    // These drive `run_parent_pid_tree` — the humble-object testable core — with
+    // in-memory mocks for `TmuxProvider` and `ProcReader`, so every exit code
+    // (0/1/2/3) and flag combination (--json/--verbose/--pid) is reachable
+    // without touching tmux or /proc. The previous test-coverage pass had to
+    // reject these because the command function wrote to stdout via println!
+    // and called tmux directly; Phase 1 (trait extraction) put the seam in
+    // place.
+
+    /// In-memory `TmuxProvider` mock. Constructed with a pre-built result —
+    /// either a list of (pane_id, pane_pid) pairs, or an explicit `TmuxError`
+    /// for testing the exit-2 paths.
+    enum MockTmuxResult {
+        Ok(Vec<(String, u32)>),
+        NotRunning,
+        ListFailed,
+    }
+
+    struct MockTmuxProvider {
+        result: MockTmuxResult,
+    }
+
+    impl MockTmuxProvider {
+        fn with_panes(pairs: &[(&str, u32)]) -> Self {
+            let pairs = pairs
+                .iter()
+                .map(|(id, pid)| ((*id).to_string(), *pid))
+                .collect();
+            Self {
+                result: MockTmuxResult::Ok(pairs),
+            }
+        }
+
+        fn not_running() -> Self {
+            Self {
+                result: MockTmuxResult::NotRunning,
+            }
+        }
+
+        fn list_failed() -> Self {
+            Self {
+                result: MockTmuxResult::ListFailed,
+            }
+        }
+    }
+
+    impl TmuxProvider for MockTmuxProvider {
+        fn list_pane_pids(&self) -> Result<Vec<(String, u32)>, TmuxError> {
+            match &self.result {
+                MockTmuxResult::Ok(pairs) => Ok(pairs.clone()),
+                MockTmuxResult::NotRunning => Err(TmuxError::NotRunning),
+                MockTmuxResult::ListFailed => Err(TmuxError::ListFailed(
+                    std::io::Error::new(std::io::ErrorKind::NotFound, "no such binary"),
+                )),
+            }
+        }
+
+        fn active_pane(&self) -> Result<Option<String>, TmuxError> {
+            Ok(None)
+        }
+    }
+
+    /// In-memory `ProcReader` mock. Takes a list of `(child, parent)` pairs
+    /// plus an optional set of pids that "fail" — these return `None` from
+    /// `read_ppid` even if they have an entry in the chain. A pid with no
+    /// chain entry and no failure marker falls off (returns None), matching
+    /// real-world "process vanished" semantics.
+    struct MockProcReader {
+        chain: Vec<(u32, u32)>,
+        fail_on: HashSet<u32>,
+    }
+
+    impl MockProcReader {
+        fn from_chain(chain: &[(u32, u32)]) -> Self {
+            Self {
+                chain: chain.to_vec(),
+                fail_on: HashSet::new(),
+            }
+        }
+
+        fn failing_on(mut self, pid: u32) -> Self {
+            self.fail_on.insert(pid);
+            self
+        }
+    }
+
+    impl ProcReader for MockProcReader {
+        fn read_ppid(&self, pid: u32) -> Option<u32> {
+            if self.fail_on.contains(&pid) {
+                return None;
+            }
+            self.chain
+                .iter()
+                .find_map(|(c, p)| if *c == pid { Some(*p) } else { None })
+        }
+    }
+
+    fn args(json: bool, pid: Option<u32>, verbose: bool) -> ParentPidTreeArgs {
+        ParentPidTreeArgs { json, pid, verbose }
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_default_json_output() {
+        // Larry scenario shaped for the CLI: self_pid=999, its ppid is 2594534
+        // (the pane_pid of %35). --json should emit the documented payload.
+        let tmux = MockTmuxProvider::with_panes(&[("%35", 2594534), ("%65", 331460)]);
+        let proc = MockProcReader::from_chain(&[(999, 2594534)]);
+        let outcome = run_parent_pid_tree(args(true, None, false), 999, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.stderr_lines, Vec::<String>::new());
+        // Parse the emitted JSON to assert on each field.
+        let payload: serde_json::Value =
+            serde_json::from_str(&outcome.stdout).expect("stdout must be valid JSON");
+        assert_eq!(payload["pane_id"], "%35");
+        assert_eq!(payload["pane_pid"], 2594534);
+        assert_eq!(payload["walked_from_pid"], 2594534);
+        assert_eq!(payload["ancestors_walked"], serde_json::json!([2594534]));
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_explicit_pid_override_walks_from_that_pid() {
+        // --pid 999 must start the walk from 999, not from self_pid/ppid-of-self.
+        // The self_pid we pass is deliberately unrelated — it must not be
+        // consulted because args.pid is Some.
+        let tmux = MockTmuxProvider::with_panes(&[("%42", 12345)]);
+        // Chain: 999 -> 12345, which matches %42.
+        let proc = MockProcReader::from_chain(&[(999, 12345)]);
+        let outcome =
+            run_parent_pid_tree(args(true, Some(999), false), 9_999_999, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
+        assert_eq!(payload["pane_id"], "%42");
+        assert_eq!(payload["walked_from_pid"], 999);
+        assert_eq!(payload["ancestors_walked"], serde_json::json!([999, 12345]));
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_explicit_pid_does_not_read_self_ppid() {
+        // If self_pid's ppid reader would fail, we'd get exit 3 via the
+        // default path. Passing --pid must skip that read entirely. We assert
+        // by setting self_pid to something that would fail AND passing an
+        // explicit pid — result must be exit 0, not 3.
+        let tmux = MockTmuxProvider::with_panes(&[("%7", 400)]);
+        // Reader has a chain for 100 -> 400 but fails on pid 42. If the code
+        // read_ppid(42) we'd take the "None" branch → exit 3.
+        let proc = MockProcReader::from_chain(&[(100, 400)]).failing_on(42);
+        let outcome = run_parent_pid_tree(args(false, Some(100), false), 42, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.stdout, "%7");
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_plain_output_is_just_pane_id() {
+        // Default (no --json) stdout must be just the pane id — callers rely on
+        // `pane=$(rmux_helper parent-pid-tree)` returning something assignable.
+        let tmux = MockTmuxProvider::with_panes(&[("%7", 400)]);
+        let proc = MockProcReader::from_chain(&[(500, 400)]);
+        let outcome = run_parent_pid_tree(args(false, Some(500), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.stdout, "%7");
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_verbose_emits_walk_chain_to_stderr() {
+        // --verbose must log both the starting pid and the walk chain with the
+        // documented arrow format.
+        let tmux = MockTmuxProvider::with_panes(&[("%35", 2594534)]);
+        let proc = MockProcReader::from_chain(&[(999, 398200), (398200, 2594534)]);
+        let outcome = run_parent_pid_tree(args(false, Some(999), true), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.stdout, "%35");
+        // First verbose line is the start announcement, second is the chain.
+        assert!(
+            outcome.stderr_lines.iter().any(|l| l.contains("starting walk at pid 999")),
+            "stderr missing start line: {:?}",
+            outcome.stderr_lines
+        );
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("999 -> 398200 -> 2594534") && l.contains("pane %35")),
+            "stderr missing walk chain: {:?}",
+            outcome.stderr_lines
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_exit_1_no_match() {
+        // Walker walks from 999 -> 1 (init) and never hits a pane_pid. Exit 1,
+        // empty stdout, human-readable stderr.
+        let tmux = MockTmuxProvider::with_panes(&[("%99", 9999)]);
+        let proc = MockProcReader::from_chain(&[(999, 500), (500, 1)]);
+        let outcome = run_parent_pid_tree(args(false, Some(999), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 1);
+        assert_eq!(outcome.stdout, "");
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("no tmux pane found for pid 999")),
+            "stderr missing no-match message: {:?}",
+            outcome.stderr_lines
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_exit_2_not_running() {
+        // TmuxProvider returns NotRunning → exit 2 with the canonical stderr
+        // message. Must not print anything to stdout.
+        let tmux = MockTmuxProvider::not_running();
+        let proc = MockProcReader::from_chain(&[]);
+        let outcome = run_parent_pid_tree(args(false, Some(1), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 2);
+        assert_eq!(outcome.stdout, "");
+        assert_eq!(
+            outcome.stderr_lines,
+            vec!["tmux not running or no panes".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_exit_2_list_failed_has_different_stderr() {
+        // ListFailed is a distinct flavor of exit 2 — the stderr carries the
+        // underlying io::Error rather than the plain "not running" message.
+        let tmux = MockTmuxProvider::list_failed();
+        let proc = MockProcReader::from_chain(&[]);
+        let outcome = run_parent_pid_tree(args(false, Some(1), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 2);
+        assert_eq!(outcome.stdout, "");
+        let joined = outcome.stderr_lines.join("\n");
+        assert!(
+            joined.contains("tmux list-panes failed"),
+            "stderr missing list-failed detail: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_exit_3_cannot_read_self_ppid() {
+        // No --pid passed and ProcReader.read_ppid(self_pid) returns None → exit 3.
+        let tmux = MockTmuxProvider::with_panes(&[("%1", 100)]);
+        let proc = MockProcReader::from_chain(&[]); // any read returns None
+        let outcome = run_parent_pid_tree(args(false, None, false), 42, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 3);
+        assert_eq!(outcome.stdout, "");
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("could not read /proc/42/stat")),
+            "stderr missing exit-3 message: {:?}",
+            outcome.stderr_lines
+        );
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_json_and_pid_flags_combine() {
+        // --json + --pid should emit JSON from the explicit pid's walk.
+        let tmux = MockTmuxProvider::with_panes(&[("%8", 800)]);
+        let proc = MockProcReader::from_chain(&[(700, 800)]);
+        let outcome = run_parent_pid_tree(args(true, Some(700), false), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
+        assert_eq!(payload["pane_id"], "%8");
+        assert_eq!(payload["walked_from_pid"], 700);
+    }
+
+    #[test]
+    fn test_run_parent_pid_tree_json_and_verbose_both_emit() {
+        // --json + --verbose: stdout gets the JSON payload, stderr still gets
+        // the walk chain. The two streams must not pollute each other.
+        let tmux = MockTmuxProvider::with_panes(&[("%9", 900)]);
+        let proc = MockProcReader::from_chain(&[(800, 900)]);
+        let outcome = run_parent_pid_tree(args(true, Some(800), true), 1, &tmux, &proc);
+        assert_eq!(outcome.exit_code, 0);
+        // stdout is JSON.
+        let payload: serde_json::Value = serde_json::from_str(&outcome.stdout).unwrap();
+        assert_eq!(payload["pane_id"], "%9");
+        // stderr has the walk chain — JSON must not leak into stderr lines.
+        assert!(
+            outcome
+                .stderr_lines
+                .iter()
+                .any(|l| l.contains("800 -> 900") && l.contains("pane %9"))
+        );
+        for line in &outcome.stderr_lines {
+            assert!(
+                !line.contains("\"pane_id\""),
+                "stderr leaked JSON payload: {}",
+                line
+            );
+        }
+    }
 }

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -2,11 +2,13 @@ mod link_picker;
 mod picker;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum, ValueHint};
+use clap_complete::engine::{ArgValueCompleter, CompletionCandidate};
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use sysinfo::{Pid, ProcessRefreshKind, System};
 
@@ -54,6 +56,7 @@ enum Commands {
     /// Supports file:line syntax (e.g. foo.py:42). No args = print status only.
     SideEdit {
         /// File path to open (supports file:line syntax)
+        #[arg(value_hint = ValueHint::FilePath)]
         file: Option<String>,
     },
     /// Run a shell command in the side pane (reuses same pane as side-edit).
@@ -85,7 +88,7 @@ enum Commands {
         json: bool,
         /// Start the walk from this pid instead of the caller's pid.
         /// When omitted, starts from the parent of rmux_helper (i.e. the caller).
-        #[arg(long)]
+        #[arg(long, add = ArgValueCompleter::new(pid_completer))]
         pid: Option<u32>,
         /// Log the walk (ancestor chain, pane match) to stderr for debugging
         #[arg(long)]
@@ -94,6 +97,23 @@ enum Commands {
         /// metadata per PID. Combine with --json for structured output.
         #[arg(long)]
         tree: bool,
+    },
+    /// Install shell completions for rmux_helper.
+    ///
+    /// Writes a shell-specific completion script to the conventional location for
+    /// the target shell and prints a one-line confirmation. Completions are
+    /// dynamic — e.g. `parent-pid-tree --pid <TAB>` resolves live pids from
+    /// `/proc` at tab-time.
+    InstallCompletions {
+        /// Target shell. Defaults to auto-detection from `$SHELL`.
+        #[arg(long, value_enum)]
+        shell: Option<CompletionShell>,
+        /// Print the completion script to stdout instead of writing a file.
+        #[arg(long, conflicts_with = "dry_run")]
+        print_only: bool,
+        /// Report the target path and skip the write. Useful for scripting.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -2619,7 +2639,272 @@ fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool, tree: bool) 
     outcome.exit_code
 }
 
+// ---------------------------------------------------------------------------
+// Shell completions
+// ---------------------------------------------------------------------------
+
+/// Shells for which `install-completions` knows a conventional install path
+/// and writes a completion script. `Powershell` and `Elvish` are accepted for
+/// `--print-only` use but do not have a default install path (noted in docs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CompletionShell {
+    Zsh,
+    Bash,
+    Fish,
+    Powershell,
+    Elvish,
+}
+
+impl CompletionShell {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Zsh => "zsh",
+            Self::Bash => "bash",
+            Self::Fish => "fish",
+            Self::Powershell => "powershell",
+            Self::Elvish => "elvish",
+        }
+    }
+}
+
+/// Pure function: map a `$SHELL`-style string (e.g. `/bin/zsh`, `fish`) to
+/// a `CompletionShell`. Returns `None` on unknown/empty input so the caller
+/// can emit a helpful `--shell` suggestion.
+fn detect_shell_from_env(shell: Option<&str>) -> Option<CompletionShell> {
+    let s = shell?;
+    let basename = s.rsplit('/').next().unwrap_or(s).trim();
+    if basename.is_empty() {
+        return None;
+    }
+    match basename {
+        "zsh" => Some(CompletionShell::Zsh),
+        "bash" => Some(CompletionShell::Bash),
+        "fish" => Some(CompletionShell::Fish),
+        "pwsh" | "powershell" => Some(CompletionShell::Powershell),
+        "elvish" => Some(CompletionShell::Elvish),
+        _ => None,
+    }
+}
+
+/// Environment snapshot used by `completion_install_path`. Extracted to a
+/// struct so tests can inject values without mutating the real process env.
+#[derive(Debug, Default, Clone)]
+struct EnvSnapshot {
+    pub home: Option<String>,
+    pub zdotdir: Option<String>,
+    pub xdg_data_home: Option<String>,
+    pub xdg_config_home: Option<String>,
+}
+
+impl EnvSnapshot {
+    fn from_env() -> Self {
+        Self {
+            home: std::env::var("HOME").ok(),
+            zdotdir: std::env::var("ZDOTDIR").ok(),
+            xdg_data_home: std::env::var("XDG_DATA_HOME").ok(),
+            xdg_config_home: std::env::var("XDG_CONFIG_HOME").ok(),
+        }
+    }
+}
+
+/// Resolve the conventional install path for a shell's `rmux_helper`
+/// completion file. Returns `None` for shells without a default location
+/// (powershell / elvish) or when `$HOME` is unset and no XDG override is
+/// available.
+fn completion_install_path(shell: CompletionShell, env: &EnvSnapshot) -> Option<PathBuf> {
+    match shell {
+        CompletionShell::Zsh => {
+            let base = env
+                .zdotdir
+                .as_deref()
+                .or(env.home.as_deref())
+                .map(PathBuf::from)?;
+            Some(base.join(".zfunc").join("_rmux_helper"))
+        }
+        CompletionShell::Bash => {
+            let base = if let Some(x) = env.xdg_data_home.as_deref() {
+                PathBuf::from(x)
+            } else {
+                let home = env.home.as_deref()?;
+                PathBuf::from(home).join(".local").join("share")
+            };
+            Some(
+                base.join("bash-completion")
+                    .join("completions")
+                    .join("rmux_helper"),
+            )
+        }
+        CompletionShell::Fish => {
+            let base = if let Some(x) = env.xdg_config_home.as_deref() {
+                PathBuf::from(x)
+            } else {
+                let home = env.home.as_deref()?;
+                PathBuf::from(home).join(".config")
+            };
+            Some(base.join("fish").join("completions").join("rmux_helper.fish"))
+        }
+        CompletionShell::Powershell | CompletionShell::Elvish => None,
+    }
+}
+
+/// Friendly post-install note per shell — printed on successful write so the
+/// user knows what (if anything) they need to do to activate completions.
+fn completion_friendly_note(shell: CompletionShell) -> &'static str {
+    match shell {
+        CompletionShell::Zsh => {
+            "Make sure ~/.zfunc is in your $fpath and `autoload -Uz compinit && compinit` has run. Typically added to ~/.zshrc."
+        }
+        CompletionShell::Bash => {
+            "Sourced automatically if bash-completion is installed (apt install bash-completion on Debian/Ubuntu, brew install bash-completion@2 on macOS)."
+        }
+        CompletionShell::Fish => "Loaded automatically on next fish shell start.",
+        CompletionShell::Powershell | CompletionShell::Elvish => {
+            "Pipe the output to your shell's profile; no default install path."
+        }
+    }
+}
+
+/// Generate the dynamic-completion registration script for a shell. Invokes
+/// the current binary with `COMPLETE=<shell>` which `clap_complete`'s
+/// `CompleteEnv` intercepts and emits the script on stdout.
+///
+/// The script is a small wrapper that calls back into this binary at tab-time
+/// with `COMPLETE=<shell> <args>`, so all completion values — including the
+/// live pid list for `parent-pid-tree --pid` — are resolved dynamically.
+fn generate_completion_script(shell: CompletionShell) -> Result<String> {
+    let exe = std::env::current_exe().context("failed to locate rmux_helper binary")?;
+    let output = Command::new(&exe)
+        .env("COMPLETE", shell.as_str())
+        .output()
+        .with_context(|| format!("failed to spawn {} for completion generation", exe.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "rmux_helper exited {} while generating {} completions: {}",
+            output.status,
+            shell.as_str(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn install_completions_cmd(
+    shell: Option<CompletionShell>,
+    print_only: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let resolved = match shell {
+        Some(s) => s,
+        None => {
+            let env_shell = std::env::var("SHELL").ok();
+            detect_shell_from_env(env_shell.as_deref()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "could not detect shell from $SHELL (got {:?}); pass --shell zsh|bash|fish|powershell|elvish",
+                    env_shell
+                )
+            })?
+        }
+    };
+
+    let script = generate_completion_script(resolved)?;
+
+    if print_only {
+        print!("{}", script);
+        return Ok(());
+    }
+
+    let env = EnvSnapshot::from_env();
+    let target = completion_install_path(resolved, &env).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no default install path for {}; re-run with --print-only and pipe to your shell's profile",
+            resolved.as_str()
+        )
+    })?;
+
+    if dry_run {
+        println!("would install {} completions to {}", resolved.as_str(), target.display());
+        return Ok(());
+    }
+
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!("failed to create completion dir {}", parent.display())
+        })?;
+    }
+    fs::write(&target, &script)
+        .with_context(|| format!("failed to write {}", target.display()))?;
+    println!(
+        "installed {} completions to {}",
+        resolved.as_str(),
+        target.display()
+    );
+    println!("note: {}", completion_friendly_note(resolved));
+    Ok(())
+}
+
+/// Dynamic completion callback for `parent-pid-tree --pid`.
+///
+/// Enumerates running pids from `/proc`, filters by the user's partial input,
+/// and annotates each candidate with the process's `comm` for a readable
+/// tab-complete menu. Capped at 500 candidates to avoid flooding the terminal
+/// on a busy box.
+///
+/// Intentionally tolerant: `/proc` missing (macOS, BSD) or unreadable returns
+/// an empty list — never panic during completion.
+fn pid_completer(current: &OsStr) -> Vec<CompletionCandidate> {
+    let current = current.to_string_lossy();
+    let entries = enumerate_pid_candidates(&RealProcReader, Path::new("/proc"), 500);
+    entries
+        .into_iter()
+        .filter(|(pid, _)| current.is_empty() || pid.to_string().starts_with(current.as_ref()))
+        .map(|(pid, comm)| {
+            let mut c = CompletionCandidate::new(pid.to_string());
+            if let Some(name) = comm {
+                c = c.help(Some(name.into()));
+            }
+            c
+        })
+        .collect()
+}
+
+/// Pure-ish helper that enumerates `(pid, comm)` pairs from a `/proc`-shaped
+/// directory. Dependency-injected over `ProcReader` + a root path so tests
+/// can feed a tempdir layout without touching the real filesystem.
+///
+/// Sort order: pid descending (newest first) so the most recently spawned
+/// processes appear at the top of the completion menu. Truncated at `cap`.
+fn enumerate_pid_candidates(
+    proc: &dyn ProcReader,
+    proc_root: &Path,
+    cap: usize,
+) -> Vec<(u32, Option<String>)> {
+    let Ok(entries) = fs::read_dir(proc_root) else {
+        return Vec::new();
+    };
+    let mut pids: Vec<u32> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.file_name().to_str().and_then(|s| s.parse::<u32>().ok()))
+        .collect();
+    pids.sort_unstable_by(|a, b| b.cmp(a));
+    pids.truncate(cap);
+    pids.into_iter()
+        .map(|pid| {
+            let comm = proc.read_comm(pid);
+            (pid, comm)
+        })
+        .collect()
+}
+
 fn main() -> Result<()> {
+    // Intercept completion requests (COMPLETE=<shell> rmux_helper ...). When
+    // the env var is set clap_complete handles the request and exits; when
+    // unset this is a no-op and we proceed to regular arg parsing.
+    clap_complete::CompleteEnv::with_factory(|| {
+        use clap::CommandFactory;
+        Cli::command()
+    })
+    .complete();
+
     let cli = Cli::parse();
 
     match cli.command {
@@ -2644,6 +2929,11 @@ fn main() -> Result<()> {
             let code = parent_pid_tree_cmd(json, pid, verbose, tree);
             std::process::exit(code);
         }
+        Some(Commands::InstallCompletions {
+            shell,
+            print_only,
+            dry_run,
+        }) => install_completions_cmd(shell, print_only, dry_run),
         None => {
             // Show help when no command given
             use clap::CommandFactory;
@@ -4057,5 +4347,191 @@ mod tests {
         assert!(comm.is_some(), "own comm must be readable");
         let exe = reader.read_exe(pid);
         assert!(exe.is_some(), "own exe must be readable");
+    }
+
+    // ---- install-completions ----
+
+    #[test]
+    fn test_detect_shell_from_env_basenames() {
+        assert_eq!(detect_shell_from_env(Some("/bin/zsh")), Some(CompletionShell::Zsh));
+        assert_eq!(detect_shell_from_env(Some("/usr/bin/bash")), Some(CompletionShell::Bash));
+        assert_eq!(detect_shell_from_env(Some("fish")), Some(CompletionShell::Fish));
+        assert_eq!(detect_shell_from_env(Some("/opt/homebrew/bin/pwsh")), Some(CompletionShell::Powershell));
+        assert_eq!(detect_shell_from_env(Some("elvish")), Some(CompletionShell::Elvish));
+    }
+
+    #[test]
+    fn test_detect_shell_from_env_rejects_unknown_and_empty() {
+        assert_eq!(detect_shell_from_env(Some("/weird/custom")), None);
+        assert_eq!(detect_shell_from_env(Some("")), None);
+        assert_eq!(detect_shell_from_env(None), None);
+    }
+
+    #[test]
+    fn test_completion_install_path_zsh_uses_zdotdir_when_set() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            zdotdir: Some("/home/user/dotfiles/zsh".into()),
+            ..Default::default()
+        };
+        let p = completion_install_path(CompletionShell::Zsh, &env).unwrap();
+        assert_eq!(p, PathBuf::from("/home/user/dotfiles/zsh/.zfunc/_rmux_helper"));
+    }
+
+    #[test]
+    fn test_completion_install_path_zsh_falls_back_to_home() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            ..Default::default()
+        };
+        let p = completion_install_path(CompletionShell::Zsh, &env).unwrap();
+        assert_eq!(p, PathBuf::from("/home/user/.zfunc/_rmux_helper"));
+    }
+
+    #[test]
+    fn test_completion_install_path_bash_respects_xdg_data_home() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            xdg_data_home: Some("/custom/data".into()),
+            ..Default::default()
+        };
+        let p = completion_install_path(CompletionShell::Bash, &env).unwrap();
+        assert_eq!(
+            p,
+            PathBuf::from("/custom/data/bash-completion/completions/rmux_helper")
+        );
+    }
+
+    #[test]
+    fn test_completion_install_path_bash_default_xdg() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            ..Default::default()
+        };
+        let p = completion_install_path(CompletionShell::Bash, &env).unwrap();
+        assert_eq!(
+            p,
+            PathBuf::from("/home/user/.local/share/bash-completion/completions/rmux_helper")
+        );
+    }
+
+    #[test]
+    fn test_completion_install_path_fish_respects_xdg_config_home() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            xdg_config_home: Some("/custom/cfg".into()),
+            ..Default::default()
+        };
+        let p = completion_install_path(CompletionShell::Fish, &env).unwrap();
+        assert_eq!(
+            p,
+            PathBuf::from("/custom/cfg/fish/completions/rmux_helper.fish")
+        );
+    }
+
+    #[test]
+    fn test_completion_install_path_fish_default() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            ..Default::default()
+        };
+        let p = completion_install_path(CompletionShell::Fish, &env).unwrap();
+        assert_eq!(
+            p,
+            PathBuf::from("/home/user/.config/fish/completions/rmux_helper.fish")
+        );
+    }
+
+    #[test]
+    fn test_completion_install_path_powershell_none() {
+        let env = EnvSnapshot {
+            home: Some("/home/user".into()),
+            ..Default::default()
+        };
+        assert_eq!(completion_install_path(CompletionShell::Powershell, &env), None);
+        assert_eq!(completion_install_path(CompletionShell::Elvish, &env), None);
+    }
+
+    #[test]
+    fn test_completion_install_path_no_home_no_xdg_returns_none() {
+        // $HOME unset with no XDG override -> can't resolve zsh/bash/fish path.
+        let env = EnvSnapshot::default();
+        assert_eq!(completion_install_path(CompletionShell::Zsh, &env), None);
+        assert_eq!(completion_install_path(CompletionShell::Bash, &env), None);
+        assert_eq!(completion_install_path(CompletionShell::Fish, &env), None);
+    }
+
+    #[test]
+    fn test_enumerate_pid_candidates_sorted_desc_and_truncated() {
+        // Build a tempdir `/proc`-like layout with numeric-named subdirs.
+        let tmp = std::env::temp_dir().join(format!(
+            "rmux_helper_pid_enum_test_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+        for pid in [1u32, 5, 42, 100, 500, 9999] {
+            fs::create_dir(tmp.join(pid.to_string())).unwrap();
+        }
+        // Also create a non-numeric dir — should be ignored.
+        fs::create_dir(tmp.join("self")).unwrap();
+
+        // Mock reader that returns a fixed comm for known pids.
+        let proc = MockProcReader::from_chain(&[])
+            .with_comm(42, "claude")
+            .with_comm(100, "zsh");
+
+        let out = enumerate_pid_candidates(&proc, &tmp, 3);
+        // Descending order, capped at 3.
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].0, 9999);
+        assert_eq!(out[1].0, 500);
+        assert_eq!(out[2].0, 100);
+        assert_eq!(out[2].1.as_deref(), Some("zsh"));
+
+        // Uncapped path: all six pids, comms attached where known.
+        let full = enumerate_pid_candidates(&proc, &tmp, 100);
+        assert_eq!(full.len(), 6);
+        let pids: Vec<u32> = full.iter().map(|(p, _)| *p).collect();
+        assert_eq!(pids, vec![9999, 500, 100, 42, 5, 1]);
+        assert_eq!(full[3].1.as_deref(), Some("claude"));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_enumerate_pid_candidates_missing_proc_returns_empty() {
+        // /proc-equivalent path doesn't exist — return empty, never panic.
+        let proc = MockProcReader::from_chain(&[]);
+        let missing = PathBuf::from("/nonexistent/proc/path/xyz_rmux_test");
+        let out = enumerate_pid_candidates(&proc, &missing, 100);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_install_completions_cli_parses_conflicting_flags() {
+        // --print-only and --dry-run are mutually exclusive; clap should reject.
+        use clap::Parser;
+        let result = Cli::try_parse_from([
+            "rmux_helper",
+            "install-completions",
+            "--shell",
+            "zsh",
+            "--print-only",
+            "--dry-run",
+        ]);
+        assert!(result.is_err(), "expected conflicts_with to reject this");
+    }
+
+    #[test]
+    fn test_install_completions_cli_rejects_unknown_shell() {
+        use clap::Parser;
+        let result = Cli::try_parse_from([
+            "rmux_helper",
+            "install-completions",
+            "--shell",
+            "nosuchshell",
+        ]);
+        assert!(result.is_err(), "unknown shell should be rejected by clap");
     }
 }

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -1845,6 +1845,123 @@ fn debug_keys() -> Result<()> {
 // caller's pid up through ppid (via /proc/<pid>/stat field 4) until we hit a pid
 // that matches a `pane_pid` reported by `tmux list-panes`. The first ancestor
 // match is deterministically the caller's pane, regardless of focus state.
+//
+// Architecture: Humble Object pattern. The "shell" that shells out to `tmux`
+// or reads `/proc` lives behind the `TmuxProvider` + `ProcReader` traits. All
+// walk logic, flag handling, exit-code selection, and output formatting lives
+// in `run_parent_pid_tree`, which takes the traits as dependencies. The
+// command wrapper (and in turn `main()`) is the only place that constructs
+// the `Real*` impls and writes to real stdout/stderr. Tests drive
+// `run_parent_pid_tree` with in-memory mocks so every exit code and flag
+// combination is reachable without touching tmux or `/proc`.
+//
+// Scope note: `TmuxProvider` only exposes the primitives `parent-pid-tree`
+// needs today. Other tmux call sites in this binary (`side_edit`, `side_run`,
+// `rename_all`, `rotate`, `third`) still shell out directly via
+// `run_tmux_command` and scattered `Command::new("tmux")` calls. Migrating
+// those requires characterization tests that don't exist yet. New tmux code
+// should use this trait; old sites can migrate incrementally.
+
+/// Errors surfaced by the `TmuxProvider` humble shell.
+///
+/// The walker + command layer translate these to concrete exit codes; the
+/// shell itself doesn't know about the 0/1/2/3 scheme.
+#[derive(Debug)]
+enum TmuxError {
+    /// tmux is not installed, no server is running, or `list-panes` returned
+    /// empty output (e.g. no sessions). Maps to exit code 2.
+    NotRunning,
+    /// Spawning `tmux` failed or the child exited non-zero with an io-level
+    /// error. Preserves the underlying `io::Error` for context. Also exit 2,
+    /// with a more specific stderr message.
+    ListFailed(std::io::Error),
+    /// `tmux` output could not be parsed as expected. Present for
+    /// forward-compat — the current line-based parser skips malformed lines
+    /// rather than erroring. Also exit 2.
+    #[allow(dead_code)]
+    ParseFailed(String),
+}
+
+impl std::fmt::Display for TmuxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TmuxError::NotRunning => write!(f, "tmux not running or no panes"),
+            TmuxError::ListFailed(e) => write!(f, "tmux list-panes failed: {}", e),
+            TmuxError::ParseFailed(msg) => write!(f, "tmux output parse failed: {}", msg),
+        }
+    }
+}
+
+/// Humble shell over `tmux` for `parent-pid-tree`. Only primitives this PR
+/// needs are defined; add more methods here (and to `RealTmuxProvider`) when
+/// migrating other call sites.
+trait TmuxProvider {
+    /// List every tmux pane's `(pane_id, pane_pid)` across all sessions
+    /// (`tmux list-panes -a`). Returns `NotRunning` if tmux is unreachable or
+    /// the server has no panes. Order is not guaranteed.
+    fn list_pane_pids(&self) -> Result<Vec<(String, u32)>, TmuxError>;
+
+    /// Return the currently tmux-active pane id (focused in the attached
+    /// client). This is intentionally NOT what `parent-pid-tree` uses to
+    /// answer "which pane am I in" — it exists for explicit active-pane
+    /// lookups and future migrations.
+    #[allow(dead_code)]
+    fn active_pane(&self) -> Result<Option<String>, TmuxError>;
+}
+
+/// Humble shell over `/proc/<pid>/stat`. Tests inject a mock that returns a
+/// pre-built chain without touching the filesystem.
+trait ProcReader {
+    /// Return the parent pid of `pid` (field 4 of `/proc/<pid>/stat`). Returns
+    /// `None` for pid 0, a vanished process, or an unreadable/unparseable stat
+    /// file. `None` is non-fatal to the walker — it just means "stop here".
+    fn read_ppid(&self, pid: u32) -> Option<u32>;
+}
+
+/// Production implementation of `TmuxProvider` — shells out to the `tmux`
+/// binary via `std::process::Command`.
+struct RealTmuxProvider;
+
+impl TmuxProvider for RealTmuxProvider {
+    fn list_pane_pids(&self) -> Result<Vec<(String, u32)>, TmuxError> {
+        let output = Command::new("tmux")
+            .args(["list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"])
+            .output()
+            .map_err(TmuxError::ListFailed)?;
+        if !output.status.success() {
+            return Err(TmuxError::NotRunning);
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let pairs = parse_pane_pid_pairs(&stdout);
+        if pairs.is_empty() {
+            return Err(TmuxError::NotRunning);
+        }
+        Ok(pairs)
+    }
+
+    fn active_pane(&self) -> Result<Option<String>, TmuxError> {
+        let output = Command::new("tmux")
+            .args(["display-message", "-p", "#{pane_id}"])
+            .output()
+            .map_err(TmuxError::ListFailed)?;
+        if !output.status.success() {
+            return Err(TmuxError::NotRunning);
+        }
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if s.is_empty() { Ok(None) } else { Ok(Some(s)) }
+    }
+}
+
+/// Production implementation of `ProcReader`. Delegates to
+/// `read_ppid_from_proc`, whose `rfind(')')`-based parser is load-bearing for
+/// `comm` fields containing parens or spaces — do NOT reimplement it inline.
+struct RealProcReader;
+
+impl ProcReader for RealProcReader {
+    fn read_ppid(&self, pid: u32) -> Option<u32> {
+        read_ppid_from_proc(pid)
+    }
+}
 
 /// Result of a successful parent-pid walk.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1876,10 +1993,11 @@ fn read_ppid_from_proc(pid: u32) -> Option<u32> {
     ppid_str.parse().ok()
 }
 
-/// Parse `tmux list-panes -a -F '#{pane_id} #{pane_pid}'` output into a map
-/// from pane_pid -> pane_id.
-fn parse_pane_pids(output: &str) -> HashMap<u32, String> {
-    let mut map = HashMap::new();
+/// Parse `tmux list-panes -a -F '#{pane_id} #{pane_pid}'` output into a list
+/// of `(pane_id, pane_pid)` tuples. Malformed lines are silently skipped so
+/// a single garbage line from tmux doesn't blow up the whole walk.
+fn parse_pane_pid_pairs(output: &str) -> Vec<(String, u32)> {
+    let mut pairs = Vec::new();
     for line in output.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -1893,25 +2011,22 @@ fn parse_pane_pids(output: &str) -> HashMap<u32, String> {
             continue;
         };
         if let Ok(pid) = pid_str.parse::<u32>() {
-            map.insert(pid, pane_id.to_string());
+            pairs.push((pane_id.to_string(), pid));
         }
     }
-    map
+    pairs
 }
 
-/// Fetch `tmux list-panes -a -F '#{pane_id} #{pane_pid}'` and parse it.
-/// Returns an error if tmux is not running or the command fails.
-fn list_tmux_pane_pids() -> Result<HashMap<u32, String>> {
-    let output = Command::new("tmux")
-        .args(["list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"])
-        .output()
-        .context("failed to spawn tmux")?;
-    if !output.status.success() {
-        anyhow::bail!("tmux list-panes failed (is tmux running?)");
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let map = parse_pane_pids(&stdout);
-    Ok(map)
+/// Parse `tmux list-panes -a -F '#{pane_id} #{pane_pid}'` output into a map
+/// from pane_pid -> pane_id. Kept for test-level coverage of the parser;
+/// production code goes through `parse_pane_pid_pairs` inside
+/// `RealTmuxProvider::list_pane_pids`.
+#[cfg(test)]
+fn parse_pane_pids(output: &str) -> HashMap<u32, String> {
+    parse_pane_pid_pairs(output)
+        .into_iter()
+        .map(|(pane_id, pid)| (pid, pane_id))
+        .collect()
 }
 
 /// Safety cap on walk depth — normal process trees on Linux are well under this.
@@ -1971,91 +2086,169 @@ where
     None
 }
 
-/// Run the parent-pid-tree command end to end: default start-pid resolution,
-/// tmux list-panes, walk, output formatting, exit code.
+/// CLI-level flags for `parent-pid-tree`. Extracted into a struct so the
+/// testable core can be driven with plain values without re-parsing clap.
+#[derive(Debug, Clone, Copy)]
+struct ParentPidTreeArgs {
+    json: bool,
+    pid: Option<u32>,
+    verbose: bool,
+}
+
+/// Structured result of running `parent-pid-tree`.
 ///
-/// Returns a concrete exit code (0/1/2/3) rather than anyhow::Error so that the
-/// error contract documented in CLAUDE.md is preserved — we want deterministic
-/// codes regardless of what fails underneath.
-fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool) -> i32 {
+/// `main()` is the only place that actually writes to real stdout/stderr —
+/// this type makes the command function a pure data transform that tests can
+/// assert against. Any non-empty `stdout` is printed as-is with a trailing
+/// newline, and every `stderr_lines` entry is printed on its own line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParentPidTreeOutcome {
+    /// Line to print to stdout (matched pane id or JSON blob). Empty on the
+    /// failure exit codes 1/2/3.
+    stdout: String,
+    /// Lines to print to stderr. `--verbose` adds walk-chain entries; error
+    /// paths add a human-readable message.
+    stderr_lines: Vec<String>,
+    /// Concrete exit code. See `run_parent_pid_tree` for the contract.
+    exit_code: i32,
+}
+
+/// Testable core of `parent-pid-tree`. Takes humble-shell dependencies so
+/// every branch is reachable without touching tmux or `/proc`.
+///
+/// Exit code contract (mirrored in CLAUDE.md — keep in sync):
+/// - `0` — pane found, `stdout` holds the pane id or JSON payload
+/// - `1` — no match (walker exhausted chain without finding a pane_pid)
+/// - `2` — tmux not running / list-panes failed / empty pane set
+/// - `3` — could not read self's ppid (default-start-pid path only)
+///
+/// `self_pid` is passed explicitly instead of calling `std::process::id()`
+/// internally so tests can control the "read my own ppid" branch. Production
+/// callers pass `std::process::id()`.
+fn run_parent_pid_tree(
+    args: ParentPidTreeArgs,
+    self_pid: u32,
+    tmux: &dyn TmuxProvider,
+    proc: &dyn ProcReader,
+) -> ParentPidTreeOutcome {
+    let mut stderr_lines: Vec<String> = Vec::new();
+
     // 1. Fetch pane_pid map from tmux.
-    let pane_pids = match list_tmux_pane_pids() {
-        Ok(map) if map.is_empty() => {
-            eprintln!("tmux not running or no panes");
-            return 2;
+    let pane_pids: HashMap<u32, String> = match tmux.list_pane_pids() {
+        Ok(pairs) => pairs
+            .into_iter()
+            .map(|(pane_id, pid)| (pid, pane_id))
+            .collect(),
+        Err(TmuxError::NotRunning) => {
+            stderr_lines.push("tmux not running or no panes".to_string());
+            return ParentPidTreeOutcome {
+                stdout: String::new(),
+                stderr_lines,
+                exit_code: 2,
+            };
         }
-        Ok(map) => map,
         Err(e) => {
-            eprintln!("tmux not running or no panes: {}", e);
-            return 2;
+            stderr_lines.push(format!("tmux not running or no panes: {}", e));
+            return ParentPidTreeOutcome {
+                stdout: String::new(),
+                stderr_lines,
+                exit_code: 2,
+            };
         }
     };
 
     // 2. Determine start pid. When the user passed --pid we trust it verbatim.
     // Otherwise we walk from the PARENT of rmux_helper itself: rmux_helper is
     // a child of whoever invoked it, and that caller is what we want to resolve.
-    let start_pid = match pid {
+    let start_pid = match args.pid {
         Some(p) => p,
-        None => {
-            let self_pid = std::process::id();
-            match read_ppid_from_proc(self_pid) {
-                Some(p) => p,
-                None => {
-                    eprintln!(
-                        "could not read /proc/{}/stat to find caller pid",
-                        self_pid
-                    );
-                    return 3;
-                }
+        None => match proc.read_ppid(self_pid) {
+            Some(p) => p,
+            None => {
+                stderr_lines.push(format!(
+                    "could not read /proc/{}/stat to find caller pid",
+                    self_pid
+                ));
+                return ParentPidTreeOutcome {
+                    stdout: String::new(),
+                    stderr_lines,
+                    exit_code: 3,
+                };
             }
-        }
+        },
     };
 
-    if verbose {
-        eprintln!("parent-pid-tree: starting walk at pid {}", start_pid);
+    if args.verbose {
+        stderr_lines.push(format!("parent-pid-tree: starting walk at pid {}", start_pid));
     }
 
-    // 3. Walk the chain.
-    let result = resolve_pane_by_parent_chain(start_pid, &pane_pids, read_ppid_from_proc);
+    // 3. Walk the chain. The walker takes its own read_ppid closure, which we
+    //    adapt from the injected `ProcReader`.
+    let result = resolve_pane_by_parent_chain(start_pid, &pane_pids, |p| proc.read_ppid(p));
 
     match result {
         Some(m) => {
-            if verbose {
+            if args.verbose {
                 let chain: Vec<String> = m
                     .ancestors_walked
                     .iter()
                     .map(|p| p.to_string())
                     .collect();
-                eprintln!(
+                stderr_lines.push(format!(
                     "parent-pid-tree: walked {} (pane_pid) -> pane {}",
                     chain.join(" -> "),
                     m.pane_id
-                );
+                ));
             }
-            if json {
+            let stdout = if args.json {
                 let payload = serde_json::json!({
                     "pane_id": m.pane_id,
                     "pane_pid": m.pane_pid,
                     "walked_from_pid": start_pid,
                     "ancestors_walked": m.ancestors_walked,
                 });
-                println!("{}", payload);
+                payload.to_string()
             } else {
-                println!("{}", m.pane_id);
+                m.pane_id.clone()
+            };
+            ParentPidTreeOutcome {
+                stdout,
+                stderr_lines,
+                exit_code: 0,
             }
-            0
         }
         None => {
-            if verbose {
-                eprintln!(
+            if args.verbose {
+                stderr_lines.push(format!(
                     "parent-pid-tree: no pane match for pid {} (walked until init/unreadable/max-depth)",
                     start_pid
-                );
+                ));
             }
-            eprintln!("no tmux pane found for pid {}", start_pid);
-            1
+            stderr_lines.push(format!("no tmux pane found for pid {}", start_pid));
+            ParentPidTreeOutcome {
+                stdout: String::new(),
+                stderr_lines,
+                exit_code: 1,
+            }
         }
     }
+}
+
+/// Thin wrapper that wires the real humble-shell impls into the testable core
+/// and performs the actual stdout/stderr writes. `main()` calls this; tests
+/// call `run_parent_pid_tree` directly with mocks.
+fn parent_pid_tree_cmd(json: bool, pid: Option<u32>, verbose: bool) -> i32 {
+    let args = ParentPidTreeArgs { json, pid, verbose };
+    let tmux = RealTmuxProvider;
+    let proc = RealProcReader;
+    let outcome = run_parent_pid_tree(args, std::process::id(), &tmux, &proc);
+    for line in &outcome.stderr_lines {
+        eprintln!("{}", line);
+    }
+    if !outcome.stdout.is_empty() {
+        println!("{}", outcome.stdout);
+    }
+    outcome.exit_code
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
## Summary

- Adds a `parent-pid-tree` subcommand to `rmux_helper` that walks the caller's parent-PID chain against `tmux list-panes` to deterministically find the caller's owning tmux pane.
- Documents the new subcommand in `rust/tmux_helper/CLAUDE.md` with exit-code contract and usage.
- Factors the walker into a DI-friendly helper with unit tests for the multi-session scenario, no-match case, and vanished-parent case.

## Motivation

Observed 2026-04-14: `harden-telegram`'s `watchdog.py` auto-recovery sent `/reload-plugins` to the wrong Claude session for ~45 minutes because it resolved the target pane via `tmux display-message -p '#{pane_id}'`, which returns the tmux-*active* pane, not the caller's pane. With two Claude sessions running concurrently (Larry in pane %35, blog in pane %65), the watchdog reloaded the wrong session every time.

The correct primitive is a parent-PID walk: start from the caller's pid, read `/proc/<pid>/stat` field 4 for ppid, and match ancestors against `tmux list-panes -a -F '#{pane_pid}'`. First match is the answer. That's deterministic regardless of focus state.

This PR encapsulates that primitive in `rmux_helper` so future tmux-integration code can call `rmux_helper parent-pid-tree` and trust the answer instead of hand-rolling the walk. A companion PR in `chop-conventions` (#101) is fixing the specific watchdog.py case; this one makes the primitive reusable.

## Test plan

- [x] `cargo test` passes with the new unit tests (181 total, 9 new)
- [x] `cargo clippy --all-targets` clean on new code (pre-existing `link_picker` warnings unchanged)
- [x] `rmux_helper parent-pid-tree` from inside a tmux pane prints that pane's id
- [x] `rmux_helper parent-pid-tree --pid 1` (init) returns no-match, exit 1
- [x] `rmux_helper parent-pid-tree --verbose` shows the walk chain on stderr
- [x] `rmux_helper parent-pid-tree --json` emits valid JSON

Live smoke test output (from a tmux pane):
```
$ rmux_helper parent-pid-tree --verbose
parent-pid-tree: starting walk at pid 485370
parent-pid-tree: walked 485370 -> 4114505 -> 4114434 -> 2594534 (pane_pid) -> pane %35
%35
```

## Follow-up: `--tree`

Added a `--tree` flag that prints the full ancestor chain as a visual tree with per-PID metadata: short `comm`, full `cmdline` (from `/proc/<pid>/cmdline`, null-separated argv joined with spaces), and `exe` readlink. Leverages the `TmuxProvider` / `ProcReader` DI layout from the earlier commits so the tree-builder and formatters are testable in isolation.

Composition:

- `--tree` alone — ASCII tree on stdout, exit 0/1 matches the walk result
- `--tree --json` — structured payload (`start_pid`, `pane_id`, `pane_pid`, `chain[]` with `pid`/`comm`/`cmdline`/`exe`)
- `--tree --verbose` — tree on stdout, walk log on stderr (streams don't cross)
- `--tree --pid N` — tree for an arbitrary start pid
- Default (no `--tree`) — unchanged; still emits just `%N`

Kernel-thread / permission-denied paths degrade gracefully: empty cmdline falls back to `[comm]`; unreadable `exe` prints `exe: (unreadable)` (or `null` in JSON). Long cmdlines truncate at 120 chars with `…` in the text view; full values always available via `--json`.

Eleven new tests cover: metadata collection, missing cmdline/exe handling, tree+json combination, no-match tree population (for debugging), formatter truncation, ASCII box-drawing, pane annotation at the leaf, and a real-`/proc` smoke test against the test process itself.

Live sample:

```
$ rmux_helper parent-pid-tree --tree
parent-pid-tree
├─ [pid 597447 ] zsh             /home/linuxbrew/.linuxbrew/bin/zsh -c source ...
│     exe: /home/linuxbrew/.linuxbrew/Cellar/zsh/5.9/bin/zsh
├─ [pid 4114505] claude          claude /startup-larry --dangerously-skip-permissions --channels plugin:telegram@claude-plugins-official
│     exe: /home/developer/.local/share/claude/versions/2.1.107
├─ [pid 4114434] larry_start.sh  /bin/bash ./larry_start.sh
│     exe: /usr/bin/bash
└─ [pid 2594534] zsh             /home/linuxbrew/.linuxbrew/bin/zsh  (pane shell)
      exe: /home/linuxbrew/.linuxbrew/Cellar/zsh/5.9/bin/zsh
      tmux pane: %35
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up: shell completions

Adds an `install-completions` subcommand that writes shell completion scripts to the conventional location for zsh/bash/fish (powershell/elvish supported via `--print-only`). Auto-detects shell from `$SHELL`; override via `--shell`. Supports `--dry-run` (reports target path) and `--print-only` (stdout) for scripted use — mutually exclusive via clap.

```bash
rmux_helper install-completions              # auto-detect
rmux_helper install-completions --shell zsh  # explicit
rmux_helper install-completions --print-only # dump to stdout
rmux_helper install-completions --dry-run    # report path, skip write
```

Default install paths:

| Shell | Path |
|---|---|
| zsh | `$ZDOTDIR/.zfunc/_rmux_helper` or `$HOME/.zfunc/_rmux_helper` |
| bash | `$XDG_DATA_HOME/bash-completion/completions/rmux_helper` or `$HOME/.local/share/bash-completion/completions/rmux_helper` |
| fish | `$XDG_CONFIG_HOME/fish/completions/rmux_helper.fish` or `$HOME/.config/fish/completions/rmux_helper.fish` |

### Dynamic completion — live values at tab-time

`parent-pid-tree --pid <TAB>` resolves live pids from `/proc` at tab-time, annotated with each process's `comm` as the completion description — capped at 500 entries, sorted newest-first so the most recently spawned processes appear first.

Uses `clap_complete::CompleteEnv::with_factory(Cli::command).complete()` at the top of `main()` (feature `unstable-dynamic`). When invoked with `COMPLETE=<shell>` in env, clap_complete intercepts and emits the shell script to stdout. The installed shell script re-invokes the binary with `COMPLETE` set on every tab press, so values are always live — no static snapshot to regenerate on upgrade.

Static completions (subcommand names, flag names, enum values like `--shell <TAB>`) come free from clap. `side-edit <file>` is annotated with `ValueHint::FilePath` for default shell file completion.

### Live smoke

```
$ rmux_helper install-completions --shell zsh --dry-run
would install zsh completions to /home/developer/.zfunc/_rmux_helper

$ _CLAP_COMPLETE_INDEX=3 COMPLETE=zsh rmux_helper -- rmux_helper parent-pid-tree --pid "" | head -5
4114505:claude
4114434:larry_start.sh
4024124:tmux: client
4023867:bash
4023865:etterminal
```

### Tests

14 new unit tests (shell detection, install-path resolution per shell+XDG, pid enumeration / truncation, missing-`/proc` tolerance, clap-level conflicts and unknown-shell rejection). `cargo test` now: **222 passed, 0 failed** (was 208).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `parent-pid-tree` command with `--json`, `--pid`, and `--verbose` flags for resolving tmux pane ownership via parent process chain.
  * Added dynamic shell completion support for the new command.

* **Chores**
  * Added dependency for shell completion generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->