### PR TITLE
herdr: tmux-parity config, agent sidebar, and docs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,6 +71,10 @@ ln -s -f ~/settings/config/mcphub ~/.config/mcphub
 ln -s -f ~/settings/config/mpv ~/.config/mpv
 ln -s -f ~/settings/config/ghostty ~/.config/ghostty
 
+# herdr keeps logs/sockets in ~/.config/herdr, so link only the config file
+mkdir -p ~/.config/herdr
+ln -s -f ~/settings/config/herdr/config.toml ~/.config/herdr/config.toml
+
 # Cursor config (official location is ~/.cursor but also link to ~/.config/cursor for consistency)
 ln -s -f ~/settings/config/cursor ~/.config/cursor
 ln -s -f ~/settings/config/cursor ~/.cursor

--- a/config/cursor/herdr-agent-state.sh
+++ b/config/cursor/herdr-agent-state.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=cursor
+# HERDR_INTEGRATION_VERSION=1
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-cursor-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:cursor"
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+def first_text(*keys):
+    for key in keys:
+        value = hook_input.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+hook_event_name = first_text("hook_event_name", "hookEventName")
+if hook_event_name not in (None, "sessionStart"):
+    raise SystemExit(0)
+
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = first_text("session_id", "sessionId", "conversation_id", "conversationId")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+if agent_session_id:
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": {
+            "pane_id": pane_id,
+            "source": source,
+            "agent": "cursor",
+            "seq": report_seq,
+            "agent_session_id": agent_session_id,
+        },
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/config/cursor/hooks.json
+++ b/config/cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+	"hooks": {
+		"sessionStart": [
+			{
+				"command": "bash '/Users/idvorkin/.cursor/herdr-agent-state.sh' session"
+			}
+		]
+	},
+	"version": 1
+}

