### PR TITLE
fix(tmux_helper): scope session pane listing to the session, not the server

### DIFF
--- a/py/tmux_helper.py
+++ b/py/tmux_helper.py
@@ -670,7 +670,7 @@ def session_exists(session: str) -> bool:
 def get_session_pane_pids(session: str) -> list[int]:
     """Get all pane PIDs in a session"""
     result = run_tmux_command(
-        ["tmux", "list-panes", "-t", session, "-a", "-F", "#{pane_pid}"],
+        ["tmux", "list-panes", "-s", "-t", session, "-F", "#{pane_pid}"],
         capture_output=True,
     )
     if not result:


### PR DESCRIPTION
Part of #86.

`get_session_pane_pids` used `tmux list-panes -t <session> -a`, but `-a` overrides `-t` and lists every pane on the server. Its only caller, `is_process_running_in_session`, therefore matched processes running in *any* session, and `launch_servers` silently skipped creating windows whenever jekyll/btm/caffeinate ran anywhere. Now uses `list-panes -s -t <session>`.

CR (subagent code-reviewer): **approve** — verified live on tmux 3.6a with two test sessions (old form returned all 5 panes server-wide; new form returned only the target session's 2). Confirmed the two other `-a` usages in the file are intentionally server-wide (no `-t`) and correctly left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)