### PR TITLE
config(herdr): default new panes to zsh

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -14,6 +14,13 @@
 
 onboarding = false
 
+[terminal]
+# Prefer zsh over herdr's fallback chain ($SHELL, then /bin/sh) — on the dev
+# VMs the login shell is bash, so the fallback picks the wrong shell. A bare
+# name resolves via the server's PATH, which covers /bin/zsh on macOS and
+# linuxbrew zsh on the VMs alike.
+default_shell = "zsh"
+
 [keys]
 # ---------------------------------------------------------------------------
 # Prefix — C-a, same as tmux (default herdr is ctrl+b, which vi uses).


### PR DESCRIPTION
New herdr panes were opening bash on the dev VMs because the login shell there is bash and herdr's fallback chain is $SHELL → /bin/sh.

This sets `[terminal] default_shell = "zsh"`. A bare name resolves via the server's PATH, so it covers /bin/zsh on macOS and linuxbrew zsh on the VMs without hardcoding a path.

Verified on c-5001: `herdr config check` passes, server reload applied clean, and a freshly created pane spawns `zsh` (older panes keep bash until recreated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Herdr now uses `zsh` as the default shell in terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->