### PR TITLE
fix(nvim-tests): call packadd mini.nvim unconditionally

### DIFF
--- a/nvim/tests/minit.lua
+++ b/nvim/tests/minit.lua
@@ -4,8 +4,9 @@ local mini_path = vim.fn.stdpath("data") .. "/site/pack/deps/start/mini.nvim"
 if not vim.uv.fs_stat(mini_path) then
 	vim.notify("Cloning mini.nvim...", vim.log.levels.INFO)
 	vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/echasnovski/mini.nvim", mini_path })
-	vim.cmd("packadd mini.nvim")
 end
+-- packadd must run every headless invocation — start/ is not auto-loaded by `nvim -l`
+vim.cmd("packadd mini.nvim")
 
 -- Add repo root to rtp so require("nvim.foo") works
 vim.opt.rtp:prepend(vim.uv.cwd())


### PR DESCRIPTION
## Summary
- `packadd mini.nvim` was inside the clone-on-first-run `if` block, so after the initial clone it never ran again
- In headless mode (`nvim -l`), packages under `start/` do NOT auto-load, so `require("mini.test")` failed on every subsequent `just test`
- Fix: move `packadd` out of the conditional so it fires every invocation

Closes #53

## Test plan
- [x] `just test` → 27/27 pass (blog_links: 19, jekyll_browser: 5, youtube_template: 3)
- [x] StyLua + typos pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)