--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -1,0 +1,191 @@
+# herdr
+
+Terminal workspace manager for AI coding agents — a tmux-shaped multiplexer that
+also tracks which panes are running an agent and what state each one is in.
+
+- Config: [`config.toml`](config.toml), symlinked to `~/.config/herdr/config.toml`
+  by [`bootstrap.sh`](../../bootstrap.sh).
+- Only the file is symlinked, not the directory — herdr writes logs, sockets, and
+  `session.json` into `~/.config/herdr`.
+- Validate: `herdr config check` · Reload: `prefix+r` or `herdr server reload-config`
+
+## Mental model
+
+The container hierarchy is three levels deep and maps cleanly onto tmux:
+
+| herdr     | tmux    | notes                                   |
+| --------- | ------- | --------------------------------------- |
+| session   | server  | named, persistent; usually just one     |
+| workspace | session | **also called a "space"** — see below   |
+| tab       | window  |                                         |
+| pane      | pane    |                                         |
+
+**"Space" and "workspace" are the same thing.** herdr's docs use "space" only in
+the sidebar/agent-panel settings (`agent_panel_sort`, `[ui.sidebar.spaces]`);
+every command and keybinding says "workspace". Per the default config:
+`"workspaces" is accepted as an alias for "spaces"`. There is no separate
+fourth container.
+
+**An "agent" is not a container.** It is a property of a pane. When herdr detects
+a supported AI CLI running in a pane, that pane also shows up in the agent panel
+with a live status (`working` / `idle` / `unknown`). The agent panel is a
+cross-cutting view over panes, not a place things live.
+
+```
+session "default"
+└── workspace w1  "settings"          <- a "space"
+    ├── tab w1:t1 └── pane w1:p1      <- claude here => shows in agent panel
+    ├── tab w1:t2 └── pane w1:p2      <- claude here => shows in agent panel
+    └── tab w1:t3 └── pane w1:p3      <- plain shell => not an agent
+```
+
+### Gotcha: the agent panel groups by workspace, and cannot show cwd
+
+If two agents are working in different repos but live in the same workspace, the
+agent panel lists both under that one workspace name — which reads as though both
+are in the same repo. That is a display limitation, not stale data: `herdr pane list`
+reports the correct distinct `cwd` for each pane.
+
+Two things combine to cause it:
+
+1. `agent_panel_sort = "spaces"` groups agent rows by workspace.
+2. The default agent row is `rows = [["state_icon", "workspace", "tab"], ["agent"]]`,
+   and the built-in row tokens are `state_icon`, `state_text`, `workspace`, `tab`,
+   `pane`, `agent`, `terminal_title`, `terminal_title_stripped`. **There is no `cwd`
+   token** — a working directory column is not available without plumbing custom
+   pane metadata over the socket API.
+
+A workspace label is just a name; it does not constrain what a pane inside it can
+`cd` to. So opening extra tabs in an existing workspace for *other* repos is what
+produces the confusing panel.
+
+Ways to fix it, best first:
+
+- **One workspace per repo** (`prefix+shift+n`). This is what the agent panel is
+  designed around, and it makes the workspace column meaningful again.
+  Note `herdr tab` has **no move command** — a tab cannot be relocated to another
+  workspace after the fact, so start the agent in the right workspace.
+- **Surface the task instead of the location** — show the agent's terminal title,
+  which Claude Code sets to the current task:
+  ```toml
+  [ui.sidebar.agents.rows_by_agent]
+  claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+  ```
+- **Sort by attention instead of grouping** — `agent_panel_sort = "priority"` turns
+  the panel into a queue of who needs you, making the workspace grouping moot.
+
+## Keybindings
+
+Prefix is `ctrl+a`, matching `shared/.tmux.conf` (herdr's default is `ctrl+b`,
+which collides with vi paging). Everything below is set in [`config.toml`](config.toml);
+entries marked ✱ override a herdr default to restore tmux muscle memory.
+
+### Session
+
+| Keys             | Action        | tmux                    |
+| ---------------- | ------------- | ----------------------- |
+| `prefix+?`       | help          | `?` list-keys           |
+| `prefix+d`       | detach ✱      | `d` detach              |
+| `prefix+r`       | reload config ✱ | `r` source-file        |
+| `prefix+shift+r` | resize mode   | —                       |
+| `prefix+s`       | settings      | —                       |
+| `prefix+b`       | toggle sidebar | —                      |
+
+### Workspaces (tmux sessions)
+
+| Keys             | Action              | tmux                    |
+| ---------------- | ------------------- | ----------------------- |
+| `prefix+w`       | workspace picker    | `w` → `rmux_helper pick-tui` |
+| `prefix+(`       | previous workspace  | `(` switch-client -p    |
+| `prefix+)`       | next workspace      | `)` switch-client -n    |
+| `prefix+$`       | rename workspace ✱  | `$` rename-session      |
+| `prefix+shift+n` | new workspace       | —                       |
+| `prefix+shift+d` | close workspace     | prompts, `confirm_close = true` |
+| `prefix+shift+g` | new git worktree    | herdr-only              |
+| `prefix+g`       | goto                | herdr-only              |
+
+### Tabs (tmux windows)
+
+| Keys           | Action        | tmux                 |
+| -------------- | ------------- | -------------------- |
+| `prefix+c`     | new tab       | `c` new-window       |
+| `prefix+n`     | next tab      | `n` next-window      |
+| `prefix+p`     | previous tab  | `p` previous-window  |
+| `prefix+1..9`  | switch tab    | `1-9` select-window  |
+| `prefix+,`     | rename tab ✱  | `,` rename-window    |
+| `prefix+&`     | close tab ✱   | `&` kill-window      |
+
+### Panes
+
+| Keys             | Action                | tmux                    |
+| ---------------- | --------------------- | ----------------------- |
+| `prefix+%`       | split side-by-side ✱  | `%` split-window -h     |
+| `prefix+"`       | split stacked ✱       | `"` split-window -v     |
+| `prefix+x`       | close pane            | `x` kill-pane           |
+| `prefix+z`       | zoom                  | `z` resize-pane -Z      |
+| `prefix+h/j/k/l` | focus left/down/up/right | vim-style            |
+| `prefix+o`       | cycle next pane ✱     | `o` select-pane -t :.+  |
+| `prefix+ctrl+o`  | cycle previous pane   | `C-o` rotate-window     |
+| `prefix+;`       | last pane ✱           | `;` last-pane           |
+| `prefix+{` / `}` | swap pane up/down     | `{` / `}` swap-pane     |
+| `prefix+shift+k` / `shift+j` | swap pane up/down | —           |
+| `prefix+shift+p` | rename pane           | —                       |
+
+Verified against `herdr pane layout`: `split_vertical` produces a pane to the
+**right** (tmux `%`), `split_horizontal` produces one **below** (tmux `"`). The
+names are the opposite of tmux's flag naming, which is why the config comments
+call it out.
+
+### Scrollback and popups
+
+| Keys            | Action                                  |
+| --------------- | --------------------------------------- |
+| `prefix+v`      | copy mode (tmux `C-a v`, mode-keys vi)  |
+| `prefix+e`      | dump scrollback into `$EDITOR` — herdr-only |
+| `prefix+ctrl+g` | lazygit popup, 90% × 90%                |
+| `prefix+ctrl+t` | `tig status` popup, 90% × 90%           |
+
+Popups mirror the `:tig` / `:gdiff` command aliases in `shared/.tmux.conf`.
+
+## CLI
+
+The CLI drives the running server over its unix socket and returns JSON — handy
+for scripting and for checking what the UI is actually reporting.
+
+```bash
+herdr                          # launch or attach to the persistent session
+herdr status                   # client and server status
+herdr session list             # named sessions
+herdr workspace list           # workspaces (spaces)
+herdr tab list                 # tabs
+herdr pane list                # panes — the only view with per-pane cwd
+herdr agent list               # panes running a detected agent, with status
+herdr agent explain            # why a pane did or did not register as an agent
+herdr config check             # validate config.toml
+herdr server reload-config     # apply config.toml without restarting
+```
+
+Pipe through `python3 -m json.tool` to read the output comfortably.
+
+## Agent integrations
+
+`herdr integration install <agent>` writes hooks that let an agent report its
+session id back to herdr, which is what drives live status in the agent panel.
+Supported: `claude`, `codex`, `cursor`, `copilot`, `devin`, `droid`, `kimi`,
+`opencode`, `kilo`, `hermes`, `qodercli`, `mastracode`, `pi`, `omp`.
+
+Installed here:
+
+- **cursor** → [`../cursor/herdr-agent-state.sh`](../cursor/herdr-agent-state.sh)
+  and [`../cursor/hooks.json`](../cursor/hooks.json). These land in this repo
+  because `~/.cursor` is symlinked to `config/cursor`, so they travel to new
+  machines via `bootstrap.sh`.
+- **claude** → hooks in `~/.claude/settings.json`, which is **not** tracked in this
+  repo. Re-run `herdr integration install claude` on a new machine.
+
+Both generated Cursor files carry a `managed by herdr` header and are overwritten
+on reinstall or upgrade — add custom hooks in sibling files rather than editing
+them. `hooks.json` also hardcodes an absolute `~/.cursor` path, so it is
+macOS-specific as written. Note that pre-commit's Biome reformats `hooks.json`
+(tabs, trailing newline), so it will show as modified again after a reinstall;
+the JSON is semantically unchanged.

