### PR TITLE
finicky: fix v4 rewrite API, route more domains to Chrome

### DIFF
--- a/mac/.finicky.js
+++ b/mac/.finicky.js
@@ -48,6 +48,7 @@ export default {
 			match: [
 				/fburl\.com/i,
 				/internalfb\.com/i,
+				/internalmeta\.com/i,
 				/fb\.facebook\.com/i,
 				/fb\.workplace\.com/i,
 				/docs\.google\.com/i,
@@ -55,6 +56,8 @@ export default {
 				/fb\.okta\.com/i,
 				/drive\.google\.com\/drive\/folders/i,
 				/fb\.quip\.com/i,
+				/ghe\.oculus-rep\.com/i,
+				/github\.com/i,
 			],
 			browser: "Google Chrome",
 		},

--- a/mac/.finicky.js
+++ b/mac/.finicky.js
@@ -9,8 +9,8 @@ export default {
 	// Rewrite all http URLs to https
 	rewrite: [
 		{
-			match: ({ url }) => url.protocol === "http:",
-			url: ({ url }) => url.href.replace(/^http:/, "https:"),
+			match: (url) => url.protocol === "http:",
+			url: (url) => url.href.replace(/^http:/, "https:"),
 		},
 	],
 

--- a/mac/.finicky.js
+++ b/mac/.finicky.js
@@ -1,7 +1,7 @@
 // ~/.finicky.js
 
 export default {
-	defaultBrowser: "Microsoft Edge",
+	defaultBrowser: "Google Chrome",
 
 	// Optional: Disable logging requests to disk
 	logRequests: false,


### PR DESCRIPTION
## What

Three finicky changes, split out of a long-lived local branch.

- **`finicky: pass URL instance directly to rewrite fns (v4 API)`** — the real bug fix. The `rewrite` handlers were destructuring `({ url })`, which is the v3 signature; finicky v4 passes the `URL` instance directly. Without this the http→https rewrite silently stops firing.
- **`finicky: route internalmeta, GHE, and github to Chrome`** — adds `internalmeta.com`, `ghe.oculus-rep.com`, and `github.com` to the existing Chrome match list, alongside the `fburl.com` / `internalfb.com` / `fb.okta.com` entries already there.
- **`finicky: default to Chrome to avoid auth issues`** — flips `defaultBrowser` from Microsoft Edge to Google Chrome.

## Test plan

`~/.finicky.js` symlinks to `mac/.finicky.js`, so this config has been running live on my Mac since June.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Google Chrome is now the default browser.
  * Added routing support for additional GitHub and internal-tools URLs.
  * Updated URL rewrite handling for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->