### PR TITLE
tooling: justfile rinstall on dirty tree, all-platform pyperclip, gitignore fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,7 +257,8 @@ lazy-lock.json
 # Private individual user cursor rules
 .cursor/rules/_*.mdc
 # Claude local settings (should not be committed)
-.claude/settings.local.json
+# Leading **/ so this also catches per-platform dirs like mac/.claude/
+**/.claude/settings.local.json
 # SpecStory explanation file
 .specstory/.what-is-this.md
 # Cursor extensions directory

--- a/justfile
+++ b/justfile
@@ -30,11 +30,12 @@ rinstall:
     set -euo pipefail
     cd rust/tmux_helper
     current_hash=$(git rev-parse --short HEAD)
+    dirty=$(git status --porcelain -- . | head -n1)
     installed_version=$(rmux_helper --version 2>/dev/null || echo "")
-    if [[ "$installed_version" == *"$current_hash"* ]]; then
+    if [[ -z "$dirty" && "$installed_version" == *"$current_hash"* ]]; then
         echo "rmux_helper already up-to-date ($current_hash)"
     else
-        echo "Building and installing rmux_helper ($current_hash)..."
+        echo "Building and installing rmux_helper ($current_hash${dirty:+ +dirty})..."
         cargo install --path . --force
     fi
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rich",
     "icecream",
     "pydantic",
-    "pyperclip; sys_platform == 'darwin'",
+    "pyperclip",
     "pyautogui; sys_platform == 'darwin'",
     "pyobjc; sys_platform == 'darwin'",
     "httpx",


### PR DESCRIPTION
## What

Three small independent tooling fixes, split out of a long-lived local branch.

- **`just: rinstall rebuilds when working tree is dirty`** — previously a dirty tree could skip the rebuild, leaving a stale binary installed.
- **`y: install pyperclip on all platforms`** — drops the `; sys_platform == 'darwin'` marker. `y.py` uses `pyperclip` on non-Mac paths too, so gating it to darwin left those broken.
- **`gitignore: catch .claude/settings.local.json in subdirs`** — the existing pattern had an embedded slash, which anchors it to the repo root, so `mac/.claude/settings.local.json` was never actually ignored. Prefixing `**/` matches the original intent at any depth.

## Test plan

- `git check-ignore -v mac/.claude/settings.local.json` now resolves to the new rule.
- The `pyproject.toml` and `justfile` changes are one-liners; no upstream conflict (upstream only bumped the package version in the same file).