--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -63,14 +63,17 @@ Ways to fix it, best first:
 
 - **One workspace per repo** (`prefix+shift+n`). This is what the agent panel is
   designed around, and it makes the workspace column meaningful again.
-  Note `herdr tab` has **no move command** — a tab cannot be relocated to another
-  workspace after the fact, so start the agent in the right workspace.
+  Note `herdr tab` has **no move command**, so a tab cannot be relocated wholesale.
+  Individual panes can move, though — `herdr pane move <PANE_ID> --tab <TAB_ID>`,
+  and tab ids are workspace-scoped (`w2:t3`), so it should reach another
+  workspace's tab.
 - **Surface the task instead of the location** — show the agent's terminal title,
-  which Claude Code sets to the current task:
-  ```toml
-  [ui.sidebar.agents.rows_by_agent]
-  claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
-  ```
+  which Claude Code keeps set to the current task. This is configured in
+  [`config.toml`](config.toml). Note it is **opt-in**: `rows_by_agent` appears in
+  `herdr --default-config` only as a commented example, and the real built-in
+  default is `rows = [["state_icon", "workspace", "tab"], ["agent"]]` — two lines
+  per agent, with no title. Without setting it explicitly the panel shows only
+  workspace, tab, and agent name.
 - **Sort by attention instead of grouping** — `agent_panel_sort = "priority"` turns
   the panel into a queue of who needs you, making the workspace grouping moot.
 

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -107,3 +107,14 @@ prompt_new_tab_name = false
 mouse_capture = true
 confirm_close = true
 agent_panel_sort = "spaces"
