### PR TITLE
fix(web_to_markdown): honor the --remove-links option

### DIFF
--- a/py/web_to_markdown.py
+++ b/py/web_to_markdown.py
@@ -43,7 +43,7 @@ def main(
     if response.status_code == 200:
         html_content = response.text
         text_maker = html2text.HTML2Text()
-        text_maker.ignore_links = True
+        text_maker.ignore_links = remove_links
         text_maker.body_width = 0
         markdown_output = text_maker.handle(html_content)
 


### PR DESCRIPTION
Part of #86.

`ignore_links` was hardcoded to `True`, so links were always stripped and the `--remove-links` option (default `False`) did nothing.

⚠️ **Behavior change**: links are now *kept* by default; pass `--remove-links` to get the old always-strip behavior.

CR (subagent code-reviewer): **approve** — audited the whole repo for callers (shell configs, scripts, aliases, nvim); the only references are in historical chat logs, so nothing automated relies on the old default. Only human muscle memory is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)