### PR TITLE
fix(vim_python): include _td posts in RandomBlogPost candidates

### DIFF
--- a/py/vim_python.py
+++ b/py/vim_python.py
@@ -144,7 +144,7 @@ def RandomBlogPost():
     files = []
     files.extend(list(blog_path.glob("_posts/*md")))
     files.extend(list(blog_path.glob("_d/*md")))
-    list(blog_path.glob("_td/*md"))
+    files.extend(list(blog_path.glob("_td/*md")))
     random_post = random.choice(files)
     print(random_post)
 


### PR DESCRIPTION
Part of #86.

`RandomBlogPost` computed `list(blog_path.glob("_td/*md"))` and discarded the result — missing the `files.extend()` its sibling lines have — so `_td` posts could never be picked.

CR (subagent code-reviewer): **approve** — git history shows commit `7b73a44` (2022) refactored a single `*/*md` glob (which *did* include `_td`) into three per-directory globs and dropped the assignment on the third, so this was a regression, not a deliberate exclusion. Live check: `_td/` has 51 markdown files that now re-enter the pool (~15% of 346 candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)