### PR TITLE
fix(brew_check): don't crash when brew is not installed

### DIFF
--- a/py/brew_check.py
+++ b/py/brew_check.py
@@ -143,11 +143,14 @@ def is_formula_installed(name: str, installed_norm: set[str]) -> bool:
     if normalize_name(name) in installed_norm:
         return True
     # Second-chance: let brew resolve the name
-    result = subprocess.run(
-        ["brew", "list", "--formula", name],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["brew", "list", "--formula", name],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
     return result.returncode == 0
 
 
@@ -157,7 +160,9 @@ def get_missing_by_category(
     """Get missing packages organized by category."""
     missing_formula_cats = []
     for cat, pkgs in FORMULA_CATEGORIES:
-        missing = [p for p in pkgs if not is_formula_installed(p, installed_formulae_norm)]
+        missing = [
+            p for p in pkgs if not is_formula_installed(p, installed_formulae_norm)
+        ]
         if missing:
             missing_formula_cats.append((cat, missing))
 


### PR DESCRIPTION
Part of #86.

`get_installed_packages` degrades gracefully when brew is absent, but execution then reached `is_formula_installed`'s second-chance `brew list` call, which raised an unhandled `FileNotFoundError` on the first package — a traceback instead of the intended "everything missing" listing. A missing brew is now treated as "not installed".

CR (subagent code-reviewer): **approve** — traced every `brew` subprocess call in the file; this was the only unguarded call on the read-only no-brew path. The install-path calls (`brew tap`/`brew install`) only run after explicit user opt-in (`--install`/`--pick`/confirm prompt) and are correctly left unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)