+
+# Show what each agent is working on. Claude Code keeps its terminal title set
+# to the current task, so terminal_title_stripped is a live "what am I doing"
+# field. Not on by default -- rows_by_agent is opt-in, the built-in default is
+# just [["state_icon", "workspace", "tab"], ["agent"]].
+[ui.sidebar.agents.rows_by_agent]
+claude = [
+  ["state_icon", "workspace", "tab"],
+  ["terminal_title_stripped"],
+  ["agent"],
+]

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -113,8 +113,10 @@ agent_panel_sort = "spaces"
 # field. Not on by default -- rows_by_agent is opt-in, the built-in default is
 # just [["state_icon", "workspace", "tab"], ["agent"]].
 [ui.sidebar.agents.rows_by_agent]
+# No "agent" row -- every agent here is claude, so the label is pure noise.
+# No cwd token exists, but with one workspace per repo the workspace label is
+# effectively the directory.
 claude = [
   ["state_icon", "workspace", "tab"],
   ["terminal_title_stripped"],
-  ["agent"],
 ]

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -1,0 +1,109 @@
+# herdr configuration — tmux-parity keybindings
+#
+# Symlinked from ~/.config/herdr/config.toml (see bootstrap.sh).
+# Herdr writes logs/sockets into ~/.config/herdr, so only this file is
+# symlinked, not the whole directory.
+#
+# Goal: reuse the muscle memory from ~/settings/shared/.tmux.conf.
+# Concept mapping:  tmux session -> herdr workspace
+#                   tmux window  -> herdr tab
+#                   tmux pane    -> herdr pane
+#
+# Reload after editing:  prefix+r  (or `herdr server reload-config`)
+# Validate:              herdr config check
+
+onboarding = false
+
+[keys]
+# ---------------------------------------------------------------------------
+# Prefix — C-a, same as tmux (default herdr is ctrl+b, which vi uses).
+# ---------------------------------------------------------------------------
+prefix = "ctrl+a"
+
+# --- session-level -----------------------------------------------------------
+help = "prefix+?"                     # tmux: ? list-keys
+detach = "prefix+d"                   # tmux: d detach                 (herdr default: prefix+q)
+reload_config = "prefix+r"            # tmux: r source-file ~/.tmux.conf (herdr default: prefix+shift+r)
+resize_mode = "prefix+shift+r"        # displaced by reload_config above
+settings = "prefix+s"
+toggle_sidebar = "prefix+b"
+
+# --- workspaces (tmux sessions) ---------------------------------------------
+workspace_picker = "prefix+w"         # tmux: C-a w -> rmux_helper pick-tui
+previous_workspace = "prefix+("       # tmux: ( switch-client -p
+next_workspace = "prefix+)"           # tmux: ) switch-client -n
+rename_workspace = "prefix+$"         # tmux: $ rename-session        (herdr default: prefix+shift+w)
+new_workspace = "prefix+shift+n"
+close_workspace = "prefix+shift+d"    # prompts (ui.confirm_close = true)
+new_worktree = "prefix+shift+g"
+goto = "prefix+g"
+# switch_workspace = "prefix+shift+1..9"   # optional direct workspace jump
+
+# --- tabs (tmux windows) -----------------------------------------------------
+new_tab = "prefix+c"                  # tmux: c new-window
+next_tab = "prefix+n"                 # tmux: n next-window
+previous_tab = "prefix+p"             # tmux: p previous-window
+switch_tab = "prefix+1..9"            # tmux: 1-9 select-window (base-index 1)
+rename_tab = "prefix+comma"           # tmux: , rename-window         (herdr default: prefix+shift+t)
+close_tab = "prefix+&"                # tmux: & kill-window           (herdr default: prefix+shift+x)
+
+# --- panes -------------------------------------------------------------------
+# Verified against `herdr pane layout`: split_vertical -> "right" (side by
+# side, tmux %), split_horizontal -> "down" (stacked, tmux ").
+split_vertical = "prefix+%"           # tmux: % split-window -h       (herdr default: prefix+v)
+split_horizontal = 'prefix+"'         # tmux: " split-window -v       (herdr default: prefix+minus)
+close_pane = "prefix+x"               # tmux: x kill-pane
+zoom = "prefix+z"                     # tmux: z resize-pane -Z
+rename_pane = "prefix+shift+p"
+
+focus_pane_left = "prefix+h"
+focus_pane_down = "prefix+j"
+focus_pane_up = "prefix+k"
+focus_pane_right = "prefix+l"
+
+cycle_pane_next = "prefix+o"          # tmux: o select-pane -t :.+    (herdr default: prefix+tab)
+cycle_pane_previous = "prefix+ctrl+o" # tmux: C-o rotate-window
+last_pane = "prefix+;"                # tmux: ; last-pane             (herdr default: unbound)
+
+swap_pane_left = "prefix+{"           # tmux: { swap-pane -U
+swap_pane_right = "prefix+}"          # tmux: } swap-pane -D
+swap_pane_up = "prefix+shift+k"
+swap_pane_down = "prefix+shift+j"
+
+# --- scrollback / copy -------------------------------------------------------
+copy_mode = "prefix+v"                # tmux: C-a v / V copy-mode (mode-keys vi)
+edit_scrollback = "prefix+e"          # herdr-only: dump scrollback into $EDITOR
+
+# --- notifications -----------------------------------------------------------
+open_notification_target = "prefix+shift+o"  # displaced by cycle_pane_next
+
+# Navigate-mode movement (local shortcuts while the navigator is open).
+navigate_workspace_up = "up"
+navigate_workspace_down = "down"
+navigate_pane_left = "h"
+navigate_pane_down = "j"
+navigate_pane_up = "k"
+navigate_pane_right = "l"
+
+# --- popups (mirrors the :tig / :gdiff tmux command aliases) ------------------
+[[keys.command]]
+key = "prefix+ctrl+g"
+type = "popup"
+command = "lazygit"
+width = "90%"
+height = "90%"
+
+[[keys.command]]
+key = "prefix+ctrl+t"
+type = "popup"
+command = "tig status"
+width = "90%"
+height = "90%"
+
+[ui]
+# tmux `c` creates a window immediately; don't prompt for a name.
+prompt_new_tab_name = false
+# tmux: set -g mouse on
+mouse_capture = true
+confirm_close = true
+agent_panel_sort = "spaces"


