### PR TITLE
fix(pick-links): empty-state panel instead of a flashing popup

### DIFF
--- a/rust/tmux_helper/src/link_picker/mod.rs
+++ b/rust/tmux_helper/src/link_picker/mod.rs
@@ -44,12 +44,15 @@ pub fn pick_links(json: bool, enrich_deadline_ms: u64) -> Result<()> {
     // 4. Enrich (blocks inside tokio, then drops runtime before TUI)
     let rows = enrich::enrich_rows(rows, enrich_deadline_ms);
 
-    // 5. TUI
-    if rows.is_empty() {
-        eprintln!("pick-links: no links, servers, or IPs in scrollback");
-        return Ok(());
-    }
-    let action = tui::run(rows, mux)?;
+    // 5. TUI. An empty result still goes through the TUI: it renders an
+    // empty-state panel naming the pane it read. Returning early here
+    // instead printed to stderr and exited, which inside a popup is a
+    // flash the user cannot read — the popup dies with the message.
+    let source = tui::Source {
+        pane_id: pane_id.clone(),
+        lines: raw.lines().count(),
+    };
+    let action = tui::run(rows, mux, &source)?;
 
     // 6-7. Dispatch post-TUI (terminal already restored by tui::run).
     match action {
@@ -284,12 +287,30 @@ fn herdr_capture_pane(pane_id: &str) -> Result<String> {
 /// otherwise the focused pane. Popups get `HERDR_ENV` but not
 /// `HERDR_PANE_ID`, and `C-a L` is bound as a popup — so the fallback is
 /// the common path, not the edge case.
+/// Choose the herdr pane to capture from the two env vars herdr provides,
+/// in precedence order. Pure so the precedence is testable without env
+/// mutation, which races across cargo's parallel test threads.
+///
+/// `HERDR_PANE_ID` is set for a managed pane. Popups do not get it
+/// (herdr `src/app/popup.rs`, `without_pane_identity()`) but DO get
+/// `HERDR_ACTIVE_PANE_ID` naming the pane that was active when the popup
+/// opened — which is exactly the pane whose scrollback the user means.
+pub(crate) fn pick_herdr_pane(pane_id: Option<&str>, active_pane_id: Option<&str>) -> Option<String> {
+    [pane_id, active_pane_id]
+        .into_iter()
+        .flatten()
+        .find(|v| !v.is_empty())
+        .map(str::to_string)
+}
+
 fn resolve_herdr_pane_id() -> Result<String> {
-    if let Ok(p) = env::var("HERDR_PANE_ID") {
-        if !p.is_empty() {
-            return Ok(p);
-        }
+    if let Some(p) = pick_herdr_pane(
+        env::var("HERDR_PANE_ID").ok().as_deref(),
+        env::var("HERDR_ACTIVE_PANE_ID").ok().as_deref(),
+    ) {
+        return Ok(p);
     }
+    // Last resort: infer from the focused pane of the active workspace.
     let layout = crate::mux::fetch_layout(None)?;
     if layout.focused_pane_id.is_empty() {
         return Err(anyhow!(
@@ -388,6 +409,17 @@ mod orchestration_tests {
             !args.iter().any(|a| a == "-e"),
             "must NOT include ANSI escapes (they corrupt popup rendering)"
         );
+    }
+
+    #[test]
+    fn herdr_pane_prefers_pane_id_then_active_pane_id() {
+        assert_eq!(pick_herdr_pane(Some("w9:p1"), Some("w2:p3")).as_deref(), Some("w9:p1"));
+        // Popups get only HERDR_ACTIVE_PANE_ID — the pane the user pressed
+        // the key from, which is the one whose scrollback they mean.
+        assert_eq!(pick_herdr_pane(None, Some("w2:p3")).as_deref(), Some("w2:p3"));
+        assert_eq!(pick_herdr_pane(Some(""), Some("w2:p3")).as_deref(), Some("w2:p3"));
+        assert_eq!(pick_herdr_pane(None, None), None);
+        assert_eq!(pick_herdr_pane(Some(""), Some("")), None);
     }
 
     #[test]

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -30,6 +30,46 @@ pub enum Action {
     SwapToPickTui,
 }
 
+/// Where the scrollback came from, for the empty-state message. Populated by
+/// the orchestrator so the user can tell WHICH pane was read when nothing
+/// turned up — the difference between "the tool is broken" and "that pane
+/// has no links in it."
+pub struct Source {
+    pub pane_id: String,
+    pub lines: usize,
+}
+
+/// Body of the empty-state panel. Pure so its content is unit-testable
+/// without a terminal.
+pub(crate) fn empty_state_lines(source: &Source) -> Vec<String> {
+    vec![
+        String::new(),
+        "No links, servers, or IPs found".to_string(),
+        String::new(),
+        format!(
+            "read {} — {} line{} of scrollback",
+            source.pane_id,
+            source.lines,
+            if source.lines == 1 { "" } else { "s" }
+        ),
+        String::new(),
+        "Esc / q to close".to_string(),
+    ]
+}
+
+/// Keys that dismiss the empty-state panel. Deliberately narrow: an escape
+/// sequence a multiplexer injects into a fresh popup pty must not dismiss
+/// the panel before it can be read — that is the exact flash this panel
+/// exists to fix.
+pub(crate) fn is_empty_state_dismiss(code: KeyCode, mods: KeyModifiers) -> bool {
+    match code {
+        KeyCode::Esc => true,
+        KeyCode::Char('q') if mods.is_empty() => true,
+        KeyCode::Char('c') if mods.contains(KeyModifiers::CONTROL) => true,
+        _ => false,
+    }
+}
+
 struct App {
     rows: Vec<Row>,
     filtered: Vec<usize>, // indices into rows in display order (including separators)
@@ -511,6 +551,70 @@ mod help_overlay_tests {
         );
     }
 
+    fn src() -> Source {
+        Source { pane_id: "w9:p1".into(), lines: 53 }
+    }
+
+    #[test]
+    fn empty_state_names_the_pane_and_line_count() {
+        // The whole point of the panel: distinguish "the tool is broken"
+        // from "that pane has no links in it."
+        let body = empty_state_lines(&src()).join("\n");
+        assert!(body.contains("No links, servers, or IPs found"), "{body}");
+        assert!(body.contains("w9:p1"), "must name the pane it read: {body}");
+        assert!(body.contains("53 lines"), "must report capture depth: {body}");
+        assert!(body.contains("Esc / q to close"), "must say how to dismiss: {body}");
+    }
+
+    #[test]
+    fn empty_state_pluralizes_single_line_capture() {
+        let one = Source { pane_id: "w9:p1".into(), lines: 1 };
+        assert!(empty_state_lines(&one).join("\n").contains("1 line of"));
+    }
+
+    #[test]
+    fn empty_state_dismiss_accepts_esc_q_and_ctrl_c() {
+        assert!(is_empty_state_dismiss(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(is_empty_state_dismiss(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(is_empty_state_dismiss(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn empty_state_ignores_keys_a_popup_might_inject() {
+        // Regression guard for the flash this panel fixes: a fresh popup pty
+        // gets cursor-position and device-attribute replies that crossterm can
+        // surface as key events. None may dismiss the panel.
+        for (code, mods) in [
+            (KeyCode::Enter, KeyModifiers::NONE),
+            (KeyCode::Char('R'), KeyModifiers::NONE),
+            (KeyCode::Char('0'), KeyModifiers::NONE),
+            (KeyCode::Char(';'), KeyModifiers::NONE),
+            (KeyCode::Char('q'), KeyModifiers::CONTROL),
+            (KeyCode::F(2), KeyModifiers::NONE),
+        ] {
+            assert!(!is_empty_state_dismiss(code, mods), "{code:?} must not dismiss");
+        }
+    }
+
+    #[test]
+    fn empty_state_panel_renders_with_picker_chrome() {
+        use ratatui::backend::TestBackend;
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let source = src();
+        terminal.draw(|f| draw_empty(f, &source)).unwrap();
+        let painted: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(painted.contains("Links"), "keeps the picker's titled border");
+        assert!(painted.contains("No links, servers, or IPs found"), "{painted}");
+        assert!(painted.contains("w9:p1"), "{painted}");
+    }
+
     #[test]
     fn hint_bar_shows_f2_sess_under_tmux() {
         use ratatui::backend::TestBackend;
@@ -612,10 +716,7 @@ mod help_overlay_tests {
 
 // ----- Run loop + rendering -----
 
-pub fn run(rows: Vec<Row>, mux: Multiplexer) -> Result<Action> {
-    if rows.is_empty() {
-        return Ok(Action::Quit);
-    }
+pub fn run(rows: Vec<Row>, mux: Multiplexer, source: &Source) -> Result<Action> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -629,20 +730,61 @@ pub fn run(rows: Vec<Row>, mux: Multiplexer) -> Result<Action> {
     // position, device attributes, focus events) shortly after the pty comes
     // up, and crossterm's parser can treat some of these as key events. Poll
     // with a longer window than picker.rs's 1ms to catch late arrivals.
-    terminal.draw(|f| draw(f, &mut app))?;
+    let is_empty = app.rows.is_empty();
+    if is_empty {
+        terminal.draw(|f| draw_empty(f, source))?;
+    } else {
+        terminal.draw(|f| draw(f, &mut app))?;
+    }
     for _ in 0..16 {
         while event::poll(std::time::Duration::from_millis(5))? {
             let _ = event::read();
         }
     }
 
-    let result = event_loop(&mut app, &mut terminal);
+    let result = if is_empty {
+        empty_state_loop(&mut terminal, source)
+    } else {
+        event_loop(&mut app, &mut terminal)
+    };
 
     let _ = disable_raw_mode();
     let _ = execute!(io::stdout(), LeaveAlternateScreen);
     drop(terminal);
 
     result
+}
+
+/// Render the empty-state panel: same chrome as the picker, so a popup that
+/// found nothing still looks like the tool rather than a flash.
+fn draw_empty(f: &mut Frame, source: &Source) {
+    let area = f.area();
+    let block = Block::default().borders(Borders::ALL).title("Links");
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let body: Vec<Line> = empty_state_lines(source)
+        .into_iter()
+        .map(|l| Line::from(Span::raw(format!("   {l}"))))
+        .collect();
+    f.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), inner);
+}
+
+/// Hold the empty-state panel open until the user dismisses it. Redraws on
+/// resize so the panel survives a popup being resized under it.
+fn empty_state_loop<B: Backend>(terminal: &mut Terminal<B>, source: &Source) -> Result<Action> {
+    loop {
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                if is_empty_state_dismiss(key.code, key.modifiers) {
+                    return Ok(Action::Quit);
+                }
+            }
+            Event::Resize(_, _) => {
+                terminal.draw(|f| draw_empty(f, source))?;
+            }
+            _ => {}
+        }
+    }
 }
 
 fn event_loop<B: Backend>(app: &mut App, terminal: &mut Terminal<B>) -> Result<Action> {

--- a/rust/tmux_helper/src/link_picker/tui.rs
+++ b/rust/tmux_helper/src/link_picker/tui.rs
@@ -730,23 +730,29 @@ pub fn run(rows: Vec<Row>, mux: Multiplexer, source: &Source) -> Result<Action> 
     // position, device attributes, focus events) shortly after the pty comes
     // up, and crossterm's parser can treat some of these as key events. Poll
     // with a longer window than picker.rs's 1ms to catch late arrivals.
-    let is_empty = app.rows.is_empty();
-    if is_empty {
-        terminal.draw(|f| draw_empty(f, source))?;
-    } else {
-        terminal.draw(|f| draw(f, &mut app))?;
-    }
-    for _ in 0..16 {
-        while event::poll(std::time::Duration::from_millis(5))? {
-            let _ = event::read();
+    // Everything between enable_raw_mode and the cleanup below runs inside
+    // this closure so that a `?` cannot escape with the terminal still in
+    // raw mode and the alternate screen. Bailing out there would hand the
+    // user back a pane that no longer echoes input — a worse failure than
+    // whatever caused the error. Do not unwrap this closure in a refactor.
+    let result: Result<Action> = (|| {
+        let is_empty = app.rows.is_empty();
+        if is_empty {
+            terminal.draw(|f| draw_empty(f, source))?;
+        } else {
+            terminal.draw(|f| draw(f, &mut app))?;
         }
-    }
-
-    let result = if is_empty {
-        empty_state_loop(&mut terminal, source)
-    } else {
-        event_loop(&mut app, &mut terminal)
-    };
+        for _ in 0..16 {
+            while event::poll(std::time::Duration::from_millis(5))? {
+                let _ = event::read();
+            }
+        }
+        if is_empty {
+            empty_state_loop(&mut terminal, source)
+        } else {
+            event_loop(&mut app, &mut terminal)
+        }
+    })();
 
     let _ = disable_raw_mode();
     let _ = execute!(io::stdout(), LeaveAlternateScreen);


### PR DESCRIPTION
## The bug

`C-a L` flashed and did nothing. The picker was working correctly — it found no links, printed `no links, servers, or IPs in scrollback` to **stderr**, and returned. Inside a popup that message dies with the popup, so "found nothing" was indistinguishable from "crashed."

This affected tmux's `C-a L` too; it predates the herdr port.

## Diagnosis

Instrumented the live binding and captured the popup's real environment. Every layer was behaving:

| | |
|---|---|
| resolved pane | `w9:p1` — the pane the key was pressed from, a real tab pane |
| capture | 53 lines |
| links found | 0 (the one "link-ish" line was prose containing the word "ssh") |

So the popup does **not** steal focus, and capture/detection are fine. The defect was purely the invisible feedback.

## The fix

Empty results now go through the TUI, which renders an empty-state panel naming the pane it read and the capture depth:

```
┌─ Links ─────────────────────────────────┐
│   No links, servers, or IPs found       │
│   read w9:p1 — 53 lines of scrollback   │
│   Esc / q to close                      │
└─────────────────────────────────────────┘
```

The dismiss set (`Esc`/`q`/`C-c`) is deliberately narrow: a fresh popup pty gets cursor-position and device-attribute replies that crossterm can surface as key events, and those must not dismiss the panel — that is the same class of bug the panel exists to fix.

Also adopts **`HERDR_ACTIVE_PANE_ID`**, which the instrumentation revealed herdr sets on popups (they don't get `HERDR_PANE_ID`), naming the pane that was active when the popup opened. The previous `pane layout` focused-pane inference resolved correctly in this case but would pick the wrong pane whenever the active workspace differs from where the key was pressed.

## Test plan
- [x] 6 new unit tests; mutation-checked (4 fail when the guarded behavior is broken)
- [x] Injected-key regression test: Enter/`R`/`0`/`;`/`F2`/`C-q` do not dismiss
- [x] Full suite 289/289; no new clippy warnings (diffed against baseline)
- [x] Live in a herdr pane: panel renders with the pane id and line count, holds open, dismisses on Esc
- [ ] Igor: `C-a L` in a pane **with** links shows the picker; in a pane without, shows the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Link-picker sessions with no results now remain in the interface instead of closing with an unreadable error.
  * Empty results display the relevant pane and number of captured lines.
  * Pane selection now consistently uses the most specific available pane context.

* **User Experience**
  * Added clear dismissal instructions for empty states using Esc, `q`, or Ctrl-C.
  * The empty-state display remains responsive to terminal resizing and ignores unrelated input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->