### PR TITLE
security: redact leaked API keys from chop-log env dump

### DIFF
--- a/zz-chop-logs/2025-05-26_17-06-code-review-y-py-vs-clean-code-principles.md
+++ b/zz-chop-logs/2025-05-26_17-06-code-review-y-py-vs-clean-code-principles.md
@@ -117,10 +117,10 @@ That's fine. Uhm ... Something is wrong when I do tab completion -- ➜  ~ y flo
 │ ╭──────────────────────────────────────────────────────── locals ────────────────────────────────────────────────────────╮                                  │
 │ │  key = 'COMP_WORDS'                                                                                                    │                                  │
 │ │ self = environ({                                                                                                       │                                  │
-│ │        │   'ANTHROPIC_API_KEY': 'sk-ant-api03-sdHW4WeUfa0VcxWYvfLEXMI7rSMqr6ALR_s1Gbdje7I84nftE7VHU_QsmQS81B3S7ZJ'+28, │                                  │
-│ │        │   'ASSEMBLYAI_API_KEY': '95a59ff20a1349499422d4b0e5e59e42',                                                   │                                  │
+│ │        │   'ANTHROPIC_API_KEY': '<REDACTED — rotated>',                                                              │                                  │
+│ │        │   'ASSEMBLYAI_API_KEY': '<REDACTED — rotated>',                                                             │                                  │
 │ │        │   'ATUIN_HISTORY_ID': '',                                                                                     │                                  │
-│ │        │   'ATUIN_SESSION': '01970e6ca9b077e1b80e8e0505f47e55',                                                        │                                  │
+│ │        │   'ATUIN_SESSION': '<REDACTED>',                                                                            │                                  │
 │ │        │   'BING_SEARCH_URL': 'https://api.bing.microsoft.com/v7.0/search',                                            │                                  │
 │ │        │   'CARAPACE_BRIDGES': 'zsh',                                                                                  │                                  │
 │ │        │   'COLORFGBG': '15;0',                                                                                        │                                  │


### PR DESCRIPTION
## ⚠️ Action required: rotate these keys now

A rich traceback in `zz-chop-logs/2025-05-26_17-06-code-review-y-py-vs-clean-code-principles.md` captured `os.environ`, leaking secrets into this **public** repo. Committed `36b971f` on 2025-05-26 — exposed for ~1 year. **Assume fully harvested.**

| Secret | Exposure | Action |
| --- | --- | --- |
| `ANTHROPIC_API_KEY` | Partial (80 chars visible, 28 hidden by rich's `+28`) | Rotate at console.anthropic.com |
| `ASSEMBLYAI_API_KEY` | **Full** (32-char hex) | Rotate in AssemblyAI dashboard |
| `ATUIN_SESSION` | Full session token | `atuin logout && atuin login` to regenerate |

## What this PR does

Redacts the three values from `main`, removing them from the public blob. **This does not remove them from git history** — they remain in `36b971f`. Since the repo is public and the keys have been exposed for a year, rotation is the only real remediation; a history rewrite (`git filter-repo`) is optional cleanup and would require a force-push to `main`, so I've left that decision to you.

## Scope of the leak (assessed)

Scanned all 1979 commits (raw blob grep across every git object) plus the full working tree. **This is the only leak** — the `... +64` truncation in the dump means the other 64 env vars never reached the file. No other secrets anywhere in the repo or its history. The only other env-dump-shaped block in `zz-chop-logs/` is this same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)