### PR TITLE
fix(running-servers): surface cross-directory port conflicts in check

### DIFF
--- a/py/running_servers.py
+++ b/py/running_servers.py
@@ -434,6 +434,20 @@ def substitute_ports(tokens: list[str], http: int, livereload: int | None) -> li
     return out
 
 
+def _same_directory(dir_str: str, directory: Path) -> bool:
+    """True if a server's directory string refers to the same path as `directory`.
+
+    "unknown" counts as NOT the same: a port held by a process whose cwd we
+    can't read is still worth surfacing as a conflict rather than hiding.
+    """
+    if not dir_str or dir_str == "unknown":
+        return False
+    try:
+        return Path(dir_str).resolve() == directory.resolve()
+    except (OSError, ValueError):
+        return False
+
+
 # --- CLI Commands ---
 
 
@@ -577,6 +591,26 @@ def check(
         console.print(
             f"[yellow]✗[/yellow] No server with {criteria} in [cyan]{directory}[/cyan]"
         )
+        # The most useful diagnostic: the requested port may be held by a
+        # server in a DIFFERENT directory. That's why a new server can't bind
+        # and why curl on the port returns another checkout's stale content.
+        # Directory-scoped output alone hides this, so report it explicitly.
+        if expected_port is not None:
+            holder = finder.find_by_port(expected_port)
+            if holder and not _same_directory(holder["directory"], directory):
+                where = (
+                    f"a server in [cyan]{holder['directory']}[/cyan]"
+                    if holder["directory"] != "unknown"
+                    else "another process (directory unknown)"
+                )
+                console.print(
+                    f"[red]  ⚠ Port conflict:[/red] port {expected_port} is already "
+                    f"in use by {where} (pid {holder['pid']}): [dim]{holder['cmdline']}[/dim]"
+                )
+                console.print(
+                    "[dim]    A new server can't bind here — stop that one or "
+                    "use a different port.[/dim]"
+                )
         # Still show what is running in the dir so the caller can see the
         # stray processes that confused them.
         other = finder.find_for_directory(directory)

--- a/py/test_running_servers.py
+++ b/py/test_running_servers.py
@@ -406,5 +406,60 @@ def test_version_prints_bare_semver(runner):
     assert out.count(".") == 2  # X.Y.Z, no rich markup
 
 
+def test_check_port_conflict_in_other_directory_is_reported(
+    runner, monkeypatch, tmp_path
+):
+    """When --port is held by a server in a DIFFERENT directory, `check` must
+    surface that cross-directory conflict — the actual reason a new server
+    can't bind and stale content keeps being served. Regression for the
+    stale-jekyll-on-:4000 confusion where the failure message said only
+    "no server here" and gave no hint the port was occupied elsewhere.
+    """
+    target = tmp_path / "target"
+    target.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(other),
+                "name": "bundle",
+                "cmdline": "jekyll serve --port 4000",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["check", str(target), "--port", "4000"])
+    assert result.exit_code != 0, result.output
+    # The conflicting holder's directory must appear so the caller understands
+    # why their server won't start on this port.
+    assert str(other) in result.output, result.output
+    assert "4000" in result.output, result.output
+
+
+def test_check_port_match_in_target_dir_does_not_warn_conflict(
+    runner, monkeypatch, tmp_path
+):
+    """A matching server in the SAME directory is success, not a conflict —
+    the cross-directory warning must not fire."""
+    _patch_adapter(
+        monkeypatch,
+        [
+            {
+                "port": 4000,
+                "pid": 100,
+                "cwd": str(tmp_path),
+                "name": "bundle",
+                "cmdline": "jekyll serve --port 4000",
+            }
+        ],
+    )
+    result = runner.invoke(app, ["check", str(tmp_path), "--port", "4000"])
+    assert result.exit_code == 0, result.output
+    assert "conflict" not in result.output.lower(), result.output
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

`running-servers check <dir> --port N` is directory-scoped. When port `N` is held by a server in a **different** directory, the check reported only:

```
✗ No server with port 4000 in /home/developer/gits/blog5
  Other servers in this directory: ...
```

...with no hint that the port was actually occupied by a server elsewhere. This hides a real failure mode: a stale Jekyll from another blog checkout squats on `:4000`, a freshly-started server **silently fails to bind**, and `curl localhost:4000` keeps returning the other checkout's stale content. (Hit exactly this while screenshotting a blog PR — chased phantom "false negatives" before finding the stale server by hand.)

My first guess was that `--process jekyll` failed because the process shows as `bundle`, not `jekyll`. Investigation disproved that — the filter matches on the full cmdline, which contains `jekyll`. The real gap is the missing cross-directory port-conflict diagnostic.

## Fix

The failure path now looks up the requested port globally. When the holder is in another directory (or its cwd is unreadable), it prints:

```
✗ No server with port 4999 in /home/developer/gits/blog5
  ⚠ Port conflict: port 4999 is already in use by a server in /tmp (pid 1556712): python3 -m http.server 4999
    A new server can't bind here — stop that one or use a different port.
```

- New `_same_directory()` helper (resolves both paths; treats `"unknown"` cwd as a conflict worth surfacing rather than hiding).
- Conflict check only fires on the `--port` failure path; a same-directory match is still success (no false conflict).

## Tests

Two regression tests added (`test_check_port_conflict_in_other_directory_is_reported`, `test_check_port_match_in_target_dir_does_not_warn_conflict`). Followed TDD — watched the conflict test fail (holder dir absent from output) before implementing. Full suite: **10 passed**. `ruff` + pre-commit clean.

## Not fixed (noted, no evidence it fired)

`LinuxAdapter.get_listening_ports()` parses `ss -tlnp` line-by-line; `ss` can wrap long socket lines, which would silently drop a port. Latent robustness issue — left alone since I couldn't reproduce it and it's a separate concern. Happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