### PR DESCRIPTION
Adds [herdr](https://github.com/) config to the repo so it travels to other machines via `bootstrap.sh`.

## What's here

- **`config/herdr/config.toml`** — keybindings mapped onto the muscle memory from `shared/.tmux.conf`: `C-a` prefix, workspace/tab/pane bindings mirroring tmux sessions/windows/panes, plus lazygit and `tig status` popups matching the `:tig`/`:gdiff` aliases.
- **`bootstrap.sh`** — symlinks only `config.toml`, not the directory, since herdr writes logs, sockets, and `session.json` into `~/.config/herdr`.
- **`config/herdr/README.md`** — the workspace/tab/pane model and the full tmux keymap table.
- **`config/cursor/{herdr-agent-state.sh,hooks.json}`** — herdr's Cursor integration, which lands in this repo because `~/.cursor` is symlinked to `config/cursor`.

## Agent sidebar

The panel's built-in default is two lines per agent (state icon, workspace, tab / agent name), so several agents in one workspace render identically. `rows_by_agent` is opt-in — it appears in `herdr --default-config` only as a commented example, not an active default. Set explicitly here to show `terminal_title_stripped`, which Claude Code keeps set to the current task, and to drop the redundant `claude` label.

## Notes for other machines

- The Claude integration lives in `~/.claude/settings.json`, which is **not** tracked here — run `herdr integration install claude` after pulling.
- `config/cursor/hooks.json` hardcodes an absolute `~/.cursor` path, so it's macOS-specific as written.
- Pre-commit's Biome reformats `hooks.json` (tabs, trailing newline); herdr rewrites it with spaces on reinstall, so expect it to show dirty again after `herdr integration install cursor`. The JSON is semantically unchanged.

Verified with `herdr config check` (`config: ok`) and `herdr server reload-config` (`status: applied`, no diagnostics).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `herdr` setup during environment bootstrapping, including automatic configuration linking.
  * Added Cursor session integration to report agent session state.
  * Added a comprehensive `herdr` configuration with tmux-style shortcuts, navigation, pane management, popups, notifications, and UI preferences.

* **Documentation**
  * Added setup, usage, keybinding, CLI, and agent integration documentation for `herdr`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->