### PR TITLE
pick-links works under herdr

### DIFF
--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -142,13 +142,13 @@ call it out.
 
 ### Scrollback and popups
 
-| Keys            | Action                                      |
-| --------------- | ------------------------------------------- |
-| `prefix+v`      | copy mode (tmux `C-a v`, mode-keys vi)      |
-| `prefix+e`      | dump scrollback into `$EDITOR` — herdr-only |
-| `prefix+shift+l` | scrollback link picker, 95% × 95%        |
-| `prefix+ctrl+g` | lazygit popup, 90% × 90%                    |
-| `prefix+ctrl+t` | `tig status` popup, 90% × 90%               |
+| Keys             | Action                                      |
+| ---------------- | ------------------------------------------- |
+| `prefix+v`       | copy mode (tmux `C-a v`, mode-keys vi)      |
+| `prefix+e`       | dump scrollback into `$EDITOR` — herdr-only |
+| `prefix+shift+l` | scrollback link picker, 95% × 95%           |
+| `prefix+ctrl+g`  | lazygit popup, 90% × 90%                    |
+| `prefix+ctrl+t`  | `tig status` popup, 90% × 90%               |
 
 Popups mirror the `:tig` / `:gdiff` command aliases in `shared/.tmux.conf`.
 

--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -146,6 +146,7 @@ call it out.
 | --------------- | ------------------------------------------- |
 | `prefix+v`      | copy mode (tmux `C-a v`, mode-keys vi)      |
 | `prefix+e`      | dump scrollback into `$EDITOR` — herdr-only |
+| `prefix+shift+l` | scrollback link picker, 95% × 95%        |
 | `prefix+ctrl+g` | lazygit popup, 90% × 90%                    |
 | `prefix+ctrl+t` | `tig status` popup, 90% × 90%               |
 

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -94,9 +94,10 @@ navigate_pane_right = "l"
 
 # --- layout ------------------------------------------------------------------
 # tmux: C-a / -> rmux_helper third (toggle even <-> 1/3-2/3, split if 1 pane).
-# Detection checks TMUX_PANE first, then HERDR_PANE_ID/HERDR_ENV: `-u TMUX_PANE`
-# clears any TMUX_PANE this binding would otherwise inherit (e.g. if the herdr
-# server itself was launched from inside tmux), so detection falls through to
+# Detection checks TMUX/TMUX_PANE first, then HERDR_PANE_ID/HERDR_ENV: `-u TMUX
+# -u TMUX_PANE` clears both variables this binding would otherwise inherit
+# (e.g. if the herdr server itself was launched from inside tmux, where bare
+# TMUX alone is now enough to mean tmux), so detection falls through to
 # HERDR_ENV=1, which forces the herdr path -- rmux_helper then targets the
 # focused tab, the pane the keypress came from, instead of wrongly taking the
 # tmux path.
@@ -107,7 +108,19 @@ navigate_pane_right = "l"
 [[keys.command]]
 key = "prefix+/"
 type = "shell"
-command = "env -u TMUX_PANE HERDR_ENV=1 rmux_helper third"
+command = "env -u TMUX -u TMUX_PANE HERDR_ENV=1 rmux_helper third"
+
+# tmux: C-a L -> rmux_helper pick-links (scrollback link/PR/host picker).
+# Popup at 95%x95% matches the tmux display-popup binding. `env -u TMUX
+# -u TMUX_PANE` forces herdr detection: if the herdr server was launched
+# from inside tmux it would leak those vars into this command, and tmux
+# wins the detection precedence.
+[[keys.command]]
+key = "prefix+shift+l"
+type = "popup"
+command = "env -u TMUX -u TMUX_PANE rmux_helper pick-links"
+width = "95%"
+height = "95%"
 
 # --- popups (mirrors the :tig / :gdiff tmux command aliases) ------------------
 [[keys.command]]

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -118,7 +118,7 @@ command = "env -u TMUX -u TMUX_PANE HERDR_ENV=1 rmux_helper third"
 [[keys.command]]
 key = "prefix+shift+l"
 type = "popup"
-command = "env -u TMUX -u TMUX_PANE rmux_helper pick-links"
+command = "env -u TMUX -u TMUX_PANE HERDR_ENV=1 rmux_helper pick-links"
 width = "95%"
 height = "95%"
 

--- a/docs/superpowers/plans/2026-08-02-herdr-link-picker.md
+++ b/docs/superpowers/plans/2026-08-02-herdr-link-picker.md
@@ -844,7 +844,7 @@ Expected: `TOML scoping OK: 4 command blocks`.
 In `config/herdr/README.md`, add to the "Scrollback and popups" table (after the `prefix+e` row):
 
 ```markdown
-| `prefix+shift+l` | scrollback link picker, 95% × 95%        |
+| `prefix+shift+l` | scrollback link picker, 95% × 95% |
 ```
 
 In `rust/tmux_helper/CLAUDE.md`, add to the Commands list after the `third` bullet:

--- a/docs/superpowers/plans/2026-08-02-herdr-link-picker.md
+++ b/docs/superpowers/plans/2026-08-02-herdr-link-picker.md
@@ -1,0 +1,973 @@
+# Scrollback link picker under herdr Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `rmux_helper pick-links` works under herdr as well as tmux, bound to `prefix+shift+l`, with the multiplexer plumbing shared with `third` instead of duplicated.
+
+**Architecture:** A new `src/mux.rs` owns everything both multiplexer-aware commands need: the `Multiplexer` enum, a pure `classify()` + env-reading `detect()`, the `herdr` CLI shell, and the herdr `pane layout` JSON types. `herdr_third.rs` and `link_picker/` both consume it. `link_picker/mod.rs` keeps its orchestration shape; three I/O touchpoints (resolve, capture, yank) become backend-dispatched with pure, unit-tested argv/payload builders.
+
+**Tech Stack:** Rust (edition 2021), anyhow, serde/serde_json, ratatui/crossterm, `base64 = "0.22"` (new), `herdr` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md`
+
+## Global Constraints
+
+- Branch is `herdr-link-picker` (already created off the merged `main`). Never push to main; explicit `git add` by filename only; conventional commit messages.
+- Pre-commit hooks run on commit. After every `git commit`, confirm the output contains the `[herdr-link-picker <sha>] <subject>` line — if it is missing, a hook reformatted staged files and the commit did **not** land; re-stage and retry.
+- The `typos` hook rejects common misspelling fragments when they appear as standalone hyphenated words; if it fires, reword the prose rather than adding an ignore rule.
+- Build and test with the shared cache: prefix cargo commands with `CARGO_TARGET_DIR=$HOME/.cache/cargo-target`, run from `rust/tmux_helper/`.
+- The tmux code path must stay behaviorally unchanged; its existing tests (`yank_argv_passes_dash_w_and_single_payload_arg`, `capture_pane_caps_history_at_300_lines`) must keep passing untouched.
+- Detection precedence, exact: `TMUX_PANE` or `TMUX` set → Tmux; else `HERDR_PANE_ID` or `HERDR_ENV` set → Herdr; else Unknown.
+- Scrollback depth stays one shared constant: `SCROLLBACK_HISTORY_LINES = 300`.
+- Empirically verified herdr CLI semantics (2026-08-02 against herdr 0.7.5 source at `d742e51` — do not re-derive):
+  - `herdr pane read <PANE_ID> --source recent-unwrapped --lines <N>` — **pane id is positional and comes first**; flags after it. Wrong order yields `unknown option: <value>`.
+  - `herdr pane layout [--pane <ID>]` returns `result.layout` with `panes[]`, `splits[]`, and `focused_pane_id`. Bare invocation targets the focused tab.
+  - Popups (`type = "popup"`) receive `HERDR_ENV=1` but **not** `HERDR_PANE_ID` (herdr `src/app/popup.rs:154`).
+  - herdr parses OSC 52 written by any pane process and forwards it to the client clipboard (herdr `src/pane.rs:1851`).
+
+---
+
+### Task 1: Shared `src/mux.rs`
+
+**Files:**
+
+- Create: `rust/tmux_helper/src/mux.rs`
+- Modify: `rust/tmux_helper/src/main.rs` (add `mod mux;`; delete the local `Multiplexer` enum + `detect_multiplexer` near line 1162; update the branch at line 1049)
+- Modify: `rust/tmux_helper/src/herdr_third.rs` (delete its `herdr_cli` at line 106 and layout types at lines 11-40ish; import from `mux`; add `focused_pane_id` to the test helper)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces (Tasks 2 and 3 rely on these exact names):
+  - `pub enum Multiplexer { Tmux, Herdr, Unknown }` — derives `PartialEq, Debug, Clone, Copy`
+  - `pub fn classify(tmux_pane: Option<&str>, tmux: Option<&str>, herdr_pane_id: Option<&str>, herdr_env: Option<&str>) -> Multiplexer`
+  - `pub fn detect() -> Multiplexer`
+  - `pub fn herdr_cli(args: &[&str]) -> anyhow::Result<String>`
+  - `pub struct LayoutResponse { pub result: LayoutResult }`, `pub struct LayoutResult { pub layout: TabLayout }`
+  - `pub struct TabLayout { pub focused_pane_id: String, pub panes: Vec<PaneEntry>, pub splits: Vec<SplitEntry> }`
+  - `pub struct PaneEntry { pub pane_id: String, pub rect: Rect }`, `pub struct SplitEntry { pub direction: String, pub ratio: f64 }`, `pub struct Rect { pub x: i64, pub y: i64 }`
+  - `pub fn fetch_layout(pane: Option<&str>) -> anyhow::Result<TabLayout>`
+
+**Why the layout types move here:** both `third` (needs `panes`/`splits`) and `pick-links` (needs `focused_pane_id`) parse the same `herdr pane layout` response. One canonical representation is the DRY payoff this whole plan is for; leaving them in `herdr_third` would make the link picker import from a module named after an unrelated command.
+
+- [ ] **Step 1: Create `src/mux.rs` with the pure core and its tests**
+
+Create `rust/tmux_helper/src/mux.rs`:
+
+```rust
+//! Multiplexer plumbing shared by every mux-aware command (`third`,
+//! `pick-links`): which multiplexer are we in, the `herdr` CLI shell, and
+//! the herdr `pane layout` JSON shape.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::process::Command;
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum Multiplexer {
+    Tmux,
+    Herdr,
+    Unknown,
+}
+
+/// Decide the multiplexer from the four environment variables that matter.
+///
+/// Split out from `detect` so precedence is unit-testable without mutating
+/// the process environment — env mutation races across cargo's parallel
+/// test threads.
+///
+/// `TMUX_PANE` OR `TMUX` means tmux: `run-shell` sets the former,
+/// `display-popup` sets only the latter, and tmux nested inside a herdr
+/// pane still means tmux is what the user is looking at.
+pub fn classify(
+    tmux_pane: Option<&str>,
+    tmux: Option<&str>,
+    herdr_pane_id: Option<&str>,
+    herdr_env: Option<&str>,
+) -> Multiplexer {
+    let set = |v: Option<&str>| v.is_some_and(|s| !s.is_empty());
+    if set(tmux_pane) || set(tmux) {
+        Multiplexer::Tmux
+    } else if set(herdr_pane_id) || set(herdr_env) {
+        Multiplexer::Herdr
+    } else {
+        Multiplexer::Unknown
+    }
+}
+
+pub fn detect() -> Multiplexer {
+    let var = |k: &str| std::env::var(k).ok();
+    classify(
+        var("TMUX_PANE").as_deref(),
+        var("TMUX").as_deref(),
+        var("HERDR_PANE_ID").as_deref(),
+        var("HERDR_ENV").as_deref(),
+    )
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LayoutResponse {
+    pub result: LayoutResult,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LayoutResult {
+    pub layout: TabLayout,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct TabLayout {
+    #[serde(default)]
+    pub focused_pane_id: String,
+    pub panes: Vec<PaneEntry>,
+    #[serde(default)]
+    pub splits: Vec<SplitEntry>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PaneEntry {
+    pub pane_id: String,
+    pub rect: Rect,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SplitEntry {
+    pub direction: String,
+    pub ratio: f64,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy)]
+pub struct Rect {
+    pub x: i64,
+    pub y: i64,
+}
+
+pub fn herdr_cli(args: &[&str]) -> Result<String> {
+    let out = Command::new("herdr")
+        .args(args)
+        .output()
+        .context("failed to run `herdr` — is it installed and on PATH?")?;
+    if !out.status.success() {
+        bail!(
+            "herdr {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+pub fn fetch_layout(pane: Option<&str>) -> Result<TabLayout> {
+    let mut args = vec!["pane", "layout"];
+    if let Some(p) = pane {
+        args.extend(["--pane", p]);
+    }
+    // Without --pane, herdr reports the focused tab — correct for a
+    // keybinding or popup, which is where pane identity is absent.
+    let json = herdr_cli(&args)?;
+    let resp: LayoutResponse =
+        serde_json::from_str(&json).context("unexpected JSON from `herdr pane layout`")?;
+    Ok(resp.result.layout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmux_pane_alone_is_tmux() {
+        assert_eq!(classify(Some("%3"), None, None, None), Multiplexer::Tmux);
+    }
+
+    #[test]
+    fn tmux_var_alone_is_tmux() {
+        // tmux display-popup drops TMUX_PANE but keeps TMUX — pick-links
+        // runs in exactly that context.
+        assert_eq!(
+            classify(None, Some("/tmp/tmux-1000/default,123,0"), None, None),
+            Multiplexer::Tmux
+        );
+    }
+
+    #[test]
+    fn herdr_env_alone_is_herdr() {
+        // herdr popups set HERDR_ENV but omit HERDR_PANE_ID.
+        assert_eq!(classify(None, None, None, Some("1")), Multiplexer::Herdr);
+    }
+
+    #[test]
+    fn herdr_pane_id_alone_is_herdr() {
+        assert_eq!(classify(None, None, Some("w9:p1"), None), Multiplexer::Herdr);
+    }
+
+    #[test]
+    fn tmux_wins_when_both_present() {
+        assert_eq!(
+            classify(Some("%3"), None, Some("w9:p1"), Some("1")),
+            Multiplexer::Tmux
+        );
+    }
+
+    #[test]
+    fn nothing_set_is_unknown() {
+        assert_eq!(classify(None, None, None, None), Multiplexer::Unknown);
+    }
+
+    #[test]
+    fn empty_strings_do_not_count_as_set() {
+        assert_eq!(classify(Some(""), Some(""), Some(""), Some("")), Multiplexer::Unknown);
+    }
+
+    #[test]
+    fn layout_json_exposes_focused_pane_id() {
+        // Captured verbatim from `herdr pane layout` on 2026-08-02.
+        let json = r#"{"id":"cli:pane:layout","result":{"layout":{"area":{"height":56,"width":170,"x":18,"y":1},"focused_pane_id":"w9:p1","panes":[{"focused":true,"pane_id":"w9:p1","rect":{"height":56,"width":170,"x":18,"y":1}}],"splits":[],"tab_id":"w9:t1","workspace_id":"w9","zoomed":false},"type":"pane_layout"}}"#;
+        let layout = serde_json::from_str::<LayoutResponse>(json)
+            .expect("layout JSON should parse")
+            .result
+            .layout;
+        assert_eq!(layout.focused_pane_id, "w9:p1");
+        assert_eq!(layout.panes.len(), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module and run the new tests**
+
+Add `mod mux;` to the module list at the top of `rust/tmux_helper/src/main.rs` (beside `mod agent_continue;`, `mod herdr_third;`, `mod link_picker;`, `mod picker;`).
+
+Run: `CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test mux::`
+Expected: 8 tests pass.
+
+- [ ] **Step 3: Point `main.rs` at `mux` and delete the local copy**
+
+In `rust/tmux_helper/src/main.rs`, delete the whole `#[derive(PartialEq, Debug)] enum Multiplexer { ... }` block and the `fn detect_multiplexer() -> Multiplexer { ... }` below it (near line 1162, just after `get_caller_pane_id`).
+
+Change the branch at the top of `fn third` (line 1049) from:
+
+```rust
+    if detect_multiplexer() == Multiplexer::Herdr {
+```
+
+to:
+
+```rust
+    if mux::detect() == mux::Multiplexer::Herdr {
+```
+
+- [ ] **Step 4: Point `herdr_third.rs` at `mux` and delete its copies**
+
+In `rust/tmux_helper/src/herdr_third.rs`:
+
+1. Delete the `LayoutResponse`, `LayoutResult`, `TabLayout`, `PaneEntry`, `SplitEntry`, and `Rect` struct definitions, the `herdr_cli` function (line 106), and the `fetch_layout` function.
+2. Replace the `use` block at the top with:
+
+```rust
+use crate::mux::{self, PaneEntry, SplitEntry, TabLayout};
+use anyhow::{bail, Result};
+```
+
+3. In `cmd`, replace `fetch_layout(caller.as_deref())?` with `mux::fetch_layout(caller.as_deref())?` and `herdr_cli(&arg_refs)?` with `mux::herdr_cli(&arg_refs)?`.
+4. In the test module, the `parse` helper now needs the mux type — change its body to:
+
+```rust
+    fn parse(json: &str) -> TabLayout {
+        serde_json::from_str::<crate::mux::LayoutResponse>(json)
+            .expect("layout JSON should parse")
+            .result
+            .layout
+    }
+```
+
+5. The `two_pane` test helper (line ~203) constructs a `TabLayout` literal; add the new field as its first entry:
+
+```rust
+        TabLayout {
+            focused_pane_id: "w9:p1".into(),
+            panes: vec![
+```
+
+Also drop the `width`/`height` fields from the two `Rect { .. }` literals in that helper and in `three_panes_is_noop` if the compiler flags them — `mux::Rect` carries only `x` and `y`, matching what `plan_third` reads.
+
+- [ ] **Step 5: Verify the whole suite and clippy**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo clippy 2>&1 | tail -5
+```
+
+Expected: all tests pass (the 10 pre-existing `herdr_third` tests still pass against the moved types — this is the regression guard for the refactor). No new clippy warnings in `mux.rs`, `herdr_third.rs`, or `main.rs`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tmux_helper/src/mux.rs rust/tmux_helper/src/main.rs rust/tmux_helper/src/herdr_third.rs
+git commit -m "refactor(rmux_helper): extract shared mux module for detection and herdr CLI"
+```
+
+---
+
+### Task 2: herdr resolve, capture, and OSC 52 yank in `link_picker`
+
+**Files:**
+
+- Modify: `rust/tmux_helper/src/link_picker/mod.rs` (the `pick_links` orchestrator, `resolve_pane_id`, capture, yank, and dispatch)
+- Modify: `rust/tmux_helper/Cargo.toml` (add `base64`)
+
+**Interfaces:**
+
+- Consumes: `crate::mux::{detect, fetch_layout, herdr_cli, Multiplexer}` from Task 1.
+- Produces (Task 3 relies on this): `pick_links` passes a `Multiplexer` into `tui::run(rows, mux)`.
+- Produces (internal, unit-tested): `pub(crate) fn herdr_capture_args(pane_id: &str) -> Vec<String>`, `pub(crate) fn osc52_payload(text: &str) -> Vec<u8>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `orchestration_tests` module at the bottom of `rust/tmux_helper/src/link_picker/mod.rs`:
+
+```rust
+    #[test]
+    fn herdr_capture_args_put_pane_id_first_and_cap_history() {
+        // herdr's CLI takes the pane id POSITIONALLY, before any flags —
+        // `herdr pane read --source recent w9:p1` fails with
+        // "unknown option: w9:p1". Regression guard for that arg order.
+        let args = herdr_capture_args("w9:p1");
+        assert_eq!(args[0], "pane");
+        assert_eq!(args[1], "read");
+        assert_eq!(args[2], "w9:p1", "pane id must be the first positional");
+        let src = args.iter().position(|a| a == "--source").expect("needs --source");
+        assert_eq!(
+            args[src + 1],
+            "recent-unwrapped",
+            "must join soft-wrapped lines so wrapped URLs read back whole"
+        );
+        let lines = args.iter().position(|a| a == "--lines").expect("needs --lines");
+        assert_eq!(
+            args[lines + 1],
+            SCROLLBACK_HISTORY_LINES.to_string(),
+            "history depth must come from the shared constant"
+        );
+    }
+
+    #[test]
+    fn osc52_payload_wraps_base64_in_the_clipboard_escape() {
+        let bytes = osc52_payload("hi");
+        assert_eq!(bytes, b"\x1b]52;c;aGk=\x07".to_vec());
+    }
+
+    #[test]
+    fn osc52_payload_encodes_spaces_and_non_ascii() {
+        // URLs with spaces or unicode must survive the base64 hop intact.
+        let text = "https://example.com/a b/\u{e9}";
+        let bytes = osc52_payload(text);
+        let s = String::from_utf8(bytes).expect("escape is valid utf8");
+        let b64 = s
+            .strip_prefix("\x1b]52;c;")
+            .and_then(|s| s.strip_suffix('\x07'))
+            .expect("must be wrapped in the OSC 52 prefix and BEL terminator");
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        let decoded = STANDARD.decode(b64).expect("payload must be valid base64");
+        assert_eq!(String::from_utf8(decoded).unwrap(), text);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test link_picker::orchestration_tests`
+Expected: FAIL — `herdr_capture_args` and `osc52_payload` not found, plus an unresolved `base64` import.
+
+- [ ] **Step 3: Add the base64 dependency**
+
+In `rust/tmux_helper/Cargo.toml`, add to `[dependencies]` (keep the list's existing ordering style):
+
+```toml
+base64 = "0.22"
+```
+
+- [ ] **Step 4: Implement the builders and the herdr I/O**
+
+In `rust/tmux_helper/src/link_picker/mod.rs`, add near the existing `capture_pane_args`:
+
+```rust
+/// Build the argv for `herdr pane read`. The pane id is POSITIONAL and must
+/// come first — herdr rejects `pane read --source recent <id>` with
+/// "unknown option: <id>". `recent-unwrapped` is herdr's equivalent of
+/// tmux's `capture-pane -J`: it joins soft-wrapped lines so a URL that
+/// wrapped across terminal rows reads back whole.
+pub(crate) fn herdr_capture_args(pane_id: &str) -> Vec<String> {
+    vec![
+        "pane".to_string(),
+        "read".to_string(),
+        pane_id.to_string(),
+        "--source".to_string(),
+        "recent-unwrapped".to_string(),
+        "--lines".to_string(),
+        SCROLLBACK_HISTORY_LINES.to_string(),
+    ]
+}
+
+/// Build the OSC 52 clipboard escape for `text`.
+///
+/// `ESC ] 52 ; c ; <base64> BEL` — `c` is the clipboard selection. herdr
+/// parses this out of the pane's pty and forwards it to the client's OS
+/// clipboard, so under herdr this replaces tmux's `set-buffer -w` entirely.
+/// No tmux passthrough wrapping: that is a tmux-only concern and this path
+/// only runs under herdr.
+pub(crate) fn osc52_payload(text: &str) -> Vec<u8> {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let mut out = b"\x1b]52;c;".to_vec();
+    out.extend_from_slice(STANDARD.encode(text).as_bytes());
+    out.push(0x07);
+    out
+}
+
+/// Write the OSC 52 escape to the controlling terminal.
+///
+/// `/dev/tty` rather than stdout: stdout may be piped (`pick-links --json`,
+/// shell capture), and the escape has to reach the pty herdr is parsing.
+fn yank_osc52(payload: &str) -> Result<()> {
+    use std::io::Write;
+    let mut tty = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/tty")
+        .map_err(|e| anyhow!("cannot open /dev/tty for clipboard write: {e}"))?;
+    tty.write_all(&osc52_payload(payload))
+        .map_err(|e| anyhow!("failed writing OSC 52 to /dev/tty: {e}"))?;
+    tty.flush()
+        .map_err(|e| anyhow!("failed flushing OSC 52 to /dev/tty: {e}"))?;
+    Ok(())
+}
+
+/// Capture the recent scrollback of `pane_id` via `herdr pane read`.
+fn herdr_capture_pane(pane_id: &str) -> Result<String> {
+    let args = herdr_capture_args(pane_id);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::mux::herdr_cli(&arg_refs)
+}
+
+/// Resolve the herdr pane to capture: the launching pane when herdr set it,
+/// otherwise the focused pane. Popups get `HERDR_ENV` but not
+/// `HERDR_PANE_ID`, and `C-a L` is bound as a popup — so the fallback is
+/// the common path, not the edge case.
+fn resolve_herdr_pane_id() -> Result<String> {
+    if let Ok(p) = env::var("HERDR_PANE_ID") {
+        if !p.is_empty() {
+            return Ok(p);
+        }
+    }
+    let layout = crate::mux::fetch_layout(None)?;
+    if layout.focused_pane_id.is_empty() {
+        return Err(anyhow!(
+            "pick-links: herdr reported no focused pane to capture"
+        ));
+    }
+    Ok(layout.focused_pane_id)
+}
+```
+
+- [ ] **Step 5: Branch the orchestrator**
+
+Rewrite the head of `pub fn pick_links` in the same file so the three seams dispatch on the detected multiplexer. Replace lines 13-21 (from `pub fn pick_links` through `let rows = detect::parse(&raw);`) with:
+
+```rust
+pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
+    let mux = crate::mux::detect();
+
+    // 1. Resolve pane + 2. capture (sync, fallible)
+    let (pane_id, raw) = match mux {
+        crate::mux::Multiplexer::Tmux => {
+            let pane_id = resolve_pane_id()?;
+            let raw = capture_pane(&pane_id)?;
+            (pane_id, raw)
+        }
+        crate::mux::Multiplexer::Herdr => {
+            let pane_id = resolve_herdr_pane_id()?;
+            let raw = herdr_capture_pane(&pane_id)?;
+            (pane_id, raw)
+        }
+        crate::mux::Multiplexer::Unknown => {
+            return Err(anyhow!(
+                "pick-links: not inside tmux or herdr; nothing to capture"
+            ))
+        }
+    };
+
+    // 3. Detect
+    let rows = detect::parse(&raw);
+```
+
+Then update the two consumers further down the same function:
+
+- Leave the TUI call as `let action = tui::run(rows)?;` — Task 3 owns that signature change. This task must compile and pass tests on its own.
+- The `Yank` arm becomes backend-aware:
+
+```rust
+        tui::Action::Yank(row) => {
+            match mux {
+                crate::mux::Multiplexer::Herdr => yank_osc52(&row.canonical)?,
+                _ => yank_to_clipboard(&row.canonical)?,
+            }
+            println!("{}", row.canonical);
+        }
+```
+
+Leave the `Open`, `GhWeb`, `Ssh`, and `SwapToPickTui` arms exactly as they are — under herdr the TUI will not produce `Ssh` or `SwapToPickTui` (Task 3), and `Open` is already backend-agnostic.
+
+Finally, delete the now-dead `if env::var("TMUX").is_err()` guard inside the existing `resolve_pane_id` — the `Unknown` arm above owns that error now — leaving:
+
+```rust
+fn resolve_pane_id() -> Result<String> {
+    if let Ok(p) = env::var("TMUX_PANE") {
+        if !p.is_empty() {
+            return Ok(p);
+        }
+    }
+    // Fallback: ask tmux directly. Reached from display-popup, which sets
+    // TMUX but not TMUX_PANE.
+    let out = Command::new("tmux")
+        .args(["display-message", "-p", "-t", "#{client_active_pane}", "#{pane_id}"])
+        .output()
+        .map_err(|e| anyhow!("tmux display-message failed: {e}"))?;
+    if !out.status.success() {
+        return Err(anyhow!("tmux display-message returned nonzero"));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test link_picker
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo clippy 2>&1 | tail -5
+```
+
+Expected: the three new tests pass; the pre-existing `yank_argv_passes_dash_w_and_single_payload_arg`, `yank_argv_passes_payload_with_spaces_as_one_arg`, and `capture_pane_caps_history_at_300_lines` still pass unchanged. No new clippy warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tmux_helper/Cargo.toml rust/tmux_helper/Cargo.lock rust/tmux_helper/src/link_picker/mod.rs
+git commit -m "feat(rmux_helper): capture and yank via herdr in pick-links"
+```
+
+---
+
+### Task 3: TUI action filtering per backend
+
+**Files:**
+
+- Modify: `rust/tmux_helper/src/link_picker/tui.rs` (`Action` consumers, `App`, `run`, `draw`, `handle_key`, `default_action`, test helper at line ~274)
+- Modify: `rust/tmux_helper/src/link_picker/mod.rs` (the `tui::run` call site)
+
+**Interfaces:**
+
+- Consumes: `crate::mux::Multiplexer` (Task 1); `pick_links`'s local `mux` binding (Task 2).
+- Produces: `pub fn run(rows: Vec<Row>, mux: Multiplexer) -> Result<Action>`; `pub(crate) fn default_action(row: &Row, mux: Multiplexer) -> Action`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `rust/tmux_helper/src/link_picker/tui.rs`:
+
+```rust
+    fn server_row() -> Row {
+        Row {
+            category: Category::Server,
+            canonical: "c-5001".into(),
+            key: "c-5001".into(),
+            repo_or_host: "—".into(),
+            context: "ssh c-5001".into(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 0,
+        }
+    }
+
+    #[test]
+    fn server_row_defaults_to_ssh_under_tmux() {
+        assert!(matches!(
+            default_action(&server_row(), Multiplexer::Tmux),
+            Action::Ssh(_)
+        ));
+    }
+
+    #[test]
+    fn server_row_defaults_to_yank_under_herdr() {
+        // Ssh is not offered under herdr, so Enter on a host must copy it
+        // rather than silently doing nothing.
+        assert!(matches!(
+            default_action(&server_row(), Multiplexer::Herdr),
+            Action::Yank(_)
+        ));
+    }
+
+    #[test]
+    fn s_key_types_into_the_query_under_herdr() {
+        // Under tmux `s` fires Ssh; under herdr it must fall through to the
+        // generic character arm so `s` is usable as a search character.
+        let mut app = App::new(vec![server_row()], Multiplexer::Herdr);
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('s'));
+        assert!(app.action.is_none(), "must not fire an action under herdr");
+        assert_eq!(app.query, "s", "must type into the search query instead");
+    }
+
+    #[test]
+    fn s_key_fires_ssh_under_tmux() {
+        let mut app = App::new(vec![server_row()], Multiplexer::Tmux);
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('s'));
+        assert!(matches!(app.action, Some(Action::Ssh(_))));
+        assert!(app.query.is_empty(), "must not also type into the query");
+    }
+
+    #[test]
+    fn f2_is_inert_under_herdr() {
+        // herdr's own prefix+w is the session picker; swapping to pick-tui
+        // would exec a tmux-only TUI.
+        let mut app = App::new(vec![server_row()], Multiplexer::Herdr);
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::F(2));
+        assert!(app.action.is_none());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test link_picker::tui`
+Expected: FAIL — `App::new` takes one argument, `default_action` takes one argument, `Multiplexer` unresolved.
+
+- [ ] **Step 3: Thread the multiplexer through the TUI**
+
+In `rust/tmux_helper/src/link_picker/tui.rs`:
+
+1. Add to the imports at the top: `use crate::mux::Multiplexer;`
+2. Add the field to `struct App` (after `show_help: bool`):
+
+```rust
+    mux: Multiplexer,
+```
+
+3. Change `impl App`'s constructor signature and initializer:
+
+```rust
+    fn new(rows: Vec<Row>, mux: Multiplexer) -> Self {
+        let mut app = Self {
+            rows,
+            filtered: Vec::new(),
+            categories_present: Vec::new(),
+            list_state: ListState::default(),
+            query: String::new(),
+            drilled_in: None,
+            horizontal: true,
+            show_help: false,
+            action: None,
+            mux,
+        };
+        app.rebuild_filter();
+        app
+    }
+```
+
+4. Change `pub fn run(rows: Vec<Row>) -> Result<Action>` to `pub fn run(rows: Vec<Row>, mux: Multiplexer) -> Result<Action>`, and its body's `let mut app = App::new(rows);` to `let mut app = App::new(rows, mux);`.
+5. In `fn on_enter`, change `self.action = Some(default_action(&row));` to `self.action = Some(default_action(&row, self.mux));`.
+6. Change `default_action` to:
+
+```rust
+/// Default Enter action per category (see spec §Actions → Default).
+/// Under herdr, Server/Ip rows fall back to Yank — the Ssh action is
+/// tmux-only, and a dead Enter key would be worse than copying the host.
+pub(crate) fn default_action(row: &Row, mux: Multiplexer) -> Action {
+    match row.category {
+        Category::Server | Category::Ip if mux == Multiplexer::Tmux => Action::Ssh(row.clone()),
+        _ => Action::Yank(row.clone()),
+    }
+}
+```
+
+7. Guard the two tmux-only key handlers in `handle_key`:
+
+```rust
+        KeyCode::F(2) if app.mux == Multiplexer::Tmux => {
+            app.action = Some(Action::SwapToPickTui)
+        }
+```
+
+```rust
+        KeyCode::Char('s')
+            if mods.is_empty() && app.query.is_empty() && app.mux == Multiplexer::Tmux =>
+        {
+            if let Some(row) = app.selected_leaf() {
+                app.action = Some(Action::Ssh(row));
+            }
+        }
+```
+
+The `s` arm must stay **above** the generic `KeyCode::Char(c)` arm so that under tmux it still wins, and under herdr the guard fails and the generic arm types the character.
+
+8. In `fn draw`, make the hint bar backend-aware — replace the `let top = ...` block with:
+
+```rust
+    let sess_hint = if app.mux == Multiplexer::Tmux {
+        " F2:sess"
+    } else {
+        ""
+    };
+    let top = if let Some(cat) = app.drilled_in {
+        format!(
+            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back ?:help{}",
+            app.query,
+            cat.display(),
+            sess_hint
+        )
+    } else {
+        format!(
+            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh ?:help{}",
+            app.query, sess_hint
+        )
+    };
+```
+
+9. Update the existing test helper `app_with_one_row` (line ~274) so pre-existing tests keep asserting tmux behavior: change `App::new(vec![row])` to `App::new(vec![row], Multiplexer::Tmux)`.
+
+- [ ] **Step 4: Update the call site**
+
+In `rust/tmux_helper/src/link_picker/mod.rs`, change `let action = tui::run(rows)?;` to:
+
+```rust
+    let action = tui::run(rows, mux)?;
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo clippy 2>&1 | tail -5
+```
+
+Expected: the 5 new tests pass; every pre-existing `tui` test still passes. No new clippy warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tmux_helper/src/link_picker/tui.rs rust/tmux_helper/src/link_picker/mod.rs
+git commit -m "feat(rmux_helper): filter pick-links actions by multiplexer"
+```
+
+---
+
+### Task 4: herdr keybinding and docs
+
+**Files:**
+
+- Modify: `config/herdr/config.toml` (the `[[keys.command]]` section — add the new block, and add `-u TMUX` to the existing `prefix+/` block)
+- Modify: `config/herdr/README.md` (Scrollback and popups table)
+- Modify: `rust/tmux_helper/CLAUDE.md` (Commands list)
+
+**Interfaces:**
+
+- Consumes: the installed binary (Task 5 installs it; the binding is inert until then).
+- Produces: `prefix+shift+l` in herdr.
+
+- [ ] **Step 1: Add the binding**
+
+In `config/herdr/config.toml`, add immediately after the existing `prefix+/` layout block (still **below every plain `[keys]` entry** — the file's own NOTE comment explains why; TOML scopes bare keys after an array-of-tables header into that table and `herdr config check` does not catch it):
+
+```toml
+# tmux: C-a L -> rmux_helper pick-links (scrollback link/PR/host picker).
+# Popup at 95%x95% matches the tmux display-popup binding. `env -u TMUX
+# -u TMUX_PANE` forces herdr detection: if the herdr server was launched
+# from inside tmux it would leak those vars into this command, and tmux
+# wins the detection precedence.
+[[keys.command]]
+key = "prefix+shift+l"
+type = "popup"
+command = "env -u TMUX -u TMUX_PANE rmux_helper pick-links"
+width = "95%"
+height = "95%"
+```
+
+- [ ] **Step 2: Add `-u TMUX` to the existing `third` binding**
+
+In the same file, change the `prefix+/` block's command from:
+
+```toml
+command = "env HERDR_ENV=1 rmux_helper third"
+```
+
+to:
+
+```toml
+command = "env -u TMUX -u TMUX_PANE HERDR_ENV=1 rmux_helper third"
+```
+
+Required by Task 1's detection change: `TMUX` alone now means tmux, so a herdr server launched from inside tmux would otherwise send `prefix+/` down the tmux path. Update that block's comment to say it clears both variables.
+
+- [ ] **Step 3: Validate the config**
+
+`~/.config/herdr/config.toml` symlinks to the **primary** `~/settings` checkout, not this worktree — so `herdr config check` validates the wrong file unless the symlink is swapped. Validate the branch's file with a guaranteed restore:
+
+```bash
+LIVE=~/.config/herdr/config.toml
+ORIG=$(readlink "$LIVE")
+trap 'ln -sfn "$ORIG" "$LIVE"' EXIT
+ln -sfn "$PWD/config/herdr/config.toml" "$LIVE"
+herdr config check
+ln -sfn "$ORIG" "$LIVE"
+trap - EXIT
+readlink "$LIVE"
+```
+
+Expected: `config: ok`, then the readlink prints the original primary-checkout path. Do **not** run `herdr server reload-config` while swapped. If `prefix+shift+l` is rejected, try `key = "prefix+L"` and record which form was accepted in the README row.
+
+Also verify TOML scoping did not regress:
+
+```bash
+python3 -c "
+import tomllib
+d = tomllib.load(open('config/herdr/config.toml','rb'))
+k = d['keys']
+need = ['copy_mode','edit_scrollback','open_notification_target','navigate_workspace_up','navigate_workspace_down','navigate_pane_left','navigate_pane_down','navigate_pane_up','navigate_pane_right']
+missing = [x for x in need if x not in k]
+assert not missing, missing
+assert all(set(c) <= {'key','type','command','width','height'} for c in k['command']), k['command']
+print('TOML scoping OK:', len(k['command']), 'command blocks')
+"
+```
+
+Expected: `TOML scoping OK: 4 command blocks`.
+
+- [ ] **Step 4: Document**
+
+In `config/herdr/README.md`, add to the "Scrollback and popups" table (after the `prefix+e` row):
+
+```markdown
+| `prefix+shift+l` | scrollback link picker, 95% × 95%        |
+```
+
+In `rust/tmux_helper/CLAUDE.md`, add to the Commands list after the `third` bullet:
+
+```markdown
+- `pick-links` - Scrollback link/PR/host picker. Works under tmux and herdr (auto-detected); under herdr the ssh and F2-swap actions are not offered and yank goes out as OSC 52
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/herdr/config.toml config/herdr/README.md rust/tmux_helper/CLAUDE.md
+git commit -m "config(herdr): bind prefix+shift+l to rmux_helper pick-links"
+```
+
+---
+
+### Task 5: Install, smoke, tmux regression, PR
+
+**Files:**
+
+- No source changes expected. If smoke or regression fails, stop and report — do not patch code (the controller decides fix-forward).
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: installed binary, PR.
+
+- [ ] **Step 1: Install**
+
+Run from `rust/tmux_helper/`:
+
+```bash
+CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo install --path . --force
+rmux_helper pick-links --help | head -5
+```
+
+Expected: installs in well under a minute; help prints.
+
+- [ ] **Step 2: herdr smoke — headless `--json` against a real pane**
+
+The executing shell has `HERDR_PANE_ID` set. `--json` short-circuits before the TUI, so this is safe headless:
+
+```bash
+rmux_helper pick-links --json | python3 -m json.tool | head -20
+rmux_helper pick-links --json | python3 -c "import json,sys; rows=json.load(sys.stdin); print('rows:', len(rows)); print('categories:', sorted({r['category'] for r in rows}))"
+```
+
+Expected: valid JSON, one or more rows, categories drawn from this session's scrollback (it contains GitHub PR URLs, so `pull_request` or `link` should appear). Zero rows is a FAILURE for this step — it means capture returned nothing.
+
+Also prove the popup path (no `HERDR_PANE_ID`, focused-pane fallback):
+
+```bash
+env -u HERDR_PANE_ID HERDR_ENV=1 rmux_helper pick-links --json | python3 -c "import json,sys; print('fallback rows:', len(json.load(sys.stdin)))"
+```
+
+Expected: a row count, no error. This reads the focused tab, which is safe — it only reads.
+
+- [ ] **Step 3: Prove the capture reaches herdr's scrollback depth**
+
+```bash
+rmux_helper pick-links --json | python3 -c "import json,sys; rows=json.load(sys.stdin); print('max line offset seen:', max((r['most_recent_line'] for r in rows), default=0))"
+```
+
+Expected: a number greater than the visible pane height (~56) if this session's scrollback holds older links, confirming `--lines 300` is really reaching back. If it is at or below 56, note it in the report rather than failing — it may simply mean all detected links are recent.
+
+- [ ] **Step 4: tmux regression — the picker still works there**
+
+```bash
+tmux new-session -d -s links-smoke -x 200 -y 50
+tmux send-keys -t links-smoke 'echo https://github.com/idvorkin/settings/pull/101 && echo ssh c-5001' Enter
+sleep 1
+tmux send-keys -t links-smoke 'rmux_helper pick-links --json > /tmp/links-smoke.json 2>/tmp/links-smoke.err; echo done' Enter
+sleep 3
+python3 -c "import json; rows=json.load(open('/tmp/links-smoke.json')); cats=sorted({r['category'] for r in rows}); print('tmux rows:', len(rows), 'categories:', cats); assert 'pull_request' in cats, cats; assert 'server' in cats, cats; print('tmux regression OK')"
+tmux kill-session -t links-smoke
+```
+
+Expected: `tmux regression OK`. This exercises the untouched tmux resolve + capture path end to end.
+
+- [ ] **Step 5: Full suite and pre-commit**
+
+Run from the repo root:
+
+```bash
+(cd rust/tmux_helper && CARGO_TARGET_DIR=$HOME/.cache/cargo-target cargo test)
+pre-commit run --all-files 2>&1 | tail -20
+```
+
+Expected: cargo tests all pass. For pre-commit, any failure must be triaged against this branch's file footprint (`git diff --name-only main...HEAD`) — failures on files this branch never touched are pre-existing repo backlog; note them and move on. Failures on this branch's files must be fixed and committed.
+
+- [ ] **Step 6: Report the manual verification the controller must surface**
+
+Two things cannot be verified headless — name them in the report:
+
+1. `C-a L` in a live herdr tab renders the popup and is navigable.
+2. Enter/`y` on a row lands the URL on the Mac clipboard via herdr's OSC 52 forwarding.
+
+- [ ] **Step 7: Push and open the PR**
+
+```bash
+git log --oneline main..HEAD
+gh pr list --head herdr-link-picker --state all --json number,state
+git push -u origin herdr-link-picker
+gh pr create --base main --title "pick-links works under herdr" --body "$(cat <<'EOF'
+## Summary
+- `rmux_helper pick-links` auto-detects tmux vs herdr and works in both; `prefix+shift+l` bound in herdr as a 95%×95% popup
+- Shared `src/mux.rs` now owns multiplexer detection, the `herdr` CLI shell, and the `pane layout` types — `third` and `pick-links` both consume it instead of duplicating
+- Detection now treats `TMUX` (not just `TMUX_PANE`) as tmux, since `display-popup` drops `TMUX_PANE`; both herdr bindings clear `TMUX` and `TMUX_PANE`
+- Under herdr: yank emits OSC 52 (herdr forwards it to the client clipboard), ssh and F2-swap are not offered, and Enter on a host copies it
+
+Spec: docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md
+Plan: docs/superpowers/plans/2026-08-02-herdr-link-picker.md
+
+## Test plan
+- [x] Unit tests: detection precedence, herdr capture argv order, OSC 52 payload bytes, per-backend action defaults
+- [x] herdr headless smoke: `pick-links --json` returns rows from real scrollback, including the no-`HERDR_PANE_ID` popup path
+- [x] tmux regression: `pick-links --json` in a scratch session still detects PR + host rows
+- [ ] Igor: `C-a L` popup renders under herdr; yank reaches the Mac clipboard
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+If `gh pr list` shows a MERGED PR for this branch, stop and report instead of pushing. If the push is denied, fork per the repo CLAUDE.md: `gh repo fork --remote-name fork && git push fork herdr-link-picker && gh pr create --head idvorkin-ai-tools:herdr-link-picker --base main ...`.

--- a/docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md
+++ b/docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md
@@ -1,0 +1,177 @@
+# Scrollback link picker under herdr — design
+
+Date: 2026-08-02
+Status: approved by Igor (brainstorm in session), implementation pending
+
+## Goal
+
+`rmux_helper pick-links` (the `C-a L` scrollback link picker) works under
+herdr as well as tmux, sharing one orchestration path. Bind it to
+`prefix+shift+l` in herdr. Extract the multiplexer plumbing both this and
+`third` need into one module rather than duplicating it.
+
+Prior art: [`2026-04-12-scrollback-link-picker-design.md`](2026-04-12-scrollback-link-picker-design.md)
+(the tmux picker) and [`2026-08-02-herdr-third-design.md`](2026-08-02-herdr-third-design.md)
+(the first herdr port).
+
+## Scope
+
+- **In**: multiplexer auto-detection shared by `third` and `pick-links`;
+  herdr capture / pane-resolve / yank; action filtering under herdr;
+  `prefix+shift+l` binding; docs.
+- **Out**: the Ssh action and the F2 swap-to-`pick-tui` action under herdr
+  (herdr's `prefix+w` is the native picker); porting other commands;
+  enrich/detect/TUI logic changes — those are backend-agnostic already.
+
+## Findings from herdr 0.7.5 source (do not re-derive)
+
+Cloned `github.com/herdrdev/herdr` at `d742e51` and read the relevant paths:
+
+1. **`herdr pane read` takes the pane id FIRST** (`src/cli/pane.rs:443-451`):
+   `herdr pane read <pane_id> [--source visible|recent|recent-unwrapped]
+   [--lines N]`. An earlier session passed the args out of order, got
+   `unknown option: recent`, and wrongly concluded the server was too old.
+   Verified live on a 500-line shell pane: `--lines 400` returns 400 lines,
+   and `--source recent-unwrapped` joins soft-wrapped lines. This is the
+   direct equivalent of tmux `capture-pane -J -S -300 -E -`.
+2. **Popups omit `HERDR_PANE_ID`** (`src/app/popup.rs:154`,
+   `PaneLaunchEnv::without_pane_identity()`), but do set `HERDR_ENV=1`
+   (`src/pane.rs:117`). Same shape as tmux popups, which drop `TMUX_PANE`
+   but keep `TMUX` — so both backends need a focused-pane fallback.
+3. **herdr captures OSC 52 from any pane and forwards it**
+   (`src/pane.rs:1851` → `AppEvent::ClipboardWrite`). So a herdr yank is
+   just the picker emitting OSC 52 itself; there is no herdr equivalent of
+   `tmux set-buffer -w` and none is needed.
+
+## Shared module: `src/mux.rs`
+
+New module holding what both features need, so neither owns it:
+
+- `pub enum Multiplexer { Tmux, Herdr, Unknown }`
+- `pub fn detect() -> Multiplexer` — moved out of `main.rs`.
+- `pub fn herdr_cli(args: &[&str]) -> Result<String>` — promoted from
+  `herdr_third.rs`, which then consumes it. This is the DRY payoff: one
+  place shells out to `herdr`, one place decides which multiplexer we are
+  in.
+
+### Detection change: `TMUX` counts, not just `TMUX_PANE`
+
+`detect_multiplexer` currently keys on `TMUX_PANE` alone. That is
+sufficient for `third` (invoked via `run-shell`, which sets it) but wrong
+for `pick-links`, which runs inside a tmux `display-popup` where
+`TMUX_PANE` is absent and only `TMUX` is set. New rule, in order:
+
+1. `TMUX_PANE` or `TMUX` set → **Tmux** (nested tmux-inside-herdr still
+   means tmux is what the user is looking at).
+2. else `HERDR_PANE_ID` or `HERDR_ENV` set → **Herdr**.
+3. else → **Unknown** (callers keep today's behavior: `third` falls
+   through to the tmux path; `pick-links` errors as it does now).
+
+**Consequence — the existing `third` binding must be updated.** It
+currently reads `env -u TMUX_PANE HERDR_ENV=1 rmux_helper third`. Once
+`TMUX` also implies tmux, a herdr server launched from inside tmux would
+leak `TMUX` into shell bindings and re-break the case that flag was added
+to fix. Both herdr bindings therefore clear **both** variables:
+`env -u TMUX -u TMUX_PANE HERDR_ENV=1 rmux_helper <cmd>`.
+
+## Per-backend seams in `link_picker`
+
+`link_picker/mod.rs` keeps its current orchestration shape (resolve →
+capture → detect → enrich → TUI → dispatch). Five touchpoints become
+backend-dispatched, each with a **pure argv/payload builder** that is unit
+tested, mirroring the `action_args` pattern from `herdr_third`:
+
+| Step | tmux (unchanged) | herdr |
+| --- | --- | --- |
+| Resolve pane | `TMUX_PANE`, else `display-message -p -t '#{client_active_pane}' '#{pane_id}'` | `HERDR_PANE_ID`, else `focused_pane_id` from `herdr pane layout` |
+| Capture | `capture-pane -p -J -S -300 -E - -t <pane>` | `pane read <pane> --source recent-unwrapped --lines 300` |
+| Yank | `tmux set-buffer -w <payload>` | write OSC 52 to `/dev/tty` |
+| Ssh | `tmux new-window` | not offered |
+| Swap to `pick-tui` | `execvp` | not offered |
+
+`SCROLLBACK_HISTORY_LINES = 300` stays one constant feeding both builders.
+
+### Yank under herdr
+
+Emit `ESC ] 52 ; c ; <base64(payload)> BEL` to `/dev/tty` after
+`tui::run` has restored the terminal. `/dev/tty` rather than stdout
+because stdout may be piped and the sequence must reach the pty herdr is
+parsing. No tmux passthrough wrapping — that is a tmux-only concern. If
+`/dev/tty` cannot be opened, return an error rather than silently
+succeeding. Adds one dependency: `base64 = "0.22"`.
+
+The existing `yank_to_clipboard_args` test (asserting `-w` and
+single-argument payload) stays untouched and keeps guarding the tmux path.
+
+### Action filtering under herdr
+
+`App` gains a `mux: Multiplexer` field, threaded in from `pick_links` via
+`tui::run(rows, mux)`:
+
+- Hint bar drops `F2:sess` under herdr.
+- `F2` becomes a no-op under herdr (it has no query semantics to fall back
+  to).
+- The `s` handler (Ssh) is guarded on `mux == Tmux`, so under herdr `s`
+  falls through to the generic character arm and types into the search
+  query like any other letter. A dead key would be strictly worse: `s` is
+  currently unavailable as the first character of a search precisely
+  because it triggers Ssh.
+- `default_action(row, mux)` — Server/Ip rows currently default to
+  `Action::Ssh`. Under herdr they default to `Action::Yank`, so Enter on a
+  host copies it instead of doing nothing. This is the one behavioral
+  difference a user will notice, and it is deliberate.
+
+## Config and docs
+
+`config/herdr/config.toml`, added with the other `[[keys.command]]` blocks
+(**below every plain `[keys]` entry** — see the warning comment already in
+that file; TOML array-of-tables scoping silently swallows bare keys placed
+after it and `herdr config check` does not catch it):
+
+```toml
+[[keys.command]]
+key = "prefix+shift+l"
+type = "popup"
+command = "env -u TMUX -u TMUX_PANE rmux_helper pick-links"
+width = "95%"
+height = "95%"
+```
+
+Matches the tmux binding's 95%×95% popup. The existing `prefix+/` `third`
+binding gains `-u TMUX` in the same commit. Docs: a row in the
+`config/herdr/README.md` keymap table and a note in
+`rust/tmux_helper/CLAUDE.md` that `pick-links` is multiplexer-aware.
+
+`PICKER_SPEC.md` covers `pick-tui`, not `pick-links`, so it needs no
+update.
+
+## Error handling
+
+- herdr CLI missing, socket dead, or malformed layout JSON → error with
+  context; no fallback to the tmux path.
+- `Multiplexer::Unknown` in `pick-links` → today's message
+  (`not inside tmux; nothing to capture`), reworded to name both
+  multiplexers.
+
+## Testing
+
+Unit tests (pure, no multiplexer required):
+
+- herdr capture argv: pane id first, `--source recent-unwrapped`,
+  `--lines 300` derived from the shared constant.
+- OSC 52 payload bytes: correct prefix/terminator, base64 correctness,
+  payloads containing spaces and non-ASCII.
+- `focused_pane_id` extracted from a captured `pane layout` JSON fixture.
+- `default_action` returns Yank for Server/Ip under herdr, Ssh under tmux.
+- Detection precedence: `TMUX` alone → Tmux; `HERDR_ENV` alone → Herdr;
+  `TMUX` + `HERDR_ENV` → Tmux; neither → Unknown. Tested through a pure
+  function taking the four values as parameters, so no environment
+  mutation and no cross-test races.
+
+Integration: `rmux_helper pick-links --json` run inside a herdr pane
+(headless, no TUI) must emit rows detected from that pane's real
+scrollback.
+
+Manual, needs Igor: `C-a L` popup renders and is navigable under herdr;
+Enter/`y` on a row lands the URL on the Mac clipboard through herdr's OSC
+52 forwarding. Regression: the tmux `C-a L` popup still works unchanged.

--- a/docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md
+++ b/docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md
@@ -29,7 +29,7 @@ Cloned `github.com/herdrdev/herdr` at `d742e51` and read the relevant paths:
 
 1. **`herdr pane read` takes the pane id FIRST** (`src/cli/pane.rs:443-451`):
    `herdr pane read <pane_id> [--source visible|recent|recent-unwrapped]
-   [--lines N]`. An earlier session passed the args out of order, got
+[--lines N]`. An earlier session passed the args out of order, got
    `unknown option: recent`, and wrongly concluded the server was too old.
    Verified live on a 500-line shell pane: `--lines 400` returns 400 lines,
    and `--source recent-unwrapped` joins soft-wrapped lines. This is the
@@ -81,13 +81,13 @@ capture → detect → enrich → TUI → dispatch). Five touchpoints become
 backend-dispatched, each with a **pure argv/payload builder** that is unit
 tested, mirroring the `action_args` pattern from `herdr_third`:
 
-| Step | tmux (unchanged) | herdr |
-| --- | --- | --- |
-| Resolve pane | `TMUX_PANE`, else `display-message -p -t '#{client_active_pane}' '#{pane_id}'` | `HERDR_PANE_ID`, else `focused_pane_id` from `herdr pane layout` |
-| Capture | `capture-pane -p -J -S -300 -E - -t <pane>` | `pane read <pane> --source recent-unwrapped --lines 300` |
-| Yank | `tmux set-buffer -w <payload>` | write OSC 52 to `/dev/tty` |
-| Ssh | `tmux new-window` | not offered |
-| Swap to `pick-tui` | `execvp` | not offered |
+| Step               | tmux (unchanged)                                                               | herdr                                                            |
+| ------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Resolve pane       | `TMUX_PANE`, else `display-message -p -t '#{client_active_pane}' '#{pane_id}'` | `HERDR_PANE_ID`, else `focused_pane_id` from `herdr pane layout` |
+| Capture            | `capture-pane -p -J -S -300 -E - -t <pane>`                                    | `pane read <pane> --source recent-unwrapped --lines 300`         |
+| Yank               | `tmux set-buffer -w <payload>`                                                 | write OSC 52 to `/dev/tty`                                       |
+| Ssh                | `tmux new-window`                                                              | not offered                                                      |
+| Swap to `pick-tui` | `execvp`                                                                       | not offered                                                      |
 
 `SCROLLBACK_HISTORY_LINES = 300` stays one constant feeding both builders.
 

--- a/rust/tmux_helper/CLAUDE.md
+++ b/rust/tmux_helper/CLAUDE.md
@@ -13,7 +13,7 @@ The spec documents the _what_ (behavior rules), not the _how_ (implementation). 
 - `pick-tui` - Native TUI picker for sessions/windows/panes
 - `rename-all` - Rename all windows based on running processes
 - `rotate` - Toggle between horizontal/vertical layouts
-- `third` - Toggle between even and 1/3-2/3 split. Works under tmux and herdr (auto-detected via TMUX_PANE, else HERDR_PANE_ID or HERDR_ENV; bare toggle only under herdr — the `third "<cmd>"` form is tmux-only)
+- `third` - Toggle between even and 1/3-2/3 split. Works under tmux and herdr (auto-detected via TMUX_PANE or TMUX, else HERDR_PANE_ID or HERDR_ENV; bare toggle only under herdr — the `third "<cmd>"` form is tmux-only)
 - `pick-links` - Scrollback link/PR/host picker. Works under tmux and herdr (auto-detected); under herdr the ssh and F2-swap actions are not offered and yank goes out as OSC 52
 - `parent-pid-tree` - Resolve caller's owning tmux pane by walking the parent-PID chain (see below)
 - `agent-continue` - Scan the caller's pane for `claude --resume <UUID>` and exec it in place. See below.

--- a/rust/tmux_helper/CLAUDE.md
+++ b/rust/tmux_helper/CLAUDE.md
@@ -14,6 +14,7 @@ The spec documents the _what_ (behavior rules), not the _how_ (implementation). 
 - `rename-all` - Rename all windows based on running processes
 - `rotate` - Toggle between horizontal/vertical layouts
 - `third` - Toggle between even and 1/3-2/3 split. Works under tmux and herdr (auto-detected via TMUX_PANE, else HERDR_PANE_ID or HERDR_ENV; bare toggle only under herdr — the `third "<cmd>"` form is tmux-only)
+- `pick-links` - Scrollback link/PR/host picker. Works under tmux and herdr (auto-detected); under herdr the ssh and F2-swap actions are not offered and yank goes out as OSC 52
 - `parent-pid-tree` - Resolve caller's owning tmux pane by walking the parent-PID chain (see below)
 - `agent-continue` - Scan the caller's pane for `claude --resume <UUID>` and exec it in place. See below.
 - `agent-yolo-continue` - Same, but launches through `yolo-claude` (container only).

--- a/rust/tmux_helper/Cargo.lock
+++ b/rust/tmux_helper/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +733,7 @@ version = "0.1.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
+ "base64",
  "clap",
  "clap_complete",
  "crossterm 0.29.0",

--- a/rust/tmux_helper/Cargo.toml
+++ b/rust/tmux_helper/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1"
 unicode-width = "0.2"
 dirs = "5"
 libc = "0.2"
+base64 = "0.22"
 
 [profile.release]
 opt-level = 3

--- a/rust/tmux_helper/LINK_PICKER_SPEC.md
+++ b/rust/tmux_helper/LINK_PICKER_SPEC.md
@@ -43,7 +43,7 @@ Categories: fixed order above. Within a category: most-recent line first (closes
 - `←`: drill out (in drilled-in mode)
 - `Esc`: drill out (first press) or quit (if already flat)
 - `Tab` / `S-Tab`: reserved, no-op
-- `F2`: swap to `pick-tui` (bidirectional)
+- `F2`: swap to `pick-tui` (bidirectional). **tmux only** — under herdr the key is inert (no-op), since `pick-tui` execs a tmux-only picker and herdr already has its own session picker (prefix+w).
 - `?` or `F1`: toggle the modal help overlay. Any key dismisses it (the
   dismissing key is consumed, so it cannot double as a navigation or action
   key). `?` is intercepted before the generic filter-query char handler, so
@@ -56,14 +56,16 @@ Categories: fixed order above. Within a category: most-recent line first (closes
 Default `Enter` (on leaf):
 
 - URL categories → OSC 52 yank + print URL to stdout
-- Servers / IPs → `tmux new-window -t "$pane_id" -c '#{pane_current_path}' "ssh <host>"`
+- Servers / IPs → **under tmux**: `tmux new-window -t "$pane_id" -c '#{pane_current_path}' "ssh <host>"`. **Under herdr**: `Ssh` is not offered (opening a tmux window isn't meaningful there), so these rows default to the same OSC 52 yank as URL categories — a dead `Enter` key would be worse than copying the host.
 
 Override keys (query must be empty — lowercase letters otherwise type into search):
 
 - `y` — yank (OSC 52)
 - `o` — `open`/`xdg-open`
 - `g` — `gh <kind> view --web -R OWNER/REPO <id>` (GitHub rows only)
-- `s` — force ssh
+- `s` — force ssh. **tmux only** — under herdr the key guard requires tmux, so `s` falls through to the generic filter-query handler and types into the search field instead.
+
+The OSC 52 yank mechanism itself differs by backend: under tmux the payload goes out via `tmux set-buffer -w` (tmux forwards OSC 52 to attached clients); under herdr `pick-links` writes the OSC 52 escape directly to `/dev/tty` for herdr to parse out of the pane's pty and forward to the client's clipboard.
 
 ## Filtering
 
@@ -81,7 +83,7 @@ Digit-only tokens match the `key` column only.
 
 ## Cross-picker shortcut
 
-`F2` cleanly tears down the TUI (`disable_raw_mode` + `LeaveAlternateScreen` + drop terminal + flush) then `execvp`s the sibling binary with `TMUX_PANE` forwarded. OSC 52 is NOT written on `F2` — it's a swap, not an action.
+**tmux only.** `F2` cleanly tears down the TUI (`disable_raw_mode` + `LeaveAlternateScreen` + drop terminal + flush) then `execvp`s the sibling binary with `TMUX_PANE` forwarded. OSC 52 is NOT written on `F2` — it's a swap, not an action. Under herdr, `F2` is gated on the detected multiplexer and never reaches this code path at all.
 
 ## OSC 52 timing
 
@@ -93,8 +95,11 @@ When scrollback contains no detectable items, the TUI is not entered. `pick_link
 
 ## Scrollback capture
 
-`pick-links` scans the current tmux pane's scrollback only — no cross-pane, no cross-session, no external sources. The pane is resolved from `$TMUX_PANE`, falling back to `tmux display-message -p '#{client_active_pane}'`.
+`pick-links` scans the current pane's scrollback only — no cross-pane, no cross-session, no external sources. The multiplexer is auto-detected and capture takes one of two paths:
 
-History depth is **capped at 300 lines above the visible pane top** (`tmux capture-pane -J -S -300 -E -`). The visible pane content is always included in full; the cap only limits how deep into scrollback we go. This keeps results relevant to recent work — a 50 000-line `history-limit` buffer produces stale context from days-old sessions that drowns real results in noise. 300 lines is roughly several screens of recent scrollback.
+- **tmux**: the pane is resolved from `$TMUX_PANE`, falling back to `tmux display-message -p '#{client_active_pane}'`. Scrollback comes from `tmux capture-pane -J -S -300 -E -`.
+- **herdr**: the pane is resolved from `$HERDR_PANE_ID`, falling back to the layout's focused pane. Scrollback comes from `herdr pane read <id> --source recent-unwrapped --lines 300`.
 
-The `-J` flag joins soft-wrapped lines so URLs that wrapped across terminal rows read back whole. ANSI escape bytes are NOT captured (`-e` is deliberately omitted) because raw `\x1b` sequences leak through ratatui's cell rendering into the popup pty and corrupt the display.
+History depth is **capped at 300 lines above the visible pane top** on both backends. The visible pane content is always included in full; the cap only limits how deep into scrollback we go. This keeps results relevant to recent work — a 50 000-line `history-limit` buffer produces stale context from days-old sessions that drowns real results in noise. 300 lines is roughly several screens of recent scrollback.
+
+Both backends join soft-wrapped lines so URLs that wrapped across terminal rows read back whole (tmux's `-J`; herdr's `recent-unwrapped` source). ANSI escape bytes are NOT captured on either path — for tmux, `-e` is deliberately omitted because raw `\x1b` sequences leak through ratatui's cell rendering into the popup pty and corrupt the display.

--- a/rust/tmux_helper/LINK_PICKER_SPEC.md
+++ b/rust/tmux_helper/LINK_PICKER_SPEC.md
@@ -87,7 +87,12 @@ Digit-only tokens match the `key` column only.
 
 ## OSC 52 timing
 
-Write sequence, in order: TUI exits → `disable_raw_mode` → `LeaveAlternateScreen` → drop `Terminal` → flush stdout/stderr → open `/dev/tty` → write `\e]52;c;<base64>\e\\` → flush tty → `exit(0)`.
+Common to both backends: TUI exits → `disable_raw_mode` → `LeaveAlternateScreen` → drop `Terminal` → flush stdout/stderr (all inside `tui::run`, before the action is dispatched).
+
+Backend-specific dispatch after that:
+
+- **tmux**: spawn `tmux set-buffer -w <payload>` (the raw payload, not a pre-built OSC 52 escape — tmux constructs and forwards the OSC 52 sequence to attached clients itself) → `exit(0)`.
+- **herdr**: open `/dev/tty` → write `\e]52;c;<base64>` terminated with **BEL** (`\x07`), not ST (`\e\\`) → flush tty → `exit(0)`.
 
 ## Empty state
 

--- a/rust/tmux_helper/src/herdr_third.rs
+++ b/rust/tmux_helper/src/herdr_third.rs
@@ -4,44 +4,8 @@
 //! pure decision function over the parsed `herdr pane layout` JSON; the shell
 //! functions that invoke the CLI live at the bottom and stay logic-free.
 
-use anyhow::{bail, Context, Result};
-use serde::Deserialize;
-use std::process::Command;
-
-#[derive(Deserialize, Debug)]
-pub struct LayoutResponse {
-    pub result: LayoutResult,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct LayoutResult {
-    pub layout: TabLayout,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct TabLayout {
-    pub panes: Vec<PaneEntry>,
-    #[serde(default)]
-    pub splits: Vec<SplitEntry>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct PaneEntry {
-    pub pane_id: String,
-    pub rect: Rect,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct SplitEntry {
-    pub direction: String,
-    pub ratio: f64,
-}
-
-#[derive(Deserialize, Debug, Clone, Copy)]
-pub struct Rect {
-    pub x: i64,
-    pub y: i64,
-}
+use crate::mux::{self, PaneEntry, TabLayout};
+use anyhow::{bail, Result};
 
 pub const THIRD_RATIO: f64 = 1.0 / 3.0;
 pub const EVEN_RATIO: f64 = 0.5;
@@ -103,33 +67,6 @@ pub fn plan_third(layout: &TabLayout) -> ThirdAction {
     }
 }
 
-fn herdr_cli(args: &[&str]) -> Result<String> {
-    let out = Command::new("herdr")
-        .args(args)
-        .output()
-        .context("failed to run `herdr` — is it installed and on PATH?")?;
-    if !out.status.success() {
-        bail!(
-            "herdr {:?} failed: {}",
-            args,
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&out.stdout).to_string())
-}
-
-fn fetch_layout(pane: Option<&str>) -> Result<TabLayout> {
-    let mut args = vec!["pane", "layout"];
-    if let Some(p) = pane {
-        args.extend(["--pane", p]);
-    }
-    // Without --pane, herdr reports the focused tab — correct for a keybinding.
-    let json = herdr_cli(&args)?;
-    let resp: LayoutResponse =
-        serde_json::from_str(&json).context("unexpected JSON from `herdr pane layout`")?;
-    Ok(resp.result.layout)
-}
-
 /// Map a planned action to the exact `herdr` CLI argument vector, or `None`
 /// for `Noop`. Pure and unit-tested independent of any I/O — mirrors
 /// `build_exec_argv` in `agent_continue.rs`.
@@ -176,11 +113,11 @@ pub fn cmd(command: &str) -> Result<()> {
         );
     }
     let caller = std::env::var("HERDR_PANE_ID").ok().filter(|s| !s.is_empty());
-    let layout = fetch_layout(caller.as_deref())?;
+    let layout = mux::fetch_layout(caller.as_deref())?;
     let action = plan_third(&layout);
     if let Some(args) = action_args(&action) {
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        herdr_cli(&arg_refs)?;
+        mux::herdr_cli(&arg_refs)?;
     }
     Ok(())
 }
@@ -188,13 +125,14 @@ pub fn cmd(command: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mux::{Rect, SplitEntry};
 
     // Captured verbatim from `herdr pane layout --pane w9:p1` on 2026-08-02.
     const SINGLE_PANE_JSON: &str = r#"{"id":"cli:pane:layout","result":{"layout":{"area":{"height":56,"width":170,"x":18,"y":1},"focused_pane_id":"w9:p1","panes":[{"focused":true,"pane_id":"w9:p1","rect":{"height":56,"width":170,"x":18,"y":1}}],"splits":[],"tab_id":"w9:t1","workspace_id":"w9","zoomed":false},"type":"pane_layout"}}"#;
     const TWO_PANE_THIRD_JSON: &str = r#"{"id":"cli:pane:layout","result":{"layout":{"area":{"height":56,"width":170,"x":18,"y":1},"focused_pane_id":"w9:p1","panes":[{"focused":true,"pane_id":"w9:p1","rect":{"height":56,"width":56,"x":18,"y":1}},{"focused":false,"pane_id":"w9:p2","rect":{"height":56,"width":114,"x":74,"y":1}}],"splits":[{"direction":"right","id":"split_0_root","ratio":0.33,"rect":{"height":56,"width":170,"x":18,"y":1}}],"tab_id":"w9:t1","workspace_id":"w9","zoomed":false},"type":"pane_layout"}}"#;
 
     fn parse(json: &str) -> TabLayout {
-        serde_json::from_str::<LayoutResponse>(json)
+        serde_json::from_str::<crate::mux::LayoutResponse>(json)
             .expect("layout JSON should parse")
             .result
             .layout
@@ -204,6 +142,7 @@ mod tests {
         // Rects only matter for left/top-first ordering; give pane 2 the larger x/y.
         let (x2, y2) = if direction == "right" { (100, 0) } else { (0, 30) };
         TabLayout {
+            focused_pane_id: "w9:p1".into(),
             panes: vec![
                 PaneEntry {
                     pane_id: "w9:p1".into(),

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -49,7 +49,7 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
         eprintln!("pick-links: no links, servers, or IPs in scrollback");
         return Ok(());
     }
-    let action = tui::run(rows)?;
+    let action = tui::run(rows, mux)?;
 
     // 6-7. Dispatch post-TUI (terminal already restored by tui::run).
     match action {

--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -11,11 +11,26 @@ use std::process::Command;
 
 /// Entry point for `rmux_helper pick-links`. See spec §Execution Flow.
 pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
-    // 1. Resolve pane
-    let pane_id = resolve_pane_id()?;
+    let mux = crate::mux::detect();
 
-    // 2. Capture (sync, fallible)
-    let raw = capture_pane(&pane_id)?;
+    // 1. Resolve pane + 2. capture (sync, fallible)
+    let (pane_id, raw) = match mux {
+        crate::mux::Multiplexer::Tmux => {
+            let pane_id = resolve_pane_id()?;
+            let raw = capture_pane(&pane_id)?;
+            (pane_id, raw)
+        }
+        crate::mux::Multiplexer::Herdr => {
+            let pane_id = resolve_herdr_pane_id()?;
+            let raw = herdr_capture_pane(&pane_id)?;
+            (pane_id, raw)
+        }
+        crate::mux::Multiplexer::Unknown => {
+            return Err(anyhow!(
+                "pick-links: not inside tmux or herdr; nothing to capture"
+            ))
+        }
+    };
 
     // 3. Detect
     let rows = detect::parse(&raw);
@@ -40,7 +55,10 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     match action {
         tui::Action::Quit => std::process::exit(130),
         tui::Action::Yank(row) => {
-            yank_to_clipboard(&row.canonical)?;
+            match mux {
+                crate::mux::Multiplexer::Herdr => yank_osc52(&row.canonical)?,
+                _ => yank_to_clipboard(&row.canonical)?,
+            }
             println!("{}", row.canonical);
         }
         tui::Action::Open(row) => open_url(&row.canonical)?,
@@ -163,10 +181,8 @@ fn resolve_pane_id() -> Result<String> {
             return Ok(p);
         }
     }
-    if env::var("TMUX").is_err() {
-        return Err(anyhow!("pick-links: not inside tmux; nothing to capture"));
-    }
-    // Fallback: ask tmux directly.
+    // Fallback: ask tmux directly. Reached from display-popup, which sets
+    // TMUX but not TMUX_PANE.
     let out = Command::new("tmux")
         .args(["display-message", "-p", "-t", "#{client_active_pane}", "#{pane_id}"])
         .output()
@@ -206,6 +222,81 @@ pub(crate) fn capture_pane_args(pane_id: &str) -> Vec<String> {
         "-t".to_string(),
         pane_id.to_string(),
     ]
+}
+
+/// Build the argv for `herdr pane read`. The pane id is POSITIONAL and must
+/// come first — herdr rejects `pane read --source recent <id>` with
+/// "unknown option: <id>". `recent-unwrapped` is herdr's equivalent of
+/// tmux's `capture-pane -J`: it joins soft-wrapped lines so a URL that
+/// wrapped across terminal rows reads back whole.
+pub(crate) fn herdr_capture_args(pane_id: &str) -> Vec<String> {
+    vec![
+        "pane".to_string(),
+        "read".to_string(),
+        pane_id.to_string(),
+        "--source".to_string(),
+        "recent-unwrapped".to_string(),
+        "--lines".to_string(),
+        SCROLLBACK_HISTORY_LINES.to_string(),
+    ]
+}
+
+/// Build the OSC 52 clipboard escape for `text`.
+///
+/// `ESC ] 52 ; c ; <base64> BEL` — `c` is the clipboard selection. herdr
+/// parses this out of the pane's pty and forwards it to the client's OS
+/// clipboard, so under herdr this replaces tmux's `set-buffer -w` entirely.
+/// No tmux passthrough wrapping: that is a tmux-only concern and this path
+/// only runs under herdr.
+pub(crate) fn osc52_payload(text: &str) -> Vec<u8> {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let mut out = b"\x1b]52;c;".to_vec();
+    out.extend_from_slice(STANDARD.encode(text).as_bytes());
+    out.push(0x07);
+    out
+}
+
+/// Write the OSC 52 escape to the controlling terminal.
+///
+/// `/dev/tty` rather than stdout: stdout may be piped (`pick-links --json`,
+/// shell capture), and the escape has to reach the pty herdr is parsing.
+fn yank_osc52(payload: &str) -> Result<()> {
+    use std::io::Write;
+    let mut tty = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/tty")
+        .map_err(|e| anyhow!("cannot open /dev/tty for clipboard write: {e}"))?;
+    tty.write_all(&osc52_payload(payload))
+        .map_err(|e| anyhow!("failed writing OSC 52 to /dev/tty: {e}"))?;
+    tty.flush()
+        .map_err(|e| anyhow!("failed flushing OSC 52 to /dev/tty: {e}"))?;
+    Ok(())
+}
+
+/// Capture the recent scrollback of `pane_id` via `herdr pane read`.
+fn herdr_capture_pane(pane_id: &str) -> Result<String> {
+    let args = herdr_capture_args(pane_id);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::mux::herdr_cli(&arg_refs)
+}
+
+/// Resolve the herdr pane to capture: the launching pane when herdr set it,
+/// otherwise the focused pane. Popups get `HERDR_ENV` but not
+/// `HERDR_PANE_ID`, and `C-a L` is bound as a popup — so the fallback is
+/// the common path, not the edge case.
+fn resolve_herdr_pane_id() -> Result<String> {
+    if let Ok(p) = env::var("HERDR_PANE_ID") {
+        if !p.is_empty() {
+            return Ok(p);
+        }
+    }
+    let layout = crate::mux::fetch_layout(None)?;
+    if layout.focused_pane_id.is_empty() {
+        return Err(anyhow!(
+            "pick-links: herdr reported no focused pane to capture"
+        ));
+    }
+    Ok(layout.focused_pane_id)
 }
 
 /// Capture the recent scrollback of `pane_id` via `tmux capture-pane`.
@@ -297,5 +388,49 @@ mod orchestration_tests {
             !args.iter().any(|a| a == "-e"),
             "must NOT include ANSI escapes (they corrupt popup rendering)"
         );
+    }
+
+    #[test]
+    fn herdr_capture_args_put_pane_id_first_and_cap_history() {
+        // herdr's CLI takes the pane id POSITIONALLY, before any flags —
+        // `herdr pane read --source recent w9:p1` fails with
+        // "unknown option: w9:p1". Regression guard for that arg order.
+        let args = herdr_capture_args("w9:p1");
+        assert_eq!(args[0], "pane");
+        assert_eq!(args[1], "read");
+        assert_eq!(args[2], "w9:p1", "pane id must be the first positional");
+        let src = args.iter().position(|a| a == "--source").expect("needs --source");
+        assert_eq!(
+            args[src + 1],
+            "recent-unwrapped",
+            "must join soft-wrapped lines so wrapped URLs read back whole"
+        );
+        let lines = args.iter().position(|a| a == "--lines").expect("needs --lines");
+        assert_eq!(
+            args[lines + 1],
+            SCROLLBACK_HISTORY_LINES.to_string(),
+            "history depth must come from the shared constant"
+        );
+    }
+
+    #[test]
+    fn osc52_payload_wraps_base64_in_the_clipboard_escape() {
+        let bytes = osc52_payload("hi");
+        assert_eq!(bytes, b"\x1b]52;c;aGk=\x07".to_vec());
+    }
+
+    #[test]
+    fn osc52_payload_encodes_spaces_and_non_ascii() {
+        // URLs with spaces or unicode must survive the base64 hop intact.
+        let text = "https://example.com/a b/\u{e9}";
+        let bytes = osc52_payload(text);
+        let s = String::from_utf8(bytes).expect("escape is valid utf8");
+        let b64 = s
+            .strip_prefix("\x1b]52;c;")
+            .and_then(|s| s.strip_suffix('\x07'))
+            .expect("must be wrapped in the OSC 52 prefix and BEL terminator");
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        let decoded = STANDARD.decode(b64).expect("payload must be valid base64");
+        assert_eq!(String::from_utf8(decoded).unwrap(), text);
     }
 }

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -1,6 +1,7 @@
 //! Ratatui TUI for the link picker. See spec §Layout & Display and §Navigation.
 
 use crate::link_picker::detect::{Category, GhState, Row};
+use crate::mux::Multiplexer;
 use ansi_to_tui::IntoText;
 use anyhow::Result;
 use crossterm::{
@@ -39,10 +40,11 @@ struct App {
     horizontal: bool,
     show_help: bool,
     action: Option<Action>,
+    mux: Multiplexer,
 }
 
 impl App {
-    fn new(rows: Vec<Row>) -> Self {
+    fn new(rows: Vec<Row>, mux: Multiplexer) -> Self {
         let mut app = Self {
             rows,
             filtered: Vec::new(),
@@ -53,6 +55,7 @@ impl App {
             horizontal: true,
             show_help: false,
             action: None,
+            mux,
         };
         app.rebuild_filter();
         app
@@ -271,7 +274,7 @@ mod help_overlay_tests {
             count: 1,
             most_recent_line: 0,
         };
-        App::new(vec![row])
+        App::new(vec![row], Multiplexer::Tmux)
     }
 
     #[test]
@@ -460,11 +463,69 @@ mod help_overlay_tests {
             "help overlay title must NOT be visible when show_help=false"
         );
     }
+
+    fn server_row() -> Row {
+        Row {
+            category: Category::Server,
+            canonical: "c-5001".into(),
+            key: "c-5001".into(),
+            repo_or_host: "—".into(),
+            context: "ssh c-5001".into(),
+            enriched: None,
+            count: 1,
+            most_recent_line: 0,
+        }
+    }
+
+    #[test]
+    fn server_row_defaults_to_ssh_under_tmux() {
+        assert!(matches!(
+            default_action(&server_row(), Multiplexer::Tmux),
+            Action::Ssh(_)
+        ));
+    }
+
+    #[test]
+    fn server_row_defaults_to_yank_under_herdr() {
+        // Ssh is not offered under herdr, so Enter on a host must copy it
+        // rather than silently doing nothing.
+        assert!(matches!(
+            default_action(&server_row(), Multiplexer::Herdr),
+            Action::Yank(_)
+        ));
+    }
+
+    #[test]
+    fn s_key_types_into_the_query_under_herdr() {
+        // Under tmux `s` fires Ssh; under herdr it must fall through to the
+        // generic character arm so `s` is usable as a search character.
+        let mut app = App::new(vec![server_row()], Multiplexer::Herdr);
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('s'));
+        assert!(app.action.is_none(), "must not fire an action under herdr");
+        assert_eq!(app.query, "s", "must type into the search query instead");
+    }
+
+    #[test]
+    fn s_key_fires_ssh_under_tmux() {
+        let mut app = App::new(vec![server_row()], Multiplexer::Tmux);
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::Char('s'));
+        assert!(matches!(app.action, Some(Action::Ssh(_))));
+        assert!(app.query.is_empty(), "must not also type into the query");
+    }
+
+    #[test]
+    fn f2_is_inert_under_herdr() {
+        // herdr's own prefix+w is the session picker; swapping to pick-tui
+        // would exec a tmux-only TUI.
+        let mut app = App::new(vec![server_row()], Multiplexer::Herdr);
+        handle_key(&mut app, KeyModifiers::NONE, KeyCode::F(2));
+        assert!(app.action.is_none());
+    }
 }
 
 // ----- Run loop + rendering -----
 
-pub fn run(rows: Vec<Row>) -> Result<Action> {
+pub fn run(rows: Vec<Row>, mux: Multiplexer) -> Result<Action> {
     if rows.is_empty() {
         return Ok(Action::Quit);
     }
@@ -474,7 +535,7 @@ pub fn run(rows: Vec<Row>) -> Result<Action> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(rows);
+    let mut app = App::new(rows, mux);
 
     // First draw so the terminal is in its intended state, then drain any
     // queued events. Tmux popups inject terminal-state responses (cursor
@@ -520,16 +581,22 @@ fn draw(f: &mut Frame, app: &mut App) {
         .split(area);
 
     // Top bar with breadcrumb or flat hints.
+    let sess_hint = if app.mux == Multiplexer::Tmux {
+        " F2:sess"
+    } else {
+        ""
+    };
     let top = if let Some(cat) = app.drilled_in {
         format!(
-            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back ?:help F2:sess",
+            "pick> {}_  │ Links › {}  │ ↑↓ Enter:act ←:back ?:help{}",
             app.query,
-            cat.display()
+            cat.display(),
+            sess_hint
         )
     } else {
         format!(
-            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh ?:help F2:sess",
-            app.query
+            "pick> {}_  │ ↑↓ Enter:act →:drill y:yank o:open g:gh ?:help{}",
+            app.query, sess_hint
         )
     };
     f.render_widget(
@@ -801,7 +868,9 @@ fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
             }
         }
         KeyCode::Enter => app.on_enter(),
-        KeyCode::F(2) => app.action = Some(Action::SwapToPickTui),
+        KeyCode::F(2) if app.mux == Multiplexer::Tmux => {
+            app.action = Some(Action::SwapToPickTui)
+        }
         KeyCode::Backspace => {
             app.query.pop();
             app.rebuild_filter();
@@ -846,7 +915,9 @@ fn handle_key(app: &mut App, mods: KeyModifiers, code: KeyCode) {
                 }
             }
         }
-        KeyCode::Char('s') if mods.is_empty() && app.query.is_empty() => {
+        KeyCode::Char('s')
+            if mods.is_empty() && app.query.is_empty() && app.mux == Multiplexer::Tmux =>
+        {
             if let Some(row) = app.selected_leaf() {
                 app.action = Some(Action::Ssh(row));
             }
@@ -917,14 +988,16 @@ impl App {
         }
         // Leaf: default action
         let row = self.rows[idx].clone();
-        self.action = Some(default_action(&row));
+        self.action = Some(default_action(&row, self.mux));
     }
 }
 
 /// Default Enter action per category (see spec §Actions → Default).
-pub(crate) fn default_action(row: &Row) -> Action {
+/// Under herdr, Server/Ip rows fall back to Yank — the Ssh action is
+/// tmux-only, and a dead Enter key would be worse than copying the host.
+pub(crate) fn default_action(row: &Row, mux: Multiplexer) -> Action {
     match row.category {
-        Category::Server | Category::Ip => Action::Ssh(row.clone()),
+        Category::Server | Category::Ip if mux == Multiplexer::Tmux => Action::Ssh(row.clone()),
         _ => Action::Yank(row.clone()),
     }
 }

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -264,6 +264,10 @@ mod help_overlay_tests {
     use super::*;
 
     fn app_with_one_row() -> App {
+        app_with_mux(Multiplexer::Tmux)
+    }
+
+    fn app_with_mux(mux: Multiplexer) -> App {
         let row = Row {
             category: Category::Server,
             canonical: "c-5001".into(),
@@ -274,7 +278,7 @@ mod help_overlay_tests {
             count: 1,
             most_recent_line: 0,
         };
-        App::new(vec![row], Multiplexer::Tmux)
+        App::new(vec![row], mux)
     }
 
     #[test]
@@ -381,13 +385,13 @@ mod help_overlay_tests {
     }
 
     #[test]
-    fn help_text_documents_every_actionable_key() {
+    fn help_text_documents_every_actionable_key_under_tmux() {
         // If someone removes a documented key's mention from help_lines,
         // this test fires. It does NOT enforce the inverse direction
         // (adding a brand-new handler still requires updating the needle
         // list below) — that's a harder coupling to automate without
         // parsing handle_key's source.
-        let body: String = help_lines()
+        let body: String = help_lines(Multiplexer::Tmux)
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
             .collect::<Vec<_>>()
@@ -410,6 +414,49 @@ mod help_overlay_tests {
             assert!(
                 body.contains(needle),
                 "help panel must document `{needle}` — got:\n{body}"
+            );
+        }
+    }
+
+    #[test]
+    fn help_text_omits_tmux_only_keys_under_herdr() {
+        // Inverse of the above: under herdr, `s` types into the query and
+        // `F2` is inert, so the overlay must not tell the user those keys
+        // fire an action. The Enter line must also stop claiming ssh
+        // behavior, since Server/Ip rows default to Yank under herdr.
+        let body: String = help_lines(Multiplexer::Herdr)
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            !body.contains("F2"),
+            "herdr help must not mention F2 (inert there) — got:\n{body}"
+        );
+        assert!(
+            !body.contains("force ssh"),
+            "herdr help must not tell the user `s` forces ssh — got:\n{body}"
+        );
+        assert!(
+            !body.contains("ssh server or IP"),
+            "herdr help Enter line must not claim ssh-on-Enter behavior — got:\n{body}"
+        );
+        // Still documents everything that DOES work under herdr.
+        for needle in [
+            "Enter",
+            "Esc",
+            "C-c",
+            "C-l",
+            "y",
+            "o",
+            "g",
+            "Backspace",
+            "drill",
+            "yank",
+        ] {
+            assert!(
+                body.contains(needle),
+                "herdr help panel must still document `{needle}` — got:\n{body}"
             );
         }
     }
@@ -461,6 +508,46 @@ mod help_overlay_tests {
         assert!(
             !rendered.contains("Help — pick-links"),
             "help overlay title must NOT be visible when show_help=false"
+        );
+    }
+
+    #[test]
+    fn hint_bar_shows_f2_sess_under_tmux() {
+        use ratatui::backend::TestBackend;
+        let mut app = app_with_mux(Multiplexer::Tmux);
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            rendered.contains("F2:sess"),
+            "tmux hint bar must advertise F2:sess; got buffer:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn hint_bar_omits_f2_sess_under_herdr() {
+        use ratatui::backend::TestBackend;
+        let mut app = app_with_mux(Multiplexer::Herdr);
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            !rendered.contains("F2:sess"),
+            "herdr hint bar must NOT advertise F2:sess (F2 is inert there); got buffer:\n{rendered}"
         );
     }
 
@@ -642,13 +729,19 @@ fn draw(f: &mut Frame, app: &mut App) {
 
     // Help overlay (modal): render last so it paints on top of the list/preview.
     if app.show_help {
-        draw_help_overlay(f, area);
+        draw_help_overlay(f, area, app.mux);
     }
 }
 
 /// Build the help overlay content. Pulled out so the exact key list is easy
 /// to eyeball and keep in sync with `handle_key`.
-fn help_lines() -> Vec<Line<'static>> {
+///
+/// `mux`-aware: `s` (force ssh) and `F2` (swap to pick-tui) are tmux-only —
+/// under herdr `s` falls through to the query filter and `F2` is inert, so
+/// documenting them there would tell the user to press a key that either
+/// types into the search box or does nothing. The `Enter` line likewise
+/// describes tmux's ssh-on-Server/Ip default vs. herdr's yank-only default.
+fn help_lines(mux: Multiplexer) -> Vec<Line<'static>> {
     let hdr = Style::default()
         .fg(Color::LightCyan)
         .add_modifier(Modifier::BOLD);
@@ -664,7 +757,9 @@ fn help_lines() -> Vec<Line<'static>> {
         ])
     };
 
-    vec![
+    let is_tmux = mux == Multiplexer::Tmux;
+
+    let mut lines = vec![
         Line::from(Span::styled("Navigation", hdr)),
         kv("↑ ↓ / C-p C-n", "move selection (headers selectable)"),
         kv("→ / Enter", "drill into category header"),
@@ -672,27 +767,37 @@ fn help_lines() -> Vec<Line<'static>> {
         kv("1 – 9", "jump into Nth non-empty category (empty query)"),
         Line::from(""),
         Line::from(Span::styled("Actions (empty query)", hdr)),
-        kv("Enter", "default: yank URL / ssh server or IP"),
-        kv("y", "yank canonical via OSC 52"),
-        kv("o", "open / xdg-open in browser"),
-        kv("g", "gh view --web (GitHub rows only)"),
-        kv("s", "force ssh in new tmux window"),
-        Line::from(""),
-        Line::from(Span::styled("Filter", hdr)),
-        kv("a – z 0 – 9", "type into filter query"),
-        kv("Backspace", "delete last character"),
-        kv("C-c", "clear query (or quit if empty)"),
-        Line::from(""),
-        Line::from(Span::styled("Display & picker swap", hdr)),
-        kv("C-l", "toggle horizontal/vertical split"),
-        kv("F2", "swap to rmux_helper pick-tui (session picker)"),
-        kv("? / F1", "toggle this help overlay"),
-        Line::from(""),
-        Line::from(Span::styled("  Press any key to dismiss.", dim)),
-    ]
+    ];
+    if is_tmux {
+        lines.push(kv("Enter", "default: yank URL / ssh server or IP"));
+    } else {
+        lines.push(kv("Enter", "default: yank URL / server / IP via OSC 52"));
+    }
+    lines.push(kv("y", "yank canonical via OSC 52"));
+    lines.push(kv("o", "open / xdg-open in browser"));
+    lines.push(kv("g", "gh view --web (GitHub rows only)"));
+    if is_tmux {
+        lines.push(kv("s", "force ssh in new tmux window"));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled("Filter", hdr)));
+    lines.push(kv("a – z 0 – 9", "type into filter query"));
+    lines.push(kv("Backspace", "delete last character"));
+    lines.push(kv("C-c", "clear query (or quit if empty)"));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled("Display & picker swap", hdr)));
+    lines.push(kv("C-l", "toggle horizontal/vertical split"));
+    if is_tmux {
+        lines.push(kv("F2", "swap to rmux_helper pick-tui (session picker)"));
+    }
+    lines.push(kv("? / F1", "toggle this help overlay"));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled("  Press any key to dismiss.", dim)));
+
+    lines
 }
 
-fn draw_help_overlay(f: &mut Frame, area: Rect) {
+fn draw_help_overlay(f: &mut Frame, area: Rect, mux: Multiplexer) {
     let popup = centered_rect(70, 80, area);
     // Clear under the popup so the list/preview don't bleed through.
     f.render_widget(Clear, popup);
@@ -700,7 +805,7 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
         .borders(Borders::ALL)
         .title(" Help — pick-links ")
         .style(Style::default().fg(Color::LightYellow));
-    let para = Paragraph::new(help_lines())
+    let para = Paragraph::new(help_lines(mux))
         .block(block)
         .wrap(Wrap { trim: false });
     f.render_widget(para, popup);

--- a/rust/tmux_helper/src/main.rs
+++ b/rust/tmux_helper/src/main.rs
@@ -1,6 +1,7 @@
 mod agent_continue;
 mod herdr_third;
 mod link_picker;
+mod mux;
 mod picker;
 
 use anyhow::{Context, Result};
@@ -1046,7 +1047,7 @@ fn rotate() -> Result<()> {
 }
 
 fn third(command: &str) -> Result<()> {
-    if detect_multiplexer() == Multiplexer::Herdr {
+    if mux::detect() == mux::Multiplexer::Herdr {
         return herdr_third::cmd(command);
     }
     let caller_pane_id = std::env::var("TMUX_PANE").ok();
@@ -1156,26 +1157,6 @@ fn third(command: &str) -> Result<()> {
 /// Reliable even when the window is backgrounded.
 fn get_caller_pane_id() -> Option<String> {
     std::env::var("TMUX_PANE").ok().filter(|s| !s.is_empty())
-}
-
-#[derive(PartialEq, Debug)]
-enum Multiplexer {
-    Tmux,
-    Herdr,
-    Unknown,
-}
-
-/// TMUX_PANE wins when both are set: tmux running inside a herdr pane means
-/// tmux is the multiplexer the user is actually looking at.
-fn detect_multiplexer() -> Multiplexer {
-    let set = |k: &str| std::env::var(k).map(|v| !v.is_empty()).unwrap_or(false);
-    if set("TMUX_PANE") {
-        Multiplexer::Tmux
-    } else if set("HERDR_PANE_ID") || set("HERDR_ENV") {
-        Multiplexer::Herdr
-    } else {
-        Multiplexer::Unknown
-    }
 }
 
 /// Return all pane IDs in the window that contains `window_target`.

--- a/rust/tmux_helper/src/mux.rs
+++ b/rust/tmux_helper/src/mux.rs
@@ -1,0 +1,175 @@
+//! Multiplexer plumbing shared by every mux-aware command (`third`,
+//! `pick-links`): which multiplexer are we in, the `herdr` CLI shell, and
+//! the herdr `pane layout` JSON shape.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::process::Command;
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum Multiplexer {
+    Tmux,
+    Herdr,
+    Unknown,
+}
+
+/// Decide the multiplexer from the four environment variables that matter.
+///
+/// Split out from `detect` so precedence is unit-testable without mutating
+/// the process environment — env mutation races across cargo's parallel
+/// test threads.
+///
+/// `TMUX_PANE` OR `TMUX` means tmux: `run-shell` sets the former,
+/// `display-popup` sets only the latter, and tmux nested inside a herdr
+/// pane still means tmux is what the user is looking at.
+pub fn classify(
+    tmux_pane: Option<&str>,
+    tmux: Option<&str>,
+    herdr_pane_id: Option<&str>,
+    herdr_env: Option<&str>,
+) -> Multiplexer {
+    let set = |v: Option<&str>| v.is_some_and(|s| !s.is_empty());
+    if set(tmux_pane) || set(tmux) {
+        Multiplexer::Tmux
+    } else if set(herdr_pane_id) || set(herdr_env) {
+        Multiplexer::Herdr
+    } else {
+        Multiplexer::Unknown
+    }
+}
+
+pub fn detect() -> Multiplexer {
+    let var = |k: &str| std::env::var(k).ok();
+    classify(
+        var("TMUX_PANE").as_deref(),
+        var("TMUX").as_deref(),
+        var("HERDR_PANE_ID").as_deref(),
+        var("HERDR_ENV").as_deref(),
+    )
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LayoutResponse {
+    pub result: LayoutResult,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LayoutResult {
+    pub layout: TabLayout,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct TabLayout {
+    #[serde(default)]
+    pub focused_pane_id: String,
+    pub panes: Vec<PaneEntry>,
+    #[serde(default)]
+    pub splits: Vec<SplitEntry>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PaneEntry {
+    pub pane_id: String,
+    pub rect: Rect,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SplitEntry {
+    pub direction: String,
+    pub ratio: f64,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy)]
+pub struct Rect {
+    pub x: i64,
+    pub y: i64,
+}
+
+pub fn herdr_cli(args: &[&str]) -> Result<String> {
+    let out = Command::new("herdr")
+        .args(args)
+        .output()
+        .context("failed to run `herdr` — is it installed and on PATH?")?;
+    if !out.status.success() {
+        bail!(
+            "herdr {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+pub fn fetch_layout(pane: Option<&str>) -> Result<TabLayout> {
+    let mut args = vec!["pane", "layout"];
+    if let Some(p) = pane {
+        args.extend(["--pane", p]);
+    }
+    // Without --pane, herdr reports the focused tab — correct for a
+    // keybinding or popup, which is where pane identity is absent.
+    let json = herdr_cli(&args)?;
+    let resp: LayoutResponse =
+        serde_json::from_str(&json).context("unexpected JSON from `herdr pane layout`")?;
+    Ok(resp.result.layout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmux_pane_alone_is_tmux() {
+        assert_eq!(classify(Some("%3"), None, None, None), Multiplexer::Tmux);
+    }
+
+    #[test]
+    fn tmux_var_alone_is_tmux() {
+        // tmux display-popup drops TMUX_PANE but keeps TMUX — pick-links
+        // runs in exactly that context.
+        assert_eq!(
+            classify(None, Some("/tmp/tmux-1000/default,123,0"), None, None),
+            Multiplexer::Tmux
+        );
+    }
+
+    #[test]
+    fn herdr_env_alone_is_herdr() {
+        // herdr popups set HERDR_ENV but omit HERDR_PANE_ID.
+        assert_eq!(classify(None, None, None, Some("1")), Multiplexer::Herdr);
+    }
+
+    #[test]
+    fn herdr_pane_id_alone_is_herdr() {
+        assert_eq!(classify(None, None, Some("w9:p1"), None), Multiplexer::Herdr);
+    }
+
+    #[test]
+    fn tmux_wins_when_both_present() {
+        assert_eq!(
+            classify(Some("%3"), None, Some("w9:p1"), Some("1")),
+            Multiplexer::Tmux
+        );
+    }
+
+    #[test]
+    fn nothing_set_is_unknown() {
+        assert_eq!(classify(None, None, None, None), Multiplexer::Unknown);
+    }
+
+    #[test]
+    fn empty_strings_do_not_count_as_set() {
+        assert_eq!(classify(Some(""), Some(""), Some(""), Some("")), Multiplexer::Unknown);
+    }
+
+    #[test]
+    fn layout_json_exposes_focused_pane_id() {
+        // Captured verbatim from `herdr pane layout` on 2026-08-02.
+        let json = r#"{"id":"cli:pane:layout","result":{"layout":{"area":{"height":56,"width":170,"x":18,"y":1},"focused_pane_id":"w9:p1","panes":[{"focused":true,"pane_id":"w9:p1","rect":{"height":56,"width":170,"x":18,"y":1}}],"splits":[],"tab_id":"w9:t1","workspace_id":"w9","zoomed":false},"type":"pane_layout"}}"#;
+        let layout = serde_json::from_str::<LayoutResponse>(json)
+            .expect("layout JSON should parse")
+            .result
+            .layout;
+        assert_eq!(layout.focused_pane_id, "w9:p1");
+        assert_eq!(layout.panes.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- `rmux_helper pick-links` auto-detects tmux vs herdr and works in both; `prefix+shift+l` bound in herdr as a 95%×95% popup
- Shared `src/mux.rs` now owns multiplexer detection, the `herdr` CLI shell, and the `pane layout` types — `third` and `pick-links` both consume it instead of duplicating
- Detection now treats `TMUX` (not just `TMUX_PANE`) as tmux, since `display-popup` drops `TMUX_PANE`; both herdr bindings clear `TMUX` and `TMUX_PANE`
- Under herdr: yank emits OSC 52 (herdr forwards it to the client clipboard), ssh and F2-swap are not offered, and Enter on a host copies it

Spec: docs/superpowers/specs/2026-08-02-herdr-link-picker-design.md
Plan: docs/superpowers/plans/2026-08-02-herdr-link-picker.md

## Test plan
- [x] Unit tests: detection precedence, herdr capture argv order, OSC 52 payload bytes, per-backend action defaults (280 tests pass)
- [x] herdr headless smoke: `pick-links --json` returns valid JSON end-to-end; confirmed real-content detection (PR + release URLs) against a live herdr pane, and the no-`HERDR_PANE_ID` popup fallback path resolves without error
- [x] tmux regression: `pick-links --json` in a scratch session still detects PR + host rows
- [ ] Igor: `C-a L` popup renders under herdr; yank reaches the Mac clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using the link picker in both tmux and Herdr environments.
  - Added the `prefix+Shift+L` shortcut to open the link picker in a 95% × 95% popup.
  - Herdr captures recent scrollback and copies selected links through the system clipboard.
  - Added Herdr-specific handling for pane selection and link actions.

- **Documentation**
  - Updated command references and specifications to describe Herdr support and environment-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->