### PR TITLE
fix(a): w4 went to workspace 3; alfred emitted underscored command names

### DIFF
--- a/py/a.py
+++ b/py/a.py
@@ -335,7 +335,7 @@ def w3():
 
 @app.command()
 def w4():
-    call_aerospace("workspace 3")
+    call_aerospace("workspace 4")
 
 
 @app.command()
@@ -460,7 +460,7 @@ def alfred():
     #  Build a json of commands to be called from an alfred plugin workflow
     # start by reflecting to find all commands in app.
     # all_commands = app.
-    commands = [c.callback.__name__.replace("-", "_") for c in app.registered_commands]  # type:ignore
+    commands = [c.callback.__name__.replace("_", "-") for c in app.registered_commands]  # type:ignore
     items = [AlfredItems.Item(title=c, subtitle=c, arg=c) for c in commands]
     alfred_items = AlfredItems(items=items)
     print(alfred_items.model_dump_json(indent=4))


### PR DESCRIPTION
Part of #86.

Two bugs in `py/a.py`:

- **`w4` switched to workspace 3** — copy-paste from `w3`. Now `workspace 4`, matching the `alt-4` binding in `shared/aerospace.toml`.
- **`alfred()` emitted command names Typer doesn't recognize** — `.replace("-", "_")` is a no-op on Python function names; the intent (as done correctly in `ai_clip.py`) was `.replace("_", "-")`. Typer 0.26 registers `alfred_windows` as `alfred-windows`, and the Alfred workflow pipes the emitted `arg` straight back into `a $*`, so underscored names failed with "No such command".

CR (subagent code-reviewer): **approve** — verified Typer's dash registration empirically against this repo's deps and confirmed the Alfred workflow hardcodes dash-style names; no consumer relies on underscored output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed workspace 4 command to switch to the correct workspace
  * Updated command identifier naming convention to convert underscores to dashes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->