### PR TITLE
feat(running-servers): port-conflict-aware `run` + `version` commands

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "idvorkin_scripts"
-version = "0.1.0"
+version = "0.2.0"
 description = "A collection of Igor's Python scripts"
 authors = [{name = "Igor Dvorkin"}]
 dependencies = [

--- a/py/running_servers.py
+++ b/py/running_servers.py
@@ -20,12 +20,18 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+# Bump when adding a capability a caller may need to gate on. 0.2.0 introduced
+# the `run` subcommand (port-conflict-aware launching); the blog's jekyll-serve
+# recipe requires `running-servers version` >= 0.2.0.
+__version__ = "0.2.0"
+
 app = typer.Typer(
     no_args_is_help=True,
     pretty_exceptions_enable=False,
     add_completion=False,
 )
 console = Console()
+err_console = Console(stderr=True)
 
 
 # --- Platform Adapter (Humble Object) ---
@@ -301,13 +307,93 @@ class ServerFinder:
                 return server
         return None
 
-    def find_available_port(self, start: int = 4000, end: int = 4010) -> int | None:
-        """Find an available port in the given range."""
+    def find_available_port(
+        self,
+        start: int = 4000,
+        end: int = 4010,
+        exclude: set[int] | None = None,
+    ) -> int | None:
+        """Find an available port in the given range.
+
+        `exclude` lets callers reserve ports they have already chosen in the
+        same pass (e.g. an HTTP port picked just before the livereload port)
+        even though nothing is listening on them yet.
+        """
         ports_in_use = set(self.adapter.get_listening_ports().keys())
+        if exclude:
+            ports_in_use |= exclude
         for port in range(start, end + 1):
             if port not in ports_in_use:
                 return port
         return None
+
+    def plan_run(
+        self,
+        directory: Path,
+        process: str | None = None,
+        http: int = 4000,
+        livereload: int | None = None,
+        span: int = 20,
+    ) -> dict:
+        """Decide whether a server may be launched in `directory`.
+
+        This is the pure decision behind the `run` command, kept separate so it
+        can be unit-tested with a mock adapter. It never starts anything.
+
+        Returns either:
+          {"conflict": [server, ...]}   -- a matching server already serves the
+                                           directory; do NOT start a second one.
+          {"conflict": [], "http": int, "livereload": int | None,
+           "http_requested": int, "http_owner": str | None,
+           "livereload_requested": int | None, "livereload_owner": str | None}
+        """
+        directory = Path(directory).resolve()
+        existing = self.find_for_directory(directory)
+        if process:
+            needle = process.lower()
+            existing = [
+                s
+                for s in existing
+                if needle in s["process"].lower() or needle in s["cmdline"].lower()
+            ]
+
+        # One server can hold several ports (jekyll: http + livereload); dedupe
+        # by pid so the conflict message names one process, not two rows.
+        seen: set[int] = set()
+        conflict: list[dict] = []
+        for s in existing:
+            if s["pid"] not in seen:
+                seen.add(s["pid"])
+                conflict.append(s)
+        if conflict:
+            return {"conflict": conflict}
+
+        chosen_http = self.find_available_port(http, http + span)
+        http_owner = None
+        if chosen_http != http:
+            owner = self.find_by_port(http)
+            http_owner = owner["directory"] if owner else None
+
+        chosen_lr = None
+        lr_owner = None
+        if livereload is not None:
+            reserve = {chosen_http} if chosen_http is not None else None
+            chosen_lr = self.find_available_port(
+                livereload, livereload + span, exclude=reserve
+            )
+            if chosen_lr != livereload:
+                owner = self.find_by_port(livereload)
+                lr_owner = owner["directory"] if owner else None
+
+        return {
+            "conflict": [],
+            "http": chosen_http,
+            "livereload": chosen_lr,
+            "http_requested": http,
+            "http_owner": http_owner,
+            "livereload_requested": livereload,
+            "livereload_owner": lr_owner,
+        }
 
 
 # --- Utilities ---
@@ -335,6 +421,17 @@ def get_url(port: int, hostname: str | None = None) -> str:
     """Build URL for a port, using Tailscale hostname if available."""
     host = hostname or "localhost"
     return f"http://{host}:{port}"
+
+
+def substitute_ports(tokens: list[str], http: int, livereload: int | None) -> list[str]:
+    """Replace {http}/{port}/{livereload} placeholders in a command's argv."""
+    out = []
+    for t in tokens:
+        t = t.replace("{http}", str(http)).replace("{port}", str(http))
+        if livereload is not None:
+            t = t.replace("{livereload}", str(livereload))
+        out.append(t)
+    return out
 
 
 # --- CLI Commands ---
@@ -533,6 +630,111 @@ def suggest(
         console.print(f"[dim]URL: {url}[/dim]")
     else:
         console.print(f"[red]No available ports in range {start}-{end}[/red]")
+
+
+@app.command()
+def version():
+    """Print the running-servers version (for capability gating in scripts)."""
+    # Plain print (not console) so callers can parse it without rich markup.
+    print(__version__)
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def run(
+    command: list[str] = typer.Argument(
+        None,
+        help="Command to launch, after `--`. {http}/{livereload} are substituted.",
+    ),
+    directory: Path = typer.Option(
+        None, "--dir", "-d", help="Directory to guard on (default: cwd)"
+    ),
+    process: str = typer.Option(
+        None,
+        "--process",
+        "-p",
+        help="Only a server whose process/cmdline matches counts as 'already here'",
+    ),
+    http: int = typer.Option(4000, "--http", help="Preferred HTTP port"),
+    livereload: int = typer.Option(
+        None, "--livereload", "-l", help="Preferred livereload port (optional)"
+    ),
+    span: int = typer.Option(
+        20, "--span", help="How many ports above the preferred to search for a free one"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the resolved command instead of executing it"
+    ),
+):
+    """Launch a dev server, but only if one isn't already serving this directory.
+
+    Fails (exit 1) if a --process-matching server already serves the directory.
+    Otherwise picks a free HTTP port (preferring --http) plus a free livereload
+    port, substitutes {http}/{livereload} into the command, and execs it so the
+    server's stdout, Ctrl+C, and exit code pass straight through.
+    """
+    directory = (directory or Path.cwd()).resolve()
+    hostname = get_tailscale_hostname()
+    finder = get_finder()
+    plan = finder.plan_run(
+        directory, process=process, http=http, livereload=livereload, span=span
+    )
+
+    if plan["conflict"]:
+        s = plan["conflict"][0]
+        url = get_url(s["port"], hostname)
+        label = process or s["process"]
+        err_console.print(
+            f"[red]✗[/red] {label} already running here on [cyan]:{s['port']}[/cyan] "
+            f"(pid {s['pid']}) [dim]→[/dim] [blue]{url}[/blue]"
+        )
+        err_console.print(f"[dim]  {directory}[/dim]")
+        raise typer.Exit(code=1)
+
+    chosen_http = plan["http"]
+    chosen_lr = plan["livereload"]
+    if chosen_http is None:
+        err_console.print(f"[red]✗[/red] No free port in {http}-{http + span}")
+        raise typer.Exit(code=1)
+    if livereload is not None and chosen_lr is None:
+        err_console.print(
+            f"[red]✗[/red] No free livereload port in {livereload}-{livereload + span}"
+        )
+        raise typer.Exit(code=1)
+
+    # Drift notes go to stderr so stdout stays the server's (or, in --dry-run,
+    # the resolved command line only).
+    if chosen_http != http:
+        owner = plan["http_owner"] or "another process"
+        err_console.print(
+            f"[dim]ℹ port {http} held by {owner} — using :{chosen_http}[/dim]"
+        )
+    if livereload is not None and chosen_lr != livereload:
+        owner = plan["livereload_owner"] or "another process"
+        err_console.print(
+            f"[dim]ℹ livereload {livereload} held by {owner} — using :{chosen_lr}[/dim]"
+        )
+
+    resolved = substitute_ports(list(command or []), chosen_http, chosen_lr)
+    if not resolved:
+        err_console.print("[red]✗[/red] No command given (expected: run … -- CMD)")
+        raise typer.Exit(code=2)
+    leftovers = [t for t in resolved if "{livereload}" in t]
+    if leftovers:
+        err_console.print(
+            "[red]✗[/red] Command uses {livereload} but no --livereload port was given"
+        )
+        raise typer.Exit(code=2)
+
+    url = get_url(chosen_http, hostname)
+    err_console.print(f"🔨 serving [cyan]{directory}[/cyan] on :{chosen_http} → {url}")
+
+    if dry_run:
+        print(" ".join(resolved))
+        raise typer.Exit(code=0)
+
+    os.execvp(resolved[0], resolved)
 
 
 if __name__ == "__main__":

--- a/py/test_running_servers.py
+++ b/py/test_running_servers.py
@@ -213,5 +213,198 @@ def test_check_process_filter_match_exits_zero(runner, monkeypatch, tmp_path):
     assert result.exit_code == 0, result.output
 
 
+# --- plan_run unit tests (pure decision logic, no exec) ---
+
+
+def _jekyll(port, pid, cwd, livereload_port=None):
+    """Helper: a jekyll server record (optionally its livereload sibling)."""
+    rows = [
+        {
+            "port": port,
+            "pid": pid,
+            "cwd": str(cwd),
+            "name": "ruby",
+            "cmdline": f"jekyll serve --port {port}",
+        }
+    ]
+    if livereload_port is not None:
+        rows.append(
+            {
+                "port": livereload_port,
+                "pid": pid,  # same process, second socket
+                "cwd": str(cwd),
+                "name": "ruby",
+                "cmdline": f"jekyll serve --port {port}",
+            }
+        )
+    return rows
+
+
+def test_plan_run_clear_dir_picks_requested(tmp_path):
+    finder = ServerFinder(MockAdapter([]))
+    plan = finder.plan_run(tmp_path, process="jekyll", http=4000, livereload=35729)
+    assert plan["conflict"] == []
+    assert plan["http"] == 4000
+    assert plan["livereload"] == 35729
+
+
+def test_plan_run_conflict_when_jekyll_here(tmp_path):
+    finder = ServerFinder(MockAdapter(_jekyll(4000, 100, tmp_path)))
+    plan = finder.plan_run(tmp_path, process="jekyll", http=4000)
+    assert len(plan["conflict"]) == 1
+    assert plan["conflict"][0]["port"] == 4000
+
+
+def test_plan_run_dedupes_multi_port_server(tmp_path):
+    """A jekyll holding http+livereload is ONE conflict, not two."""
+    finder = ServerFinder(
+        MockAdapter(_jekyll(4000, 100, tmp_path, livereload_port=35729))
+    )
+    plan = finder.plan_run(tmp_path, process="jekyll", http=4000)
+    assert len(plan["conflict"]) == 1
+
+
+def test_plan_run_other_dir_does_not_conflict_and_drifts(tmp_path):
+    """blog4 on :4000 in another dir → no conflict, this repo drifts to :4001."""
+    other = tmp_path / "blog4"
+    other.mkdir()
+    here = tmp_path / "blog6"
+    here.mkdir()
+    finder = ServerFinder(MockAdapter(_jekyll(4000, 100, other, livereload_port=35729)))
+    plan = finder.plan_run(here, process="jekyll", http=4000, livereload=35729)
+    assert plan["conflict"] == []
+    assert plan["http"] == 4001
+    assert plan["http_owner"] == str(other)
+    assert plan["livereload"] == 35730
+
+
+def test_plan_run_non_matching_process_is_not_a_conflict(tmp_path):
+    """A serena/node server in this dir must not block a jekyll launch."""
+    finder = ServerFinder(
+        MockAdapter(
+            [
+                {
+                    "port": 24283,
+                    "pid": 200,
+                    "cwd": str(tmp_path),
+                    "name": "python",
+                    "cmdline": "serena start-mcp-server",
+                }
+            ]
+        )
+    )
+    plan = finder.plan_run(tmp_path, process="jekyll", http=4000)
+    assert plan["conflict"] == []
+    assert plan["http"] == 4000
+
+
+# --- run CLI tests ---
+
+
+def test_run_dry_run_substitutes_ports(runner, monkeypatch, tmp_path):
+    _patch_adapter(monkeypatch, [])
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--dir",
+            str(tmp_path),
+            "--process",
+            "jekyll",
+            "--http",
+            "4000",
+            "--livereload",
+            "35729",
+            "--dry-run",
+            "--",
+            "jekyll",
+            "serve",
+            "--port",
+            "{http}",
+            "--livereload-port",
+            "{livereload}",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "jekyll serve --port 4000 --livereload-port 35729" in result.stdout
+
+
+def test_run_fails_when_already_here(runner, monkeypatch, tmp_path):
+    _patch_adapter(monkeypatch, _jekyll(4000, 100, tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--dir",
+            str(tmp_path),
+            "--process",
+            "jekyll",
+            "--dry-run",
+            "--",
+            "jekyll",
+            "serve",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "already running here" in result.output
+
+
+def test_run_drifts_off_busy_port(runner, monkeypatch, tmp_path):
+    other = tmp_path / "blog4"
+    other.mkdir()
+    here = tmp_path / "blog6"
+    here.mkdir()
+    _patch_adapter(monkeypatch, _jekyll(4000, 100, other))
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--dir",
+            str(here),
+            "--process",
+            "jekyll",
+            "--http",
+            "4000",
+            "--dry-run",
+            "--",
+            "jekyll",
+            "serve",
+            "--port",
+            "{http}",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "jekyll serve --port 4001" in result.stdout
+
+
+def test_run_rejects_unfilled_livereload_placeholder(runner, monkeypatch, tmp_path):
+    _patch_adapter(monkeypatch, [])
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--dir",
+            str(tmp_path),
+            "--dry-run",
+            "--",
+            "jekyll",
+            "--livereload-port",
+            "{livereload}",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+
+
+# --- version command (used by callers to gate on capabilities) ---
+
+
+def test_version_prints_bare_semver(runner):
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0, result.output
+    out = result.stdout.strip()
+    assert out == running_servers.__version__
+    assert out.count(".") == 2  # X.Y.Z, no rich markup
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/shared/zsh_include.sh
+++ b/shared/zsh_include.sh
@@ -449,6 +449,11 @@ function safe_init()
     # On mac, gpt is in sbin, use the installed from idvorkin_nlp version instead
     alias_if_exists gpt ~/.local/bin/gpt
 
+    # oh-my-zsh's git plugin aliases `gc` to `git commit --verbose`, which
+    # shadows the Gas City `gc` binary. Free the name so `gc` resolves to the
+    # gascity CLI on PATH. Use `gcmsg` / `git commit -v` for commits instead.
+    unalias gc 2>/dev/null
+
     # Igor setups use Soed and Sodot as useful aliases
     alias Soed='nvim ~/settings/shared/zsh_include.sh'
     alias Sodot='.  ~/settings/shared/zsh_include.sh'


### PR DESCRIPTION
## What

Two new `running-servers` subcommands:

- **`run [--dir D] --process P --http N --livereload M -- CMD`** — launch a dev server only if one isn't already serving the directory. Fails fast on a same-dir duplicate; otherwise picks a free port (preferring the requested one), substitutes `{http}`/`{livereload}` into `CMD`, and `execvp`s it so stdout, Ctrl+C, and the exit code pass straight through. `--dry-run` prints the resolved command instead of executing.
- **`version`** — prints the bare semver so scripts can gate on capabilities. Bumped to **0.2.0** (the release introducing `run`).

Built entirely on the existing `find_for_directory` + `find_available_port` primitives — no new port↔dir mapping code. Decision logic factored into a pure `plan_run()` for testability.

## Why

`just jekyll-serve` across multiple blog checkouts died with "Address already in use" when another repo held :4000. `run` makes each repo coexist on a free port, and refuses to start a duplicate in the same directory. The blog's `jekyll-serve` recipe gates on `running-servers version >= 0.2.0`.

## Tests

`./py/test_running_servers.py` — 18 pass (guard, multi-port dedupe, drift, process-filter, dry-run substitution, placeholder validation, version). Live-verified across three real repos (blog4 :4000, blog6 :4001, blog5 :4002) — all served HTTP 200, the guard fired in each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.2.0

* **New Features**
  - Added `version` command to display application version
  - Added `--dry-run` option to preview resolved commands before execution
  - Improved port conflict detection with automatic port substitution
  - Enhanced `--livereload` option support for development servers

* **Bug Fixes**
  - Fixed shell alias conflict in zsh initialization preventing proper command resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->