### PR TITLE
zsh: remove sl='ssh lightsail' alias

### DIFF
--- a/shared/zsh_include.sh
+++ b/shared/zsh_include.sh
@@ -666,7 +666,6 @@ function pgpushall() {
 alias weather="curl wttr.in/seattle"
 alias dwc='pushd ~/gits/settings && python3 -c "from vim_python import * ;WCDailyPage()" && pushd ~/gits/igor2/750words '
 alias dgc='pushd ~/gits/settings && python3 -c "from vim_python import * ;GitCommitDailyPage()" && pushd ~/gits/igor2/750words '
-alias sl='ssh lightsail'
 alias asl='autossh -M 20000 lightsail_no_forward'
 alias slnf='ssh lightsail_no_forward'
 alias ytsub='youtube-dl --write-sub --sub-format srt --skip-download'


### PR DESCRIPTION
Removes the `sl='ssh lightsail'` alias from `shared/zsh_include.sh` so `sl` is free for Sapling source control.

`asl` and `slnf` lightsail aliases are kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell aliases configuration: removed one alias and introduced two new aliases for remote connection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->