### PR TITLE
tmux: enable mouse mode

### DIFF
--- a/shared/.tmux.conf
+++ b/shared/.tmux.conf
@@ -49,7 +49,7 @@
 # C-A r - Source tmux config
 
 # Run it via the mouse.
-# set-option -g mouse on
+set-option -g mouse on
 
 
 # wsl doesn't honor chsh (??)


### PR DESCRIPTION
Uncomments `set-option -g mouse on` in `shared/.tmux.conf` (single-line change, preserves the `# Run it via the mouse.` comment above it). Re-enables mouse scrolling and pane selection because Igor wants mouse mode on for tmux interaction.

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mouse support is now enabled in the tmux